### PR TITLE
Return data instead of storing it inside variables

### DIFF
--- a/json/communes.json
+++ b/json/communes.json
@@ -1,9 +1,9248 @@
-/**
- Export to JSON plugin for PHPMyAdmin
- @version 0.1
- @author othmanus
- */
-
-// communes
-
-[{"id":"1","code_postal":"01001","nom":"Adrar","wilaya_id":"1"}, {"id":"2","code_postal":"01002","nom":"Tamest","wilaya_id":"1"}, {"id":"3","code_postal":"01003","nom":"Charouine","wilaya_id":"1"}, {"id":"4","code_postal":"01004","nom":"Reggane","wilaya_id":"1"}, {"id":"5","code_postal":"01005","nom":"Inozghmir","wilaya_id":"1"}, {"id":"6","code_postal":"01006","nom":"Tit","wilaya_id":"1"}, {"id":"7","code_postal":"01007","nom":"Ksar Kaddour","wilaya_id":"1"}, {"id":"8","code_postal":"01008","nom":"Tsabit","wilaya_id":"1"}, {"id":"9","code_postal":"01009","nom":"Timimoun","wilaya_id":"1"}, {"id":"10","code_postal":"01010","nom":"Ouled Said","wilaya_id":"1"}, {"id":"11","code_postal":"01011","nom":"Zaouiet Kounta","wilaya_id":"1"}, {"id":"12","code_postal":"01012","nom":"Aoulef","wilaya_id":"1"}, {"id":"13","code_postal":"01013","nom":"Timokten","wilaya_id":"1"}, {"id":"14","code_postal":"01014","nom":"Tamentit","wilaya_id":"1"}, {"id":"15","code_postal":"01015","nom":"Fenoughil","wilaya_id":"1"}, {"id":"16","code_postal":"01016","nom":"Tinerkouk","wilaya_id":"1"}, {"id":"17","code_postal":"01017","nom":"Deldoul","wilaya_id":"1"}, {"id":"18","code_postal":"01018","nom":"Sali","wilaya_id":"1"}, {"id":"19","code_postal":"01019","nom":"Akabli","wilaya_id":"1"}, {"id":"20","code_postal":"01020","nom":"Metarfa","wilaya_id":"1"}, {"id":"21","code_postal":"01021","nom":"O Ahmed Timmi","wilaya_id":"1"}, {"id":"22","code_postal":"01022","nom":"Bouda","wilaya_id":"1"}, {"id":"23","code_postal":"01023","nom":"Aougrout","wilaya_id":"1"}, {"id":"24","code_postal":"01024","nom":"Talmine","wilaya_id":"1"}, {"id":"25","code_postal":"01025","nom":"B Badji Mokhtar","wilaya_id":"1"}, {"id":"26","code_postal":"01026","nom":"Sbaa","wilaya_id":"1"}, {"id":"27","code_postal":"01027","nom":"Ouled Aissa","wilaya_id":"1"}, {"id":"28","code_postal":"01028","nom":"Timiaouine","wilaya_id":"1"}, {"id":"29","code_postal":"02001","nom":"Chlef","wilaya_id":"2"}, {"id":"30","code_postal":"02002","nom":"Tenes","wilaya_id":"2"}, {"id":"31","code_postal":"02003","nom":"Benairia","wilaya_id":"2"}, {"id":"32","code_postal":"02004","nom":"El Karimia","wilaya_id":"2"}, {"id":"33","code_postal":"02005","nom":"Tadjna","wilaya_id":"2"}, {"id":"34","code_postal":"02006","nom":"Taougrite","wilaya_id":"2"}, {"id":"35","code_postal":"02007","nom":"Beni Haoua","wilaya_id":"2"}, {"id":"36","code_postal":"02008","nom":"Sobha","wilaya_id":"2"}, {"id":"37","code_postal":"02009","nom":"Harchoun","wilaya_id":"2"}, {"id":"38","code_postal":"02010","nom":"Ouled Fares","wilaya_id":"2"}, {"id":"39","code_postal":"02011","nom":"Sidi Akacha","wilaya_id":"2"}, {"id":"40","code_postal":"02012","nom":"Boukadir","wilaya_id":"2"}, {"id":"41","code_postal":"02013","nom":"Beni Rached","wilaya_id":"2"}, {"id":"42","code_postal":"02014","nom":"Talassa","wilaya_id":"2"}, {"id":"43","code_postal":"02015","nom":"Herenfa","wilaya_id":"2"}, {"id":"44","code_postal":"02016","nom":"Oued Goussine","wilaya_id":"2"}, {"id":"45","code_postal":"02017","nom":"Dahra","wilaya_id":"2"}, {"id":"46","code_postal":"02018","nom":"Ouled Abbes","wilaya_id":"2"}, {"id":"47","code_postal":"02019","nom":"Sendjas","wilaya_id":"2"}, {"id":"48","code_postal":"02020","nom":"Zeboudja","wilaya_id":"2"}, {"id":"49","code_postal":"02021","nom":"Oued Sly","wilaya_id":"2"}, {"id":"50","code_postal":"02022","nom":"Abou El Hassen","wilaya_id":"2"}, {"id":"51","code_postal":"02023","nom":"El Marsa","wilaya_id":"2"}, {"id":"52","code_postal":"02024","nom":"Chettia","wilaya_id":"2"}, {"id":"53","code_postal":"02025","nom":"Sidi Abderrahmane","wilaya_id":"2"}, {"id":"54","code_postal":"02026","nom":"Moussadek","wilaya_id":"2"}, {"id":"55","code_postal":"02027","nom":"El Hadjadj","wilaya_id":"2"}, {"id":"56","code_postal":"02028","nom":"Labiod Medjadja","wilaya_id":"2"}, {"id":"57","code_postal":"02029","nom":"Oued Fodda","wilaya_id":"2"}, {"id":"58","code_postal":"02030","nom":"Ouled Ben Abdelkader","wilaya_id":"2"}, {"id":"59","code_postal":"02031","nom":"Bouzghaia","wilaya_id":"2"}, {"id":"60","code_postal":"02032","nom":"Ain Merane","wilaya_id":"2"}, {"id":"61","code_postal":"02033","nom":"Oum Drou","wilaya_id":"2"}, {"id":"62","code_postal":"02034","nom":"Breira","wilaya_id":"2"}, {"id":"63","code_postal":"02035","nom":"Ben Boutaleb","wilaya_id":"2"}, {"id":"64","code_postal":"03001","nom":"Laghouat","wilaya_id":"3"}, {"id":"65","code_postal":"03002","nom":"Ksar El Hirane","wilaya_id":"3"}, {"id":"66","code_postal":"03003","nom":"Benacer Ben Chohra","wilaya_id":"3"}, {"id":"67","code_postal":"03004","nom":"Sidi Makhlouf","wilaya_id":"3"}, {"id":"68","code_postal":"03005","nom":"Hassi Delaa","wilaya_id":"3"}, {"id":"69","code_postal":"03006","nom":"Hassi R Mel","wilaya_id":"3"}, {"id":"70","code_postal":"03007","nom":"Ain Mahdi","wilaya_id":"3"}, {"id":"71","code_postal":"03008","nom":"Tadjmout","wilaya_id":"3"}, {"id":"72","code_postal":"03009","nom":"Kheneg","wilaya_id":"3"}, {"id":"73","code_postal":"03010","nom":"Gueltat Sidi Saad","wilaya_id":"3"}, {"id":"74","code_postal":"03011","nom":"Ain Sidi Ali","wilaya_id":"3"}, {"id":"75","code_postal":"03012","nom":"Beidha","wilaya_id":"3"}, {"id":"76","code_postal":"03013","nom":"Brida","wilaya_id":"3"}, {"id":"77","code_postal":"03014","nom":"El Ghicha","wilaya_id":"3"}, {"id":"78","code_postal":"03015","nom":"Hadj Mechri","wilaya_id":"3"}, {"id":"79","code_postal":"03016","nom":"Sebgag","wilaya_id":"3"}, {"id":"80","code_postal":"03017","nom":"Taouiala","wilaya_id":"3"}, {"id":"81","code_postal":"03018","nom":"Tadjrouna","wilaya_id":"3"}, {"id":"82","code_postal":"03019","nom":"Aflou","wilaya_id":"3"}, {"id":"83","code_postal":"03020","nom":"El Assafia","wilaya_id":"3"}, {"id":"84","code_postal":"03021","nom":"Oued Morra","wilaya_id":"3"}, {"id":"85","code_postal":"03022","nom":"Oued M Zi","wilaya_id":"3"}, {"id":"86","code_postal":"03023","nom":"El Haouaita","wilaya_id":"3"}, {"id":"87","code_postal":"03024","nom":"Sidi Bouzid","wilaya_id":"3"}, {"id":"88","code_postal":"04001","nom":"Oum El Bouaghi","wilaya_id":"4"}, {"id":"89","code_postal":"04002","nom":"Ain Beida","wilaya_id":"4"}, {"id":"90","code_postal":"04003","nom":"Ainmlila","wilaya_id":"4"}, {"id":"91","code_postal":"04004","nom":"Behir Chergui","wilaya_id":"4"}, {"id":"92","code_postal":"04005","nom":"El Amiria","wilaya_id":"4"}, {"id":"93","code_postal":"04006","nom":"Sigus","wilaya_id":"4"}, {"id":"94","code_postal":"04007","nom":"El Belala","wilaya_id":"4"}, {"id":"95","code_postal":"04008","nom":"Ain Babouche","wilaya_id":"4"}, {"id":"96","code_postal":"04009","nom":"Berriche","wilaya_id":"4"}, {"id":"97","code_postal":"04010","nom":"Ouled Hamla","wilaya_id":"4"}, {"id":"98","code_postal":"04011","nom":"Dhala","wilaya_id":"4"}, {"id":"99","code_postal":"04012","nom":"Ain Kercha","wilaya_id":"4"}, {"id":"100","code_postal":"04013","nom":"Hanchir Toumghani","wilaya_id":"4"}, {"id":"101","code_postal":"04014","nom":"El Djazia","wilaya_id":"4"}, {"id":"102","code_postal":"04015","nom":"Ain Diss","wilaya_id":"4"}, {"id":"103","code_postal":"04016","nom":"Fkirina","wilaya_id":"4"}, {"id":"104","code_postal":"04017","nom":"Souk Naamane","wilaya_id":"4"}, {"id":"105","code_postal":"04018","nom":"Zorg","wilaya_id":"4"}, {"id":"106","code_postal":"04019","nom":"El Fedjoudj Boughrar","wilaya_id":"4"}, {"id":"107","code_postal":"04020","nom":"Ouled Zouai","wilaya_id":"4"}, {"id":"108","code_postal":"04021","nom":"Bir Chouhada","wilaya_id":"4"}, {"id":"109","code_postal":"04022","nom":"Ksar Sbahi","wilaya_id":"4"}, {"id":"110","code_postal":"04023","nom":"Oued Nini","wilaya_id":"4"}, {"id":"111","code_postal":"04024","nom":"Meskiana","wilaya_id":"4"}, {"id":"112","code_postal":"04025","nom":"Ain Fekroune","wilaya_id":"4"}, {"id":"113","code_postal":"04026","nom":"Rahia","wilaya_id":"4"}, {"id":"114","code_postal":"04027","nom":"Ain Zitoun","wilaya_id":"4"}, {"id":"115","code_postal":"04028","nom":"Ouled Gacem","wilaya_id":"4"}, {"id":"116","code_postal":"04029","nom":"El Harmilia","wilaya_id":"4"}, {"id":"117","code_postal":"05001","nom":"Batna","wilaya_id":"5"}, {"id":"118","code_postal":"05002","nom":"Ghassira","wilaya_id":"5"}, {"id":"119","code_postal":"05003","nom":"Maafa","wilaya_id":"5"}, {"id":"120","code_postal":"05004","nom":"Merouana","wilaya_id":"5"}, {"id":"121","code_postal":"05005","nom":"Seriana","wilaya_id":"5"}, {"id":"122","code_postal":"05006","nom":"Menaa","wilaya_id":"5"}, {"id":"123","code_postal":"05007","nom":"El Madher","wilaya_id":"5"}, {"id":"124","code_postal":"05008","nom":"Tazoult","wilaya_id":"5"}, {"id":"125","code_postal":"05009","nom":"Ngaous","wilaya_id":"5"}, {"id":"126","code_postal":"05010","nom":"Guigba","wilaya_id":"5"}, {"id":"127","code_postal":"05011","nom":"Inoughissen","wilaya_id":"5"}, {"id":"128","code_postal":"05012","nom":"Ouyoun El Assafir","wilaya_id":"5"}, {"id":"129","code_postal":"05013","nom":"Djerma","wilaya_id":"5"}, {"id":"130","code_postal":"05014","nom":"Bitam","wilaya_id":"5"}, {"id":"131","code_postal":"05015","nom":"Metkaouak","wilaya_id":"5"}, {"id":"132","code_postal":"05016","nom":"Arris","wilaya_id":"5"}, {"id":"133","code_postal":"05017","nom":"Kimmel","wilaya_id":"5"}, {"id":"134","code_postal":"05018","nom":"Tilatou","wilaya_id":"5"}, {"id":"135","code_postal":"05019","nom":"Ain Djasser","wilaya_id":"5"}, {"id":"136","code_postal":"05020","nom":"Ouled Selam","wilaya_id":"5"}, {"id":"137","code_postal":"05021","nom":"Tigherghar","wilaya_id":"5"}, {"id":"138","code_postal":"05022","nom":"Ain Yagout","wilaya_id":"5"}, {"id":"139","code_postal":"05023","nom":"Fesdis","wilaya_id":"5"}, {"id":"140","code_postal":"05024","nom":"Sefiane","wilaya_id":"5"}, {"id":"141","code_postal":"05025","nom":"Rahbat","wilaya_id":"5"}, {"id":"142","code_postal":"05026","nom":"Tighanimine","wilaya_id":"5"}, {"id":"143","code_postal":"05027","nom":"Lemsane","wilaya_id":"5"}, {"id":"144","code_postal":"05028","nom":"Ksar Belezma","wilaya_id":"5"}, {"id":"145","code_postal":"05029","nom":"Seggana","wilaya_id":"5"}, {"id":"146","code_postal":"05030","nom":"Ichmoul","wilaya_id":"5"}, {"id":"147","code_postal":"05031","nom":"Foum Toub","wilaya_id":"5"}, {"id":"148","code_postal":"05032","nom":"Beni Foudhala El Hakania","wilaya_id":"5"}, {"id":"149","code_postal":"05033","nom":"Oued El Ma","wilaya_id":"5"}, {"id":"150","code_postal":"05034","nom":"Talkhamt","wilaya_id":"5"}, {"id":"151","code_postal":"05035","nom":"Bouzina","wilaya_id":"5"}, {"id":"152","code_postal":"05036","nom":"Chemora","wilaya_id":"5"}, {"id":"153","code_postal":"05037","nom":"Oued Chaaba","wilaya_id":"5"}, {"id":"154","code_postal":"05038","nom":"Taxlent","wilaya_id":"5"}, {"id":"155","code_postal":"05039","nom":"Gosbat","wilaya_id":"5"}, {"id":"156","code_postal":"05040","nom":"Ouled Aouf","wilaya_id":"5"}, {"id":"157","code_postal":"05041","nom":"Boumagueur","wilaya_id":"5"}, {"id":"158","code_postal":"05042","nom":"Barika","wilaya_id":"5"}, {"id":"159","code_postal":"05043","nom":"Djezzar","wilaya_id":"5"}, {"id":"160","code_postal":"05044","nom":"Tkout","wilaya_id":"5"}, {"id":"161","code_postal":"05045","nom":"Ain Touta","wilaya_id":"5"}, {"id":"162","code_postal":"05046","nom":"Hidoussa","wilaya_id":"5"}, {"id":"163","code_postal":"05047","nom":"Teniet El Abed","wilaya_id":"5"}, {"id":"164","code_postal":"05048","nom":"Oued Taga","wilaya_id":"5"}, {"id":"165","code_postal":"05049","nom":"Ouled Fadel","wilaya_id":"5"}, {"id":"166","code_postal":"05050","nom":"Timgad","wilaya_id":"5"}, {"id":"167","code_postal":"05051","nom":"Ras El Aioun","wilaya_id":"5"}, {"id":"168","code_postal":"05052","nom":"Chir","wilaya_id":"5"}, {"id":"169","code_postal":"05053","nom":"Ouled Si Slimane","wilaya_id":"5"}, {"id":"170","code_postal":"05054","nom":"Zanat El Beida","wilaya_id":"5"}, {"id":"171","code_postal":"05055","nom":"Amdoukal","wilaya_id":"5"}, {"id":"172","code_postal":"05056","nom":"Ouled Ammar","wilaya_id":"5"}, {"id":"173","code_postal":"05057","nom":"El Hassi","wilaya_id":"5"}, {"id":"174","code_postal":"05058","nom":"Lazrou","wilaya_id":"5"}, {"id":"175","code_postal":"05059","nom":"Boumia","wilaya_id":"5"}, {"id":"176","code_postal":"05060","nom":"Boulhilat","wilaya_id":"5"}, {"id":"177","code_postal":"05061","nom":"Larbaa","wilaya_id":"5"}, {"id":"178","code_postal":"06001","nom":"Bejaia","wilaya_id":"6"}, {"id":"179","code_postal":"06002","nom":"Amizour","wilaya_id":"6"}, {"id":"180","code_postal":"06003","nom":"Ferraoun","wilaya_id":"6"}, {"id":"181","code_postal":"06004","nom":"Taourirt Ighil","wilaya_id":"6"}, {"id":"182","code_postal":"06005","nom":"Chelata","wilaya_id":"6"}, {"id":"183","code_postal":"06006","nom":"Tamokra","wilaya_id":"6"}, {"id":"184","code_postal":"06007","nom":"Timzrit","wilaya_id":"6"}, {"id":"185","code_postal":"06008","nom":"Souk El Thenine","wilaya_id":"6"}, {"id":"186","code_postal":"06009","nom":"Mcisna","wilaya_id":"6"}, {"id":"187","code_postal":"06010","nom":"Thinabdher","wilaya_id":"6"}, {"id":"188","code_postal":"06011","nom":"Tichi","wilaya_id":"6"}, {"id":"189","code_postal":"06012","nom":"Semaoun","wilaya_id":"6"}, {"id":"190","code_postal":"06013","nom":"Kendira","wilaya_id":"6"}, {"id":"191","code_postal":"06014","nom":"Tifra","wilaya_id":"6"}, {"id":"192","code_postal":"06015","nom":"Ighram","wilaya_id":"6"}, {"id":"193","code_postal":"06016","nom":"Amalou","wilaya_id":"6"}, {"id":"194","code_postal":"06017","nom":"Ighil Ali","wilaya_id":"6"}, {"id":"195","code_postal":"06018","nom":"Ifelain Ilmathen","wilaya_id":"6"}, {"id":"196","code_postal":"06019","nom":"Toudja","wilaya_id":"6"}, {"id":"197","code_postal":"06020","nom":"Darguina","wilaya_id":"6"}, {"id":"198","code_postal":"06021","nom":"Sidi Ayad","wilaya_id":"6"}, {"id":"199","code_postal":"06022","nom":"Aokas","wilaya_id":"6"}, {"id":"200","code_postal":"06023","nom":"Beni Djellil","wilaya_id":"6"}, {"id":"201","code_postal":"06024","nom":"Adekar","wilaya_id":"6"}, {"id":"202","code_postal":"06025","nom":"Akbou","wilaya_id":"6"}, {"id":"203","code_postal":"06026","nom":"Seddouk","wilaya_id":"6"}, {"id":"204","code_postal":"06027","nom":"Tazmalt","wilaya_id":"6"}, {"id":"205","code_postal":"06028","nom":"Ait Rizine","wilaya_id":"6"}, {"id":"206","code_postal":"06029","nom":"Chemini","wilaya_id":"6"}, {"id":"207","code_postal":"06030","nom":"Souk Oufella","wilaya_id":"6"}, {"id":"208","code_postal":"06031","nom":"Taskriout","wilaya_id":"6"}, {"id":"209","code_postal":"06032","nom":"Tibane","wilaya_id":"6"}, {"id":"210","code_postal":"06033","nom":"Tala Hamza","wilaya_id":"6"}, {"id":"211","code_postal":"06034","nom":"Barbacha","wilaya_id":"6"}, {"id":"212","code_postal":"06035","nom":"Beni Ksila","wilaya_id":"6"}, {"id":"213","code_postal":"06036","nom":"Ouzallaguen","wilaya_id":"6"}, {"id":"214","code_postal":"06037","nom":"Bouhamza","wilaya_id":"6"}, {"id":"215","code_postal":"06038","nom":"Beni Melikeche","wilaya_id":"6"}, {"id":"216","code_postal":"06039","nom":"Sidi Aich","wilaya_id":"6"}, {"id":"217","code_postal":"06040","nom":"El Kseur","wilaya_id":"6"}, {"id":"218","code_postal":"06041","nom":"Melbou","wilaya_id":"6"}, {"id":"219","code_postal":"06042","nom":"Akfadou","wilaya_id":"6"}, {"id":"220","code_postal":"06043","nom":"Leflaye","wilaya_id":"6"}, {"id":"221","code_postal":"06044","nom":"Kherrata","wilaya_id":"6"}, {"id":"222","code_postal":"06045","nom":"Draa Kaid","wilaya_id":"6"}, {"id":"223","code_postal":"06046","nom":"Tamridjet","wilaya_id":"6"}, {"id":"224","code_postal":"06047","nom":"Ait Smail","wilaya_id":"6"}, {"id":"225","code_postal":"06048","nom":"Boukhelifa","wilaya_id":"6"}, {"id":"226","code_postal":"06049","nom":"Tizi Nberber","wilaya_id":"6"}, {"id":"227","code_postal":"06050","nom":"Beni Maouch","wilaya_id":"6"}, {"id":"228","code_postal":"06051","nom":"Oued Ghir","wilaya_id":"6"}, {"id":"229","code_postal":"06052","nom":"Boudjellil","wilaya_id":"6"}, {"id":"230","code_postal":"07001","nom":"Biskra","wilaya_id":"7"}, {"id":"231","code_postal":"07002","nom":"Oumache","wilaya_id":"7"}, {"id":"232","code_postal":"07003","nom":"Branis","wilaya_id":"7"}, {"id":"233","code_postal":"07004","nom":"Chetma","wilaya_id":"7"}, {"id":"234","code_postal":"07005","nom":"Ouled Djellal","wilaya_id":"7"}, {"id":"235","code_postal":"07006","nom":"Ras El Miaad","wilaya_id":"7"}, {"id":"236","code_postal":"07007","nom":"Besbes","wilaya_id":"7"}, {"id":"237","code_postal":"07008","nom":"Sidi Khaled","wilaya_id":"7"}, {"id":"238","code_postal":"07009","nom":"Doucen","wilaya_id":"7"}, {"id":"239","code_postal":"07010","nom":"Ech Chaiba","wilaya_id":"7"}, {"id":"240","code_postal":"07011","nom":"Sidi Okba","wilaya_id":"7"}, {"id":"241","code_postal":"07012","nom":"Mchouneche","wilaya_id":"7"}, {"id":"242","code_postal":"07013","nom":"El Haouch","wilaya_id":"7"}, {"id":"243","code_postal":"07014","nom":"Ain Naga","wilaya_id":"7"}, {"id":"244","code_postal":"07015","nom":"Zeribet El Oued","wilaya_id":"7"}, {"id":"245","code_postal":"07016","nom":"El Feidh","wilaya_id":"7"}, {"id":"246","code_postal":"07017","nom":"El Kantara","wilaya_id":"7"}, {"id":"247","code_postal":"07018","nom":"Ain Zaatout","wilaya_id":"7"}, {"id":"248","code_postal":"07019","nom":"El Outaya","wilaya_id":"7"}, {"id":"249","code_postal":"07020","nom":"Djemorah","wilaya_id":"7"}, {"id":"250","code_postal":"07021","nom":"Tolga","wilaya_id":"7"}, {"id":"251","code_postal":"07022","nom":"Lioua","wilaya_id":"7"}, {"id":"252","code_postal":"07023","nom":"Lichana","wilaya_id":"7"}, {"id":"253","code_postal":"07024","nom":"Ourlal","wilaya_id":"7"}, {"id":"254","code_postal":"07025","nom":"Mlili","wilaya_id":"7"}, {"id":"255","code_postal":"07026","nom":"Foughala","wilaya_id":"7"}, {"id":"256","code_postal":"07027","nom":"Bordj Ben Azzouz","wilaya_id":"7"}, {"id":"257","code_postal":"07028","nom":"Meziraa","wilaya_id":"7"}, {"id":"258","code_postal":"07029","nom":"Bouchagroun","wilaya_id":"7"}, {"id":"259","code_postal":"07030","nom":"Mekhadma","wilaya_id":"7"}, {"id":"260","code_postal":"07031","nom":"El Ghrous","wilaya_id":"7"}, {"id":"261","code_postal":"07032","nom":"El Hadjab","wilaya_id":"7"}, {"id":"262","code_postal":"07033","nom":"Khanguet Sidinadji","wilaya_id":"7"}, {"id":"263","code_postal":"08001","nom":"Bechar","wilaya_id":"8"}, {"id":"264","code_postal":"08002","nom":"Erg Ferradj","wilaya_id":"8"}, {"id":"265","code_postal":"08003","nom":"Ouled Khoudir","wilaya_id":"8"}, {"id":"266","code_postal":"08004","nom":"Meridja","wilaya_id":"8"}, {"id":"267","code_postal":"08005","nom":"Timoudi","wilaya_id":"8"}, {"id":"268","code_postal":"08006","nom":"Lahmar","wilaya_id":"8"}, {"id":"269","code_postal":"08007","nom":"Beni Abbes","wilaya_id":"8"}, {"id":"270","code_postal":"08008","nom":"Beni Ikhlef","wilaya_id":"8"}, {"id":"271","code_postal":"08009","nom":"Mechraa Houari B","wilaya_id":"8"}, {"id":"272","code_postal":"08010","nom":"Kenedsa","wilaya_id":"8"}, {"id":"273","code_postal":"08011","nom":"Igli","wilaya_id":"8"}, {"id":"274","code_postal":"08012","nom":"Tabalbala","wilaya_id":"8"}, {"id":"275","code_postal":"08013","nom":"Taghit","wilaya_id":"8"}, {"id":"276","code_postal":"08014","nom":"El Ouata","wilaya_id":"8"}, {"id":"277","code_postal":"08015","nom":"Boukais","wilaya_id":"8"}, {"id":"278","code_postal":"08016","nom":"Mogheul","wilaya_id":"8"}, {"id":"279","code_postal":"08017","nom":"Abadla","wilaya_id":"8"}, {"id":"280","code_postal":"08018","nom":"Kerzaz","wilaya_id":"8"}, {"id":"281","code_postal":"08019","nom":"Ksabi","wilaya_id":"8"}, {"id":"282","code_postal":"08020","nom":"Tamtert","wilaya_id":"8"}, {"id":"283","code_postal":"08021","nom":"Beni Ounif","wilaya_id":"8"}, {"id":"284","code_postal":"09001","nom":"Blida","wilaya_id":"9"}, {"id":"285","code_postal":"09002","nom":"Chebli","wilaya_id":"9"}, {"id":"286","code_postal":"09003","nom":"Bouinan","wilaya_id":"9"}, {"id":"287","code_postal":"09004","nom":"Oued El Alleug","wilaya_id":"9"}, {"id":"288","code_postal":"09007","nom":"Ouled Yaich","wilaya_id":"9"}, {"id":"289","code_postal":"09008","nom":"Chrea","wilaya_id":"9"}, {"id":"290","code_postal":"09010","nom":"El Affroun","wilaya_id":"9"}, {"id":"291","code_postal":"09011","nom":"Chiffa","wilaya_id":"9"}, {"id":"292","code_postal":"09012","nom":"Hammam Melouane","wilaya_id":"9"}, {"id":"293","code_postal":"09013","nom":"Ben Khlil","wilaya_id":"9"}, {"id":"294","code_postal":"09014","nom":"Soumaa","wilaya_id":"9"}, {"id":"295","code_postal":"09016","nom":"Mouzaia","wilaya_id":"9"}, {"id":"296","code_postal":"09017","nom":"Souhane","wilaya_id":"9"}, {"id":"297","code_postal":"09018","nom":"Meftah","wilaya_id":"9"}, {"id":"298","code_postal":"09019","nom":"Ouled Selama","wilaya_id":"9"}, {"id":"299","code_postal":"09020","nom":"Boufarik","wilaya_id":"9"}, {"id":"300","code_postal":"09021","nom":"Larbaa","wilaya_id":"9"}, {"id":"301","code_postal":"09022","nom":"Oued Djer","wilaya_id":"9"}, {"id":"302","code_postal":"09023","nom":"Beni Tamou","wilaya_id":"9"}, {"id":"303","code_postal":"09024","nom":"Bouarfa","wilaya_id":"9"}, {"id":"304","code_postal":"09025","nom":"Beni Mered","wilaya_id":"9"}, {"id":"305","code_postal":"09026","nom":"Bougara","wilaya_id":"9"}, {"id":"306","code_postal":"09027","nom":"Guerrouaou","wilaya_id":"9"}, {"id":"307","code_postal":"09028","nom":"Ain Romana","wilaya_id":"9"}, {"id":"308","code_postal":"09029","nom":"Djebabra","wilaya_id":"9"}, {"id":"309","code_postal":"10001","nom":"Bouira","wilaya_id":"10"}, {"id":"310","code_postal":"10002","nom":"El Asnam","wilaya_id":"10"}, {"id":"311","code_postal":"10003","nom":"Guerrouma","wilaya_id":"10"}, {"id":"312","code_postal":"10004","nom":"Souk El Khemis","wilaya_id":"10"}, {"id":"313","code_postal":"10005","nom":"Kadiria","wilaya_id":"10"}, {"id":"314","code_postal":"10006","nom":"Hanif","wilaya_id":"10"}, {"id":"315","code_postal":"10007","nom":"Dirah","wilaya_id":"10"}, {"id":"316","code_postal":"10008","nom":"Ait Laaziz","wilaya_id":"10"}, {"id":"317","code_postal":"10009","nom":"Taghzout","wilaya_id":"10"}, {"id":"318","code_postal":"10010","nom":"Raouraoua","wilaya_id":"10"}, {"id":"319","code_postal":"10011","nom":"Mezdour","wilaya_id":"10"}, {"id":"320","code_postal":"10012","nom":"Haizer","wilaya_id":"10"}, {"id":"321","code_postal":"10013","nom":"Lakhdaria","wilaya_id":"10"}, {"id":"322","code_postal":"10014","nom":"Maala","wilaya_id":"10"}, {"id":"323","code_postal":"10015","nom":"El Hachimia","wilaya_id":"10"}, {"id":"324","code_postal":"10016","nom":"Aomar","wilaya_id":"10"}, {"id":"325","code_postal":"10017","nom":"Chorfa","wilaya_id":"10"}, {"id":"326","code_postal":"10018","nom":"Bordj Oukhriss","wilaya_id":"10"}, {"id":"327","code_postal":"10019","nom":"El Adjiba","wilaya_id":"10"}, {"id":"328","code_postal":"10020","nom":"El Hakimia","wilaya_id":"10"}, {"id":"329","code_postal":"10021","nom":"El Khebouzia","wilaya_id":"10"}, {"id":"330","code_postal":"10022","nom":"Ahl El Ksar","wilaya_id":"10"}, {"id":"331","code_postal":"10023","nom":"Bouderbala","wilaya_id":"10"}, {"id":"332","code_postal":"10024","nom":"Zbarbar","wilaya_id":"10"}, {"id":"333","code_postal":"10025","nom":"Ain El Hadjar","wilaya_id":"10"}, {"id":"334","code_postal":"10026","nom":"Djebahia","wilaya_id":"10"}, {"id":"335","code_postal":"10027","nom":"Aghbalou","wilaya_id":"10"}, {"id":"336","code_postal":"10028","nom":"Taguedit","wilaya_id":"10"}, {"id":"337","code_postal":"10029","nom":"Ain Turk","wilaya_id":"10"}, {"id":"338","code_postal":"10030","nom":"Saharidj","wilaya_id":"10"}, {"id":"339","code_postal":"10031","nom":"Dechmia","wilaya_id":"10"}, {"id":"340","code_postal":"10032","nom":"Ridane","wilaya_id":"10"}, {"id":"341","code_postal":"10033","nom":"Bechloul","wilaya_id":"10"}, {"id":"342","code_postal":"10034","nom":"Boukram","wilaya_id":"10"}, {"id":"343","code_postal":"10035","nom":"Ain Bessam","wilaya_id":"10"}, {"id":"344","code_postal":"10036","nom":"Bir Ghbalou","wilaya_id":"10"}, {"id":"345","code_postal":"10037","nom":"Mchedallah","wilaya_id":"10"}, {"id":"346","code_postal":"10038","nom":"Sour El Ghozlane","wilaya_id":"10"}, {"id":"347","code_postal":"10039","nom":"Maamora","wilaya_id":"10"}, {"id":"348","code_postal":"10040","nom":"Ouled Rached","wilaya_id":"10"}, {"id":"349","code_postal":"10041","nom":"Ain Laloui","wilaya_id":"10"}, {"id":"350","code_postal":"10042","nom":"Hadjera Zerga","wilaya_id":"10"}, {"id":"351","code_postal":"10043","nom":"Ath Mansour","wilaya_id":"10"}, {"id":"352","code_postal":"10044","nom":"El Mokrani","wilaya_id":"10"}, {"id":"353","code_postal":"10045","nom":"Oued El Berdi","wilaya_id":"10"}, {"id":"354","code_postal":"11001","nom":"Tamanghasset","wilaya_id":"11"}, {"id":"355","code_postal":"11002","nom":"Abalessa","wilaya_id":"11"}, {"id":"356","code_postal":"11003","nom":"In Ghar","wilaya_id":"11"}, {"id":"357","code_postal":"11004","nom":"In Guezzam","wilaya_id":"11"}, {"id":"358","code_postal":"11005","nom":"Idles","wilaya_id":"11"}, {"id":"359","code_postal":"11006","nom":"Tazouk","wilaya_id":"11"}, {"id":"360","code_postal":"11007","nom":"Tinzaouatine","wilaya_id":"11"}, {"id":"361","code_postal":"11008","nom":"In Salah","wilaya_id":"11"}, {"id":"362","code_postal":"11009","nom":"In Amguel","wilaya_id":"11"}, {"id":"363","code_postal":"11010","nom":"Foggaret Ezzaouia","wilaya_id":"11"}, {"id":"364","code_postal":"12001","nom":"Tebessa","wilaya_id":"12"}, {"id":"365","code_postal":"12002","nom":"Bir El Ater","wilaya_id":"12"}, {"id":"366","code_postal":"12003","nom":"Cheria","wilaya_id":"12"}, {"id":"367","code_postal":"12004","nom":"Stah Guentis","wilaya_id":"12"}, {"id":"368","code_postal":"12005","nom":"El Aouinet","wilaya_id":"12"}, {"id":"369","code_postal":"12006","nom":"Lahouidjbet","wilaya_id":"12"}, {"id":"370","code_postal":"12007","nom":"Safsaf El Ouesra","wilaya_id":"12"}, {"id":"371","code_postal":"12008","nom":"Hammamet","wilaya_id":"12"}, {"id":"372","code_postal":"12009","nom":"Negrine","wilaya_id":"12"}, {"id":"373","code_postal":"12010","nom":"Bir El Mokadem","wilaya_id":"12"}, {"id":"374","code_postal":"12011","nom":"El Kouif","wilaya_id":"12"}, {"id":"375","code_postal":"12012","nom":"Morsott","wilaya_id":"12"}, {"id":"376","code_postal":"12013","nom":"El Ogla","wilaya_id":"12"}, {"id":"377","code_postal":"12014","nom":"Bir Dheheb","wilaya_id":"12"}, {"id":"378","code_postal":"12015","nom":"El Ogla El Malha","wilaya_id":"12"}, {"id":"379","code_postal":"12016","nom":"Gorriguer","wilaya_id":"12"}, {"id":"380","code_postal":"12017","nom":"Bekkaria","wilaya_id":"12"}, {"id":"381","code_postal":"12018","nom":"Boukhadra","wilaya_id":"12"}, {"id":"382","code_postal":"12019","nom":"Ouenza","wilaya_id":"12"}, {"id":"383","code_postal":"12020","nom":"El Ma El Biodh","wilaya_id":"12"}, {"id":"384","code_postal":"12021","nom":"Oum Ali","wilaya_id":"12"}, {"id":"385","code_postal":"12022","nom":"Thlidjene","wilaya_id":"12"}, {"id":"386","code_postal":"12023","nom":"Ain Zerga","wilaya_id":"12"}, {"id":"387","code_postal":"12024","nom":"El Meridj","wilaya_id":"12"}, {"id":"388","code_postal":"12025","nom":"Boulhaf Dyr","wilaya_id":"12"}, {"id":"389","code_postal":"12026","nom":"Bedjene","wilaya_id":"12"}, {"id":"390","code_postal":"12027","nom":"El Mazeraa","wilaya_id":"12"}, {"id":"391","code_postal":"12028","nom":"Ferkane","wilaya_id":"12"}, {"id":"392","code_postal":"13001","nom":"Tlemcen","wilaya_id":"13"}, {"id":"393","code_postal":"13002","nom":"Beni Mester","wilaya_id":"13"}, {"id":"394","code_postal":"13003","nom":"Ain Tallout","wilaya_id":"13"}, {"id":"395","code_postal":"13004","nom":"Remchi","wilaya_id":"13"}, {"id":"396","code_postal":"13005","nom":"El Fehoul","wilaya_id":"13"}, {"id":"397","code_postal":"13006","nom":"Sabra","wilaya_id":"13"}, {"id":"398","code_postal":"13007","nom":"Ghazaouet","wilaya_id":"13"}, {"id":"399","code_postal":"13008","nom":"Souani","wilaya_id":"13"}, {"id":"400","code_postal":"13009","nom":"Djebala","wilaya_id":"13"}, {"id":"401","code_postal":"13010","nom":"El Gor","wilaya_id":"13"}, {"id":"402","code_postal":"13011","nom":"Oued Chouly","wilaya_id":"13"}, {"id":"403","code_postal":"13012","nom":"Ain Fezza","wilaya_id":"13"}, {"id":"404","code_postal":"13013","nom":"Ouled Mimoun","wilaya_id":"13"}, {"id":"405","code_postal":"13014","nom":"Amieur","wilaya_id":"13"}, {"id":"406","code_postal":"13015","nom":"Ain Youcef","wilaya_id":"13"}, {"id":"407","code_postal":"13016","nom":"Zenata","wilaya_id":"13"}, {"id":"408","code_postal":"13017","nom":"Beni Snous","wilaya_id":"13"}, {"id":"409","code_postal":"13018","nom":"Bab El Assa","wilaya_id":"13"}, {"id":"410","code_postal":"13019","nom":"Dar Yaghmouracene","wilaya_id":"13"}, {"id":"411","code_postal":"13020","nom":"Fellaoucene","wilaya_id":"13"}, {"id":"412","code_postal":"13021","nom":"Azails","wilaya_id":"13"}, {"id":"413","code_postal":"13022","nom":"Sebbaa Chioukh","wilaya_id":"13"}, {"id":"414","code_postal":"13023","nom":"Terni Beni Hediel","wilaya_id":"13"}, {"id":"415","code_postal":"13024","nom":"Bensekrane","wilaya_id":"13"}, {"id":"416","code_postal":"13025","nom":"Ain Nehala","wilaya_id":"13"}, {"id":"417","code_postal":"13026","nom":"Hennaya","wilaya_id":"13"}, {"id":"418","code_postal":"13027","nom":"Maghnia","wilaya_id":"13"}, {"id":"419","code_postal":"13028","nom":"Hammam Boughrara","wilaya_id":"13"}, {"id":"420","code_postal":"13029","nom":"Souahlia","wilaya_id":"13"}, {"id":"421","code_postal":"13030","nom":"Msirda Fouaga","wilaya_id":"13"}, {"id":"422","code_postal":"13031","nom":"Ain Fetah","wilaya_id":"13"}, {"id":"423","code_postal":"13032","nom":"El Aricha","wilaya_id":"13"}, {"id":"424","code_postal":"13033","nom":"Souk Thlata","wilaya_id":"13"}, {"id":"425","code_postal":"13034","nom":"Sidi Abdelli","wilaya_id":"13"}, {"id":"426","code_postal":"13035","nom":"Sebdou","wilaya_id":"13"}, {"id":"427","code_postal":"13036","nom":"Beni Ouarsous","wilaya_id":"13"}, {"id":"428","code_postal":"13037","nom":"Sidi Medjahed","wilaya_id":"13"}, {"id":"429","code_postal":"13038","nom":"Beni Boussaid","wilaya_id":"13"}, {"id":"430","code_postal":"13039","nom":"Marsa Ben Mhidi","wilaya_id":"13"}, {"id":"431","code_postal":"13040","nom":"Nedroma","wilaya_id":"13"}, {"id":"432","code_postal":"13041","nom":"Sidi Djillali","wilaya_id":"13"}, {"id":"433","code_postal":"13042","nom":"Beni Bahdel","wilaya_id":"13"}, {"id":"434","code_postal":"13043","nom":"El Bouihi","wilaya_id":"13"}, {"id":"435","code_postal":"13044","nom":"Honaine","wilaya_id":"13"}, {"id":"436","code_postal":"13045","nom":"Tianet","wilaya_id":"13"}, {"id":"437","code_postal":"13046","nom":"Ouled Riyah","wilaya_id":"13"}, {"id":"438","code_postal":"13047","nom":"Bouhlou","wilaya_id":"13"}, {"id":"439","code_postal":"13048","nom":"Souk El Khemis","wilaya_id":"13"}, {"id":"440","code_postal":"13049","nom":"Ain Ghoraba","wilaya_id":"13"}, {"id":"441","code_postal":"13050","nom":"Chetouane","wilaya_id":"13"}, {"id":"442","code_postal":"13051","nom":"Mansourah","wilaya_id":"13"}, {"id":"443","code_postal":"13052","nom":"Beni Semiel","wilaya_id":"13"}, {"id":"444","code_postal":"13053","nom":"Ain Kebira","wilaya_id":"13"}, {"id":"445","code_postal":"14001","nom":"Tiaret","wilaya_id":"14"}, {"id":"446","code_postal":"14002","nom":"Medroussa","wilaya_id":"14"}, {"id":"447","code_postal":"14003","nom":"Ain Bouchekif","wilaya_id":"14"}, {"id":"448","code_postal":"14004","nom":"Sidi Ali Mellal","wilaya_id":"14"}, {"id":"449","code_postal":"14005","nom":"Ain Zarit","wilaya_id":"14"}, {"id":"450","code_postal":"14006","nom":"Ain Deheb","wilaya_id":"14"}, {"id":"451","code_postal":"14007","nom":"Sidi Bakhti","wilaya_id":"14"}, {"id":"452","code_postal":"14008","nom":"Medrissa","wilaya_id":"14"}, {"id":"453","code_postal":"14009","nom":"Zmalet El Emir Aek","wilaya_id":"14"}, {"id":"454","code_postal":"14010","nom":"Madna","wilaya_id":"14"}, {"id":"455","code_postal":"14011","nom":"Sebt","wilaya_id":"14"}, {"id":"456","code_postal":"14012","nom":"Mellakou","wilaya_id":"14"}, {"id":"457","code_postal":"14013","nom":"Dahmouni","wilaya_id":"14"}, {"id":"458","code_postal":"14014","nom":"Rahouia","wilaya_id":"14"}, {"id":"459","code_postal":"14015","nom":"Mahdia","wilaya_id":"14"}, {"id":"460","code_postal":"14016","nom":"Sougueur","wilaya_id":"14"}, {"id":"461","code_postal":"14017","nom":"Sidi Abdelghani","wilaya_id":"14"}, {"id":"462","code_postal":"14018","nom":"Ain El Hadid","wilaya_id":"14"}, {"id":"463","code_postal":"14019","nom":"Ouled Djerad","wilaya_id":"14"}, {"id":"464","code_postal":"14020","nom":"Naima","wilaya_id":"14"}, {"id":"465","code_postal":"14021","nom":"Meghila","wilaya_id":"14"}, {"id":"466","code_postal":"14022","nom":"Guertoufa","wilaya_id":"14"}, {"id":"467","code_postal":"14023","nom":"Sidi Hosni","wilaya_id":"14"}, {"id":"468","code_postal":"14024","nom":"Djillali Ben Amar","wilaya_id":"14"}, {"id":"469","code_postal":"14025","nom":"Sebaine","wilaya_id":"14"}, {"id":"470","code_postal":"14026","nom":"Tousnina","wilaya_id":"14"}, {"id":"471","code_postal":"14027","nom":"Frenda","wilaya_id":"14"}, {"id":"472","code_postal":"14028","nom":"Ain Kermes","wilaya_id":"14"}, {"id":"473","code_postal":"14029","nom":"Ksar Chellala","wilaya_id":"14"}, {"id":"474","code_postal":"14030","nom":"Rechaiga","wilaya_id":"14"}, {"id":"475","code_postal":"14031","nom":"Nadorah","wilaya_id":"14"}, {"id":"476","code_postal":"14032","nom":"Tagdemt","wilaya_id":"14"}, {"id":"477","code_postal":"14033","nom":"Oued Lilli","wilaya_id":"14"}, {"id":"478","code_postal":"14034","nom":"Mechraa Safa","wilaya_id":"14"}, {"id":"479","code_postal":"14035","nom":"Hamadia","wilaya_id":"14"}, {"id":"480","code_postal":"14036","nom":"Chehaima","wilaya_id":"14"}, {"id":"481","code_postal":"14037","nom":"Takhemaret","wilaya_id":"14"}, {"id":"482","code_postal":"14038","nom":"Sidi Abderrahmane","wilaya_id":"14"}, {"id":"483","code_postal":"14039","nom":"Serghine","wilaya_id":"14"}, {"id":"484","code_postal":"14040","nom":"Bougara","wilaya_id":"14"}, {"id":"485","code_postal":"14041","nom":"Faidja","wilaya_id":"14"}, {"id":"486","code_postal":"14042","nom":"Tidda","wilaya_id":"14"}, {"id":"487","code_postal":"15001","nom":"Tizi Ouzou","wilaya_id":"15"}, {"id":"488","code_postal":"15002","nom":"Ain El Hammam","wilaya_id":"15"}, {"id":"489","code_postal":"15003","nom":"Akbil","wilaya_id":"15"}, {"id":"490","code_postal":"15004","nom":"Freha","wilaya_id":"15"}, {"id":"491","code_postal":"15005","nom":"Souamaa","wilaya_id":"15"}, {"id":"492","code_postal":"15006","nom":"Mechtrass","wilaya_id":"15"}, {"id":"493","code_postal":"15007","nom":"Irdjen","wilaya_id":"15"}, {"id":"494","code_postal":"15008","nom":"Timizart","wilaya_id":"15"}, {"id":"495","code_postal":"15009","nom":"Makouda","wilaya_id":"15"}, {"id":"496","code_postal":"15010","nom":"Draa El Mizan","wilaya_id":"15"}, {"id":"497","code_postal":"15011","nom":"Tizi Ghenif","wilaya_id":"15"}, {"id":"498","code_postal":"15012","nom":"Bounouh","wilaya_id":"15"}, {"id":"499","code_postal":"15013","nom":"Ait Chaffaa","wilaya_id":"15"}, {"id":"500","code_postal":"15014","nom":"Frikat","wilaya_id":"15"}, {"id":"501","code_postal":"15015","nom":"Beni Aissi","wilaya_id":"15"}, {"id":"502","code_postal":"15016","nom":"Beni Zmenzer","wilaya_id":"15"}, {"id":"503","code_postal":"15017","nom":"Iferhounene","wilaya_id":"15"}, {"id":"504","code_postal":"15018","nom":"Azazga","wilaya_id":"15"}, {"id":"505","code_postal":"15019","nom":"Iloula Oumalou","wilaya_id":"15"}, {"id":"506","code_postal":"15020","nom":"Yakouren","wilaya_id":"15"}, {"id":"507","code_postal":"15021","nom":"Larba Nait Irathen","wilaya_id":"15"}, {"id":"508","code_postal":"15022","nom":"Tizi Rached","wilaya_id":"15"}, {"id":"509","code_postal":"15023","nom":"Zekri","wilaya_id":"15"}, {"id":"510","code_postal":"15024","nom":"Ouaguenoun","wilaya_id":"15"}, {"id":"511","code_postal":"15025","nom":"Ain Zaouia","wilaya_id":"15"}, {"id":"512","code_postal":"15026","nom":"Mkira","wilaya_id":"15"}, {"id":"513","code_postal":"15027","nom":"Ait Yahia","wilaya_id":"15"}, {"id":"514","code_postal":"15028","nom":"Ait Mahmoud","wilaya_id":"15"}, {"id":"515","code_postal":"15029","nom":"Maatka","wilaya_id":"15"}, {"id":"516","code_postal":"15030","nom":"Ait Boumehdi","wilaya_id":"15"}, {"id":"517","code_postal":"15031","nom":"Abi Youcef","wilaya_id":"15"}, {"id":"518","code_postal":"15032","nom":"Beni Douala","wilaya_id":"15"}, {"id":"519","code_postal":"15033","nom":"Illilten","wilaya_id":"15"}, {"id":"520","code_postal":"15034","nom":"Bouzguen","wilaya_id":"15"}, {"id":"521","code_postal":"15035","nom":"Ait Aggouacha","wilaya_id":"15"}, {"id":"522","code_postal":"15036","nom":"Ouadhia","wilaya_id":"15"}, {"id":"523","code_postal":"15037","nom":"Azzefoun","wilaya_id":"15"}, {"id":"524","code_postal":"15038","nom":"Tigzirt","wilaya_id":"15"}, {"id":"525","code_postal":"15039","nom":"Ait Aissa Mimoun","wilaya_id":"15"}, {"id":"526","code_postal":"15040","nom":"Boghni","wilaya_id":"15"}, {"id":"527","code_postal":"15041","nom":"Ifigha","wilaya_id":"15"}, {"id":"528","code_postal":"15042","nom":"Ait Oumalou","wilaya_id":"15"}, {"id":"529","code_postal":"15043","nom":"Tirmitine","wilaya_id":"15"}, {"id":"530","code_postal":"15044","nom":"Akerrou","wilaya_id":"15"}, {"id":"531","code_postal":"15045","nom":"Yatafen","wilaya_id":"15"}, {"id":"532","code_postal":"15046","nom":"Beni Ziki","wilaya_id":"15"}, {"id":"533","code_postal":"15047","nom":"Draa Ben Khedda","wilaya_id":"15"}, {"id":"534","code_postal":"15048","nom":"Ouacif","wilaya_id":"15"}, {"id":"535","code_postal":"15049","nom":"Idjeur","wilaya_id":"15"}, {"id":"536","code_postal":"15050","nom":"Mekla","wilaya_id":"15"}, {"id":"537","code_postal":"15051","nom":"Tizi Nthlata","wilaya_id":"15"}, {"id":"538","code_postal":"15052","nom":"Beni Yenni","wilaya_id":"15"}, {"id":"539","code_postal":"15053","nom":"Aghrib","wilaya_id":"15"}, {"id":"540","code_postal":"15054","nom":"Iflissen","wilaya_id":"15"}, {"id":"541","code_postal":"15055","nom":"Boudjima","wilaya_id":"15"}, {"id":"542","code_postal":"15056","nom":"Ait Yahia Moussa","wilaya_id":"15"}, {"id":"543","code_postal":"15057","nom":"Souk El Thenine","wilaya_id":"15"}, {"id":"544","code_postal":"15058","nom":"Ait Khelil","wilaya_id":"15"}, {"id":"545","code_postal":"15059","nom":"Sidi Naamane","wilaya_id":"15"}, {"id":"546","code_postal":"15060","nom":"Iboudraren","wilaya_id":"15"}, {"id":"547","code_postal":"15061","nom":"Aghni Goughran","wilaya_id":"15"}, {"id":"548","code_postal":"15062","nom":"Mizrana","wilaya_id":"15"}, {"id":"549","code_postal":"15063","nom":"Imsouhal","wilaya_id":"15"}, {"id":"550","code_postal":"15064","nom":"Tadmait","wilaya_id":"15"}, {"id":"551","code_postal":"15065","nom":"Ait Bouadou","wilaya_id":"15"}, {"id":"552","code_postal":"15066","nom":"Assi Youcef","wilaya_id":"15"}, {"id":"553","code_postal":"15067","nom":"Ait Toudert","wilaya_id":"15"}, {"id":"554","code_postal":"16001","nom":"Alger Centre","wilaya_id":"16"}, {"id":"555","code_postal":"16002","nom":"Sidi Mhamed","wilaya_id":"16"}, {"id":"556","code_postal":"16003","nom":"El Madania","wilaya_id":"16"}, {"id":"557","code_postal":"16004","nom":"Hamma Anassers","wilaya_id":"16"}, {"id":"558","code_postal":"16005","nom":"Bab El Oued","wilaya_id":"16"}, {"id":"559","code_postal":"16006","nom":"Bologhine Ibn Ziri","wilaya_id":"16"}, {"id":"560","code_postal":"16007","nom":"Casbah","wilaya_id":"16"}, {"id":"561","code_postal":"16008","nom":"Oued Koriche","wilaya_id":"16"}, {"id":"562","code_postal":"16009","nom":"Bir Mourad Rais","wilaya_id":"16"}, {"id":"563","code_postal":"16010","nom":"El Biar","wilaya_id":"16"}, {"id":"564","code_postal":"16011","nom":"Bouzareah","wilaya_id":"16"}, {"id":"565","code_postal":"16012","nom":"Birkhadem","wilaya_id":"16"}, {"id":"566","code_postal":"16013","nom":"El Harrach","wilaya_id":"16"}, {"id":"567","code_postal":"16014","nom":"Baraki","wilaya_id":"16"}, {"id":"568","code_postal":"16015","nom":"Oued Smar","wilaya_id":"16"}, {"id":"569","code_postal":"16016","nom":"Bourouba","wilaya_id":"16"}, {"id":"570","code_postal":"16017","nom":"Hussein Dey","wilaya_id":"16"}, {"id":"571","code_postal":"16018","nom":"Kouba","wilaya_id":"16"}, {"id":"572","code_postal":"16019","nom":"Bachedjerah","wilaya_id":"16"}, {"id":"573","code_postal":"16020","nom":"Dar El Beida","wilaya_id":"16"}, {"id":"574","code_postal":"16021","nom":"Bab Azzouar","wilaya_id":"16"}, {"id":"575","code_postal":"16022","nom":"Ben Aknoun","wilaya_id":"16"}, {"id":"576","code_postal":"16023","nom":"Dely Ibrahim","wilaya_id":"16"}, {"id":"577","code_postal":"16024","nom":"Bains Romains","wilaya_id":"16"}, {"id":"578","code_postal":"16025","nom":"Rais Hamidou","wilaya_id":"16"}, {"id":"579","code_postal":"16026","nom":"Djasr Kasentina","wilaya_id":"16"}, {"id":"580","code_postal":"16027","nom":"El Mouradia","wilaya_id":"16"}, {"id":"581","code_postal":"16028","nom":"Hydra","wilaya_id":"16"}, {"id":"582","code_postal":"16029","nom":"Mohammadia","wilaya_id":"16"}, {"id":"583","code_postal":"16030","nom":"Bordj El Kiffan","wilaya_id":"16"}, {"id":"584","code_postal":"16031","nom":"El Magharia","wilaya_id":"16"}, {"id":"585","code_postal":"16032","nom":"Beni Messous","wilaya_id":"16"}, {"id":"586","code_postal":"16033","nom":"Les Eucalyptus","wilaya_id":"16"}, {"id":"587","code_postal":"16034","nom":"Birtouta","wilaya_id":"16"}, {"id":"588","code_postal":"16035","nom":"Tassala El Merdja","wilaya_id":"16"}, {"id":"589","code_postal":"16036","nom":"Ouled Chebel","wilaya_id":"16"}, {"id":"590","code_postal":"16037","nom":"Sidi Moussa","wilaya_id":"16"}, {"id":"591","code_postal":"16038","nom":"Ain Taya","wilaya_id":"16"}, {"id":"592","code_postal":"16039","nom":"Bordj El Bahri","wilaya_id":"16"}, {"id":"593","code_postal":"16040","nom":"Marsa","wilaya_id":"16"}, {"id":"594","code_postal":"16041","nom":"Haraoua","wilaya_id":"16"}, {"id":"595","code_postal":"16042","nom":"Rouiba","wilaya_id":"16"}, {"id":"596","code_postal":"16043","nom":"Reghaia","wilaya_id":"16"}, {"id":"597","code_postal":"16044","nom":"Ain Benian","wilaya_id":"16"}, {"id":"598","code_postal":"16045","nom":"Staoueli","wilaya_id":"16"}, {"id":"599","code_postal":"16046","nom":"Zeralda","wilaya_id":"16"}, {"id":"600","code_postal":"16047","nom":"Mahelma","wilaya_id":"16"}, {"id":"601","code_postal":"16048","nom":"Rahmania","wilaya_id":"16"}, {"id":"602","code_postal":"16049","nom":"Souidania","wilaya_id":"16"}, {"id":"603","code_postal":"16050","nom":"Cheraga","wilaya_id":"16"}, {"id":"604","code_postal":"16051","nom":"Ouled Fayet","wilaya_id":"16"}, {"id":"605","code_postal":"16052","nom":"El Achour","wilaya_id":"16"}, {"id":"606","code_postal":"16053","nom":"Draria","wilaya_id":"16"}, {"id":"607","code_postal":"16054","nom":"Douera","wilaya_id":"16"}, {"id":"608","code_postal":"16055","nom":"Baba Hassen","wilaya_id":"16"}, {"id":"609","code_postal":"16056","nom":"Khracia","wilaya_id":"16"}, {"id":"610","code_postal":"16057","nom":"Saoula","wilaya_id":"16"}, {"id":"611","code_postal":"17001","nom":"Djelfa","wilaya_id":"17"}, {"id":"612","code_postal":"17002","nom":"Moudjebara","wilaya_id":"17"}, {"id":"613","code_postal":"17003","nom":"El Guedid","wilaya_id":"17"}, {"id":"614","code_postal":"17004","nom":"Hassi Bahbah","wilaya_id":"17"}, {"id":"615","code_postal":"17005","nom":"Ain Maabed","wilaya_id":"17"}, {"id":"616","code_postal":"17006","nom":"Sed Rahal","wilaya_id":"17"}, {"id":"617","code_postal":"17007","nom":"Feidh El Botma","wilaya_id":"17"}, {"id":"618","code_postal":"17008","nom":"Birine","wilaya_id":"17"}, {"id":"619","code_postal":"17009","nom":"Bouira Lahdeb","wilaya_id":"17"}, {"id":"620","code_postal":"17010","nom":"Zaccar","wilaya_id":"17"}, {"id":"621","code_postal":"17011","nom":"El Khemis","wilaya_id":"17"}, {"id":"622","code_postal":"17012","nom":"Sidi Baizid","wilaya_id":"17"}, {"id":"623","code_postal":"17013","nom":"Mliliha","wilaya_id":"17"}, {"id":"624","code_postal":"17014","nom":"El Idrissia","wilaya_id":"17"}, {"id":"625","code_postal":"17015","nom":"Douis","wilaya_id":"17"}, {"id":"626","code_postal":"17016","nom":"Hassi El Euch","wilaya_id":"17"}, {"id":"627","code_postal":"17017","nom":"Messaad","wilaya_id":"17"}, {"id":"628","code_postal":"17018","nom":"Guettara","wilaya_id":"17"}, {"id":"629","code_postal":"17019","nom":"Sidi Ladjel","wilaya_id":"17"}, {"id":"630","code_postal":"17020","nom":"Had Sahary","wilaya_id":"17"}, {"id":"631","code_postal":"17021","nom":"Guernini","wilaya_id":"17"}, {"id":"632","code_postal":"17022","nom":"Selmana","wilaya_id":"17"}, {"id":"633","code_postal":"17023","nom":"Ain Chouhada","wilaya_id":"17"}, {"id":"634","code_postal":"17024","nom":"Oum Laadham","wilaya_id":"17"}, {"id":"635","code_postal":"17025","nom":"Dar Chouikh","wilaya_id":"17"}, {"id":"636","code_postal":"17026","nom":"Charef","wilaya_id":"17"}, {"id":"637","code_postal":"17027","nom":"Beni Yacoub","wilaya_id":"17"}, {"id":"638","code_postal":"17028","nom":"Zaafrane","wilaya_id":"17"}, {"id":"639","code_postal":"17029","nom":"Deldoul","wilaya_id":"17"}, {"id":"640","code_postal":"17030","nom":"Ain El Ibel","wilaya_id":"17"}, {"id":"641","code_postal":"17031","nom":"Ain Oussera","wilaya_id":"17"}, {"id":"642","code_postal":"17032","nom":"Benhar","wilaya_id":"17"}, {"id":"643","code_postal":"17033","nom":"Hassi Fedoul","wilaya_id":"17"}, {"id":"644","code_postal":"17034","nom":"Amourah","wilaya_id":"17"}, {"id":"645","code_postal":"17035","nom":"Ain Fekka","wilaya_id":"17"}, {"id":"646","code_postal":"17036","nom":"Tadmit","wilaya_id":"17"}, {"id":"647","code_postal":"18001","nom":"Jijel","wilaya_id":"18"}, {"id":"648","code_postal":"18002","nom":"Erraguene","wilaya_id":"18"}, {"id":"649","code_postal":"18003","nom":"El Aouana","wilaya_id":"18"}, {"id":"650","code_postal":"18004","nom":"Ziamma Mansouriah","wilaya_id":"18"}, {"id":"651","code_postal":"18005","nom":"Taher","wilaya_id":"18"}, {"id":"652","code_postal":"18006","nom":"Emir Abdelkader","wilaya_id":"18"}, {"id":"653","code_postal":"18007","nom":"Chekfa","wilaya_id":"18"}, {"id":"654","code_postal":"18008","nom":"Chahna","wilaya_id":"18"}, {"id":"655","code_postal":"18009","nom":"El Milia","wilaya_id":"18"}, {"id":"656","code_postal":"18010","nom":"Sidi Maarouf","wilaya_id":"18"}, {"id":"657","code_postal":"18011","nom":"Settara","wilaya_id":"18"}, {"id":"658","code_postal":"18012","nom":"El Ancer","wilaya_id":"18"}, {"id":"659","code_postal":"18013","nom":"Sidi Abdelaziz","wilaya_id":"18"}, {"id":"660","code_postal":"18014","nom":"Kaous","wilaya_id":"18"}, {"id":"661","code_postal":"18015","nom":"Ghebala","wilaya_id":"18"}, {"id":"662","code_postal":"18016","nom":"Bouraoui Belhadef","wilaya_id":"18"}, {"id":"663","code_postal":"18017","nom":"Djmila","wilaya_id":"18"}, {"id":"664","code_postal":"18018","nom":"Selma Benziada","wilaya_id":"18"}, {"id":"665","code_postal":"18019","nom":"Boussif Ouled Askeur","wilaya_id":"18"}, {"id":"666","code_postal":"18020","nom":"El Kennar Nouchfi","wilaya_id":"18"}, {"id":"667","code_postal":"18021","nom":"Ouled Yahia Khadrouch","wilaya_id":"18"}, {"id":"668","code_postal":"18022","nom":"Boudria Beni Yadjis","wilaya_id":"18"}, {"id":"669","code_postal":"18023","nom":"Kemir Oued Adjoul","wilaya_id":"18"}, {"id":"670","code_postal":"18024","nom":"Texena","wilaya_id":"18"}, {"id":"671","code_postal":"18025","nom":"Djemaa Beni Habibi","wilaya_id":"18"}, {"id":"672","code_postal":"18026","nom":"Bordj Taher","wilaya_id":"18"}, {"id":"673","code_postal":"18027","nom":"Ouled Rabah","wilaya_id":"18"}, {"id":"674","code_postal":"18028","nom":"Ouadjana","wilaya_id":"18"}, {"id":"675","code_postal":"19001","nom":"Setif","wilaya_id":"19"}, {"id":"676","code_postal":"19002","nom":"Ain El Kebira","wilaya_id":"19"}, {"id":"677","code_postal":"19003","nom":"Beni Aziz","wilaya_id":"19"}, {"id":"678","code_postal":"19004","nom":"Ouled Sidi Ahmed","wilaya_id":"19"}, {"id":"679","code_postal":"19005","nom":"Boutaleb","wilaya_id":"19"}, {"id":"680","code_postal":"19006","nom":"Ain Roua","wilaya_id":"19"}, {"id":"681","code_postal":"19007","nom":"Draa Kebila","wilaya_id":"19"}, {"id":"682","code_postal":"19008","nom":"Bir El Arch","wilaya_id":"19"}, {"id":"683","code_postal":"19009","nom":"Beni Chebana","wilaya_id":"19"}, {"id":"684","code_postal":"19010","nom":"Ouled Tebben","wilaya_id":"19"}, {"id":"685","code_postal":"19011","nom":"Hamma","wilaya_id":"19"}, {"id":"686","code_postal":"19012","nom":"Maaouia","wilaya_id":"19"}, {"id":"687","code_postal":"19013","nom":"Ain Legraj","wilaya_id":"19"}, {"id":"688","code_postal":"19014","nom":"Ain Abessa","wilaya_id":"19"}, {"id":"689","code_postal":"19015","nom":"Dehamcha","wilaya_id":"19"}, {"id":"690","code_postal":"19016","nom":"Babor","wilaya_id":"19"}, {"id":"691","code_postal":"19017","nom":"Guidjel","wilaya_id":"19"}, {"id":"692","code_postal":"19018","nom":"Ain Lahdjar","wilaya_id":"19"}, {"id":"693","code_postal":"19019","nom":"Bousselam","wilaya_id":"19"}, {"id":"694","code_postal":"19020","nom":"El Eulma","wilaya_id":"19"}, {"id":"695","code_postal":"19021","nom":"Djemila","wilaya_id":"19"}, {"id":"696","code_postal":"19022","nom":"Beni Ouartilane","wilaya_id":"19"}, {"id":"697","code_postal":"19023","nom":"Rosfa","wilaya_id":"19"}, {"id":"698","code_postal":"19024","nom":"Ouled Addouane","wilaya_id":"19"}, {"id":"699","code_postal":"19025","nom":"Belaa","wilaya_id":"19"}, {"id":"700","code_postal":"19026","nom":"Ain Arnat","wilaya_id":"19"}, {"id":"701","code_postal":"19027","nom":"Amoucha","wilaya_id":"19"}, {"id":"702","code_postal":"19028","nom":"Ain Oulmane","wilaya_id":"19"}, {"id":"703","code_postal":"19029","nom":"Beidha Bordj","wilaya_id":"19"}, {"id":"704","code_postal":"19030","nom":"Bouandas","wilaya_id":"19"}, {"id":"705","code_postal":"19031","nom":"Bazer Sakhra","wilaya_id":"19"}, {"id":"706","code_postal":"19032","nom":"Hammam Essokhna","wilaya_id":"19"}, {"id":"707","code_postal":"19033","nom":"Mezloug","wilaya_id":"19"}, {"id":"708","code_postal":"19034","nom":"Bir Haddada","wilaya_id":"19"}, {"id":"709","code_postal":"19035","nom":"Serdj El Ghoul","wilaya_id":"19"}, {"id":"710","code_postal":"19036","nom":"Harbil","wilaya_id":"19"}, {"id":"711","code_postal":"19037","nom":"El Ouricia","wilaya_id":"19"}, {"id":"712","code_postal":"19038","nom":"Tizi Nbechar","wilaya_id":"19"}, {"id":"713","code_postal":"19039","nom":"Salah Bey","wilaya_id":"19"}, {"id":"714","code_postal":"19040","nom":"Ain Azal","wilaya_id":"19"}, {"id":"715","code_postal":"19041","nom":"Guenzet","wilaya_id":"19"}, {"id":"716","code_postal":"19042","nom":"Talaifacene","wilaya_id":"19"}, {"id":"717","code_postal":"19043","nom":"Bougaa","wilaya_id":"19"}, {"id":"718","code_postal":"19044","nom":"Beni Fouda","wilaya_id":"19"}, {"id":"719","code_postal":"19045","nom":"Tachouda","wilaya_id":"19"}, {"id":"720","code_postal":"19046","nom":"Beni Mouhli","wilaya_id":"19"}, {"id":"721","code_postal":"19047","nom":"Ouled Sabor","wilaya_id":"19"}, {"id":"722","code_postal":"19048","nom":"Guellal","wilaya_id":"19"}, {"id":"723","code_postal":"19049","nom":"Ain Sebt","wilaya_id":"19"}, {"id":"724","code_postal":"19050","nom":"Hammam Guergour","wilaya_id":"19"}, {"id":"725","code_postal":"19051","nom":"Ait Naoual Mezada","wilaya_id":"19"}, {"id":"726","code_postal":"19052","nom":"Ksar El Abtal","wilaya_id":"19"}, {"id":"727","code_postal":"19053","nom":"Beni Hocine","wilaya_id":"19"}, {"id":"728","code_postal":"19054","nom":"Ait Tizi","wilaya_id":"19"}, {"id":"729","code_postal":"19055","nom":"Maouklane","wilaya_id":"19"}, {"id":"730","code_postal":"19056","nom":"Guelta Zerka","wilaya_id":"19"}, {"id":"731","code_postal":"19057","nom":"Oued El Barad","wilaya_id":"19"}, {"id":"732","code_postal":"19058","nom":"Taya","wilaya_id":"19"}, {"id":"733","code_postal":"19059","nom":"El Ouldja","wilaya_id":"19"}, {"id":"734","code_postal":"19060","nom":"Tella","wilaya_id":"19"}, {"id":"735","code_postal":"20001","nom":"Saida","wilaya_id":"20"}, {"id":"736","code_postal":"20002","nom":"Doui Thabet","wilaya_id":"20"}, {"id":"737","code_postal":"20003","nom":"Ain El Hadjar","wilaya_id":"20"}, {"id":"738","code_postal":"20004","nom":"Ouled Khaled","wilaya_id":"20"}, {"id":"739","code_postal":"20005","nom":"Moulay Larbi","wilaya_id":"20"}, {"id":"740","code_postal":"20006","nom":"Youb","wilaya_id":"20"}, {"id":"741","code_postal":"20007","nom":"Hounet","wilaya_id":"20"}, {"id":"742","code_postal":"20008","nom":"Sidi Amar","wilaya_id":"20"}, {"id":"743","code_postal":"20009","nom":"Sidi Boubekeur","wilaya_id":"20"}, {"id":"744","code_postal":"20010","nom":"El Hassasna","wilaya_id":"20"}, {"id":"745","code_postal":"20011","nom":"Maamora","wilaya_id":"20"}, {"id":"746","code_postal":"20012","nom":"Sidi Ahmed","wilaya_id":"20"}, {"id":"747","code_postal":"20013","nom":"Ain Sekhouna","wilaya_id":"20"}, {"id":"748","code_postal":"20014","nom":"Ouled Brahim","wilaya_id":"20"}, {"id":"749","code_postal":"20015","nom":"Tircine","wilaya_id":"20"}, {"id":"750","code_postal":"20016","nom":"Ain Soltane","wilaya_id":"20"}, {"id":"751","code_postal":"21001","nom":"Skikda","wilaya_id":"21"}, {"id":"752","code_postal":"21002","nom":"Ain Zouit","wilaya_id":"21"}, {"id":"753","code_postal":"21003","nom":"El Hadaik","wilaya_id":"21"}, {"id":"754","code_postal":"21004","nom":"Azzaba","wilaya_id":"21"}, {"id":"755","code_postal":"21005","nom":"Djendel Saadi Mohamed","wilaya_id":"21"}, {"id":"756","code_postal":"21006","nom":"Ain Cherchar","wilaya_id":"21"}, {"id":"757","code_postal":"21007","nom":"Bekkouche Lakhdar","wilaya_id":"21"}, {"id":"758","code_postal":"21008","nom":"Benazouz","wilaya_id":"21"}, {"id":"759","code_postal":"21009","nom":"Es Sebt","wilaya_id":"21"}, {"id":"760","code_postal":"21010","nom":"Collo","wilaya_id":"21"}, {"id":"761","code_postal":"21011","nom":"Beni Zid","wilaya_id":"21"}, {"id":"762","code_postal":"21012","nom":"Kerkera","wilaya_id":"21"}, {"id":"763","code_postal":"21013","nom":"Ouled Attia","wilaya_id":"21"}, {"id":"764","code_postal":"21014","nom":"Oued Zehour","wilaya_id":"21"}, {"id":"765","code_postal":"21015","nom":"Zitouna","wilaya_id":"21"}, {"id":"766","code_postal":"21016","nom":"El Harrouch","wilaya_id":"21"}, {"id":"767","code_postal":"21017","nom":"Zerdazas","wilaya_id":"21"}, {"id":"768","code_postal":"21018","nom":"Ouled Hebaba","wilaya_id":"21"}, {"id":"769","code_postal":"21019","nom":"Sidi Mezghiche","wilaya_id":"21"}, {"id":"770","code_postal":"21020","nom":"Emdjez Edchich","wilaya_id":"21"}, {"id":"771","code_postal":"21021","nom":"Beni Oulbane","wilaya_id":"21"}, {"id":"772","code_postal":"21022","nom":"Ain Bouziane","wilaya_id":"21"}, {"id":"773","code_postal":"21023","nom":"Ramdane Djamel","wilaya_id":"21"}, {"id":"774","code_postal":"21024","nom":"Beni Bachir","wilaya_id":"21"}, {"id":"775","code_postal":"21025","nom":"Salah Bouchaour","wilaya_id":"21"}, {"id":"776","code_postal":"21026","nom":"Tamalous","wilaya_id":"21"}, {"id":"777","code_postal":"21027","nom":"Ain Kechra","wilaya_id":"21"}, {"id":"778","code_postal":"21028","nom":"Oum Toub","wilaya_id":"21"}, {"id":"779","code_postal":"21029","nom":"Bein El Ouiden","wilaya_id":"21"}, {"id":"780","code_postal":"21030","nom":"Fil Fila","wilaya_id":"21"}, {"id":"781","code_postal":"21031","nom":"Cheraia","wilaya_id":"21"}, {"id":"782","code_postal":"21032","nom":"Kanoua","wilaya_id":"21"}, {"id":"783","code_postal":"21033","nom":"El Ghedir","wilaya_id":"21"}, {"id":"784","code_postal":"21034","nom":"Bouchtata","wilaya_id":"21"}, {"id":"785","code_postal":"21035","nom":"Ouldja Boulbalout","wilaya_id":"21"}, {"id":"786","code_postal":"21036","nom":"Kheneg Mayoum","wilaya_id":"21"}, {"id":"787","code_postal":"21037","nom":"Hamadi Krouma","wilaya_id":"21"}, {"id":"788","code_postal":"21038","nom":"El Marsa","wilaya_id":"21"}, {"id":"789","code_postal":"22001","nom":"Sidi Bel Abbes","wilaya_id":"22"}, {"id":"790","code_postal":"22002","nom":"Tessala","wilaya_id":"22"}, {"id":"791","code_postal":"22003","nom":"Sidi Brahim","wilaya_id":"22"}, {"id":"792","code_postal":"22004","nom":"Mostefa Ben Brahim","wilaya_id":"22"}, {"id":"793","code_postal":"22005","nom":"Telagh","wilaya_id":"22"}, {"id":"794","code_postal":"22006","nom":"Mezaourou","wilaya_id":"22"}, {"id":"795","code_postal":"22007","nom":"Boukhanafis","wilaya_id":"22"}, {"id":"796","code_postal":"22008","nom":"Sidi Ali Boussidi","wilaya_id":"22"}, {"id":"797","code_postal":"22009","nom":"Badredine El Mokrani","wilaya_id":"22"}, {"id":"798","code_postal":"22010","nom":"Marhoum","wilaya_id":"22"}, {"id":"799","code_postal":"22011","nom":"Tafissour","wilaya_id":"22"}, {"id":"800","code_postal":"22012","nom":"Amarnas","wilaya_id":"22"}, {"id":"801","code_postal":"22013","nom":"Tilmouni","wilaya_id":"22"}, {"id":"802","code_postal":"22014","nom":"Sidi Lahcene","wilaya_id":"22"}, {"id":"803","code_postal":"22015","nom":"Ain Thrid","wilaya_id":"22"}, {"id":"804","code_postal":"22016","nom":"Makedra","wilaya_id":"22"}, {"id":"805","code_postal":"22017","nom":"Tenira","wilaya_id":"22"}, {"id":"806","code_postal":"22018","nom":"Moulay Slissen","wilaya_id":"22"}, {"id":"807","code_postal":"22019","nom":"El Hacaiba","wilaya_id":"22"}, {"id":"808","code_postal":"22020","nom":"Hassi Zehana","wilaya_id":"22"}, {"id":"809","code_postal":"22021","nom":"Tabia","wilaya_id":"22"}, {"id":"810","code_postal":"22022","nom":"Merine","wilaya_id":"22"}, {"id":"811","code_postal":"22023","nom":"Ras El Ma","wilaya_id":"22"}, {"id":"812","code_postal":"22024","nom":"Ain Tindamine","wilaya_id":"22"}, {"id":"813","code_postal":"22025","nom":"Ain Kada","wilaya_id":"22"}, {"id":"814","code_postal":"22026","nom":"Mcid","wilaya_id":"22"}, {"id":"815","code_postal":"22027","nom":"Sidi Khaled","wilaya_id":"22"}, {"id":"816","code_postal":"22028","nom":"Ain El Berd","wilaya_id":"22"}, {"id":"817","code_postal":"22029","nom":"Sfissef","wilaya_id":"22"}, {"id":"818","code_postal":"22030","nom":"Ain Adden","wilaya_id":"22"}, {"id":"819","code_postal":"22031","nom":"Oued Taourira","wilaya_id":"22"}, {"id":"820","code_postal":"22032","nom":"Dhaya","wilaya_id":"22"}, {"id":"821","code_postal":"22033","nom":"Zerouala","wilaya_id":"22"}, {"id":"822","code_postal":"22034","nom":"Lamtar","wilaya_id":"22"}, {"id":"823","code_postal":"22035","nom":"Sidi Chaib","wilaya_id":"22"}, {"id":"824","code_postal":"22036","nom":"Sidi Dahou Dezairs","wilaya_id":"22"}, {"id":"825","code_postal":"22037","nom":"Oued Sbaa","wilaya_id":"22"}, {"id":"826","code_postal":"22038","nom":"Boudjebaa El Bordj","wilaya_id":"22"}, {"id":"827","code_postal":"22039","nom":"Sehala Thaoura","wilaya_id":"22"}, {"id":"828","code_postal":"22040","nom":"Sidi Yacoub","wilaya_id":"22"}, {"id":"829","code_postal":"22041","nom":"Sidi Hamadouche","wilaya_id":"22"}, {"id":"830","code_postal":"22042","nom":"Belarbi","wilaya_id":"22"}, {"id":"831","code_postal":"22043","nom":"Oued Sefioun","wilaya_id":"22"}, {"id":"832","code_postal":"22044","nom":"Teghalimet","wilaya_id":"22"}, {"id":"833","code_postal":"22045","nom":"Ben Badis","wilaya_id":"22"}, {"id":"834","code_postal":"22046","nom":"Sidi Ali Benyoub","wilaya_id":"22"}, {"id":"835","code_postal":"22047","nom":"Chetouane Belaila","wilaya_id":"22"}, {"id":"836","code_postal":"22048","nom":"Bir El Hammam","wilaya_id":"22"}, {"id":"837","code_postal":"22049","nom":"Taoudmout","wilaya_id":"22"}, {"id":"838","code_postal":"22050","nom":"Redjem Demouche","wilaya_id":"22"}, {"id":"839","code_postal":"22051","nom":"Benachiba Chelia","wilaya_id":"22"}, {"id":"840","code_postal":"22052","nom":"Hassi Dahou","wilaya_id":"22"}, {"id":"841","code_postal":"23001","nom":"Annaba","wilaya_id":"23"}, {"id":"842","code_postal":"23002","nom":"Berrahel","wilaya_id":"23"}, {"id":"843","code_postal":"23003","nom":"El Hadjar","wilaya_id":"23"}, {"id":"844","code_postal":"23004","nom":"Eulma","wilaya_id":"23"}, {"id":"845","code_postal":"23005","nom":"El Bouni","wilaya_id":"23"}, {"id":"846","code_postal":"23006","nom":"Oued El Aneb","wilaya_id":"23"}, {"id":"847","code_postal":"23007","nom":"Cheurfa","wilaya_id":"23"}, {"id":"848","code_postal":"23008","nom":"Seraidi","wilaya_id":"23"}, {"id":"849","code_postal":"23009","nom":"Ain Berda","wilaya_id":"23"}, {"id":"850","code_postal":"23010","nom":"Chetaibi","wilaya_id":"23"}, {"id":"851","code_postal":"23011","nom":"Sidi Amer","wilaya_id":"23"}, {"id":"852","code_postal":"23012","nom":"Treat","wilaya_id":"23"}, {"id":"853","code_postal":"24001","nom":"Guelma","wilaya_id":"24"}, {"id":"854","code_postal":"24002","nom":"Nechmaya","wilaya_id":"24"}, {"id":"855","code_postal":"24003","nom":"Bouati Mahmoud","wilaya_id":"24"}, {"id":"856","code_postal":"24004","nom":"Oued Zenati","wilaya_id":"24"}, {"id":"857","code_postal":"24005","nom":"Tamlouka","wilaya_id":"24"}, {"id":"858","code_postal":"24006","nom":"Oued Fragha","wilaya_id":"24"}, {"id":"859","code_postal":"24007","nom":"Ain Sandel","wilaya_id":"24"}, {"id":"860","code_postal":"24008","nom":"Ras El Agba","wilaya_id":"24"}, {"id":"861","code_postal":"24009","nom":"Dahouara","wilaya_id":"24"}, {"id":"862","code_postal":"24010","nom":"Belkhir","wilaya_id":"24"}, {"id":"863","code_postal":"24011","nom":"Ben Djarah","wilaya_id":"24"}, {"id":"864","code_postal":"24012","nom":"Bou Hamdane","wilaya_id":"24"}, {"id":"865","code_postal":"24013","nom":"Ain Makhlouf","wilaya_id":"24"}, {"id":"866","code_postal":"24014","nom":"Ain Ben Beida","wilaya_id":"24"}, {"id":"867","code_postal":"24015","nom":"Khezara","wilaya_id":"24"}, {"id":"868","code_postal":"24016","nom":"Beni Mezline","wilaya_id":"24"}, {"id":"869","code_postal":"24017","nom":"Bou Hachana","wilaya_id":"24"}, {"id":"870","code_postal":"24018","nom":"Guelaat Bou Sbaa","wilaya_id":"24"}, {"id":"871","code_postal":"24019","nom":"Hammam Maskhoutine","wilaya_id":"24"}, {"id":"872","code_postal":"24020","nom":"El Fedjoudj","wilaya_id":"24"}, {"id":"873","code_postal":"24021","nom":"Bordj Sabat","wilaya_id":"24"}, {"id":"874","code_postal":"24022","nom":"Hamman Nbail","wilaya_id":"24"}, {"id":"875","code_postal":"24023","nom":"Ain Larbi","wilaya_id":"24"}, {"id":"876","code_postal":"24024","nom":"Medjez Amar","wilaya_id":"24"}, {"id":"877","code_postal":"24025","nom":"Bouchegouf","wilaya_id":"24"}, {"id":"878","code_postal":"24026","nom":"Heliopolis","wilaya_id":"24"}, {"id":"879","code_postal":"24027","nom":"Ain Hessania","wilaya_id":"24"}, {"id":"880","code_postal":"24028","nom":"Roknia","wilaya_id":"24"}, {"id":"881","code_postal":"24029","nom":"Salaoua Announa","wilaya_id":"24"}, {"id":"882","code_postal":"24030","nom":"Medjez Sfa","wilaya_id":"24"}, {"id":"883","code_postal":"24031","nom":"Boumahra Ahmed","wilaya_id":"24"}, {"id":"884","code_postal":"24032","nom":"Ain Reggada","wilaya_id":"24"}, {"id":"885","code_postal":"24033","nom":"Oued Cheham","wilaya_id":"24"}, {"id":"886","code_postal":"24034","nom":"Djeballah Khemissi","wilaya_id":"24"}, {"id":"887","code_postal":"25001","nom":"Constantine","wilaya_id":"25"}, {"id":"888","code_postal":"25002","nom":"Hamma Bouziane","wilaya_id":"25"}, {"id":"889","code_postal":"25003","nom":"El Haria","wilaya_id":"25"}, {"id":"890","code_postal":"25004","nom":"Zighoud Youcef","wilaya_id":"25"}, {"id":"891","code_postal":"25005","nom":"Didouche Mourad","wilaya_id":"25"}, {"id":"892","code_postal":"25006","nom":"El Khroub","wilaya_id":"25"}, {"id":"893","code_postal":"25007","nom":"Ain Abid","wilaya_id":"25"}, {"id":"894","code_postal":"25008","nom":"Beni Hamiden","wilaya_id":"25"}, {"id":"895","code_postal":"25009","nom":"Ouled Rahmoune","wilaya_id":"25"}, {"id":"896","code_postal":"25010","nom":"Ain Smara","wilaya_id":"25"}, {"id":"897","code_postal":"25011","nom":"Mesaoud Boudjeriou","wilaya_id":"25"}, {"id":"898","code_postal":"25012","nom":"Ibn Ziad","wilaya_id":"25"}, {"id":"899","code_postal":"26001","nom":"Medea","wilaya_id":"26"}, {"id":"900","code_postal":"26002","nom":"Ouzera","wilaya_id":"26"}, {"id":"901","code_postal":"26003","nom":"Ouled Maaref","wilaya_id":"26"}, {"id":"902","code_postal":"26004","nom":"Ain Boucif","wilaya_id":"26"}, {"id":"903","code_postal":"26005","nom":"Aissaouia","wilaya_id":"26"}, {"id":"904","code_postal":"26006","nom":"Ouled Deide","wilaya_id":"26"}, {"id":"905","code_postal":"26007","nom":"El Omaria","wilaya_id":"26"}, {"id":"906","code_postal":"26008","nom":"Derrag","wilaya_id":"26"}, {"id":"907","code_postal":"26009","nom":"El Guelbelkebir","wilaya_id":"26"}, {"id":"908","code_postal":"26010","nom":"Bouaiche","wilaya_id":"26"}, {"id":"909","code_postal":"26011","nom":"Mezerena","wilaya_id":"26"}, {"id":"910","code_postal":"26012","nom":"Ouled Brahim","wilaya_id":"26"}, {"id":"911","code_postal":"26013","nom":"Damiat","wilaya_id":"26"}, {"id":"912","code_postal":"26014","nom":"Sidi Ziane","wilaya_id":"26"}, {"id":"913","code_postal":"26015","nom":"Tamesguida","wilaya_id":"26"}, {"id":"914","code_postal":"26016","nom":"El Hamdania","wilaya_id":"26"}, {"id":"915","code_postal":"26017","nom":"Kef Lakhdar","wilaya_id":"26"}, {"id":"916","code_postal":"26018","nom":"Chelalet El Adhaoura","wilaya_id":"26"}, {"id":"917","code_postal":"26019","nom":"Bouskene","wilaya_id":"26"}, {"id":"918","code_postal":"26020","nom":"Rebaia","wilaya_id":"26"}, {"id":"919","code_postal":"26021","nom":"Bouchrahil","wilaya_id":"26"}, {"id":"920","code_postal":"26022","nom":"Ouled Hellal","wilaya_id":"26"}, {"id":"921","code_postal":"26023","nom":"Tafraout","wilaya_id":"26"}, {"id":"922","code_postal":"26024","nom":"Baata","wilaya_id":"26"}, {"id":"923","code_postal":"26025","nom":"Boghar","wilaya_id":"26"}, {"id":"924","code_postal":"26026","nom":"Sidi Naamane","wilaya_id":"26"}, {"id":"925","code_postal":"26027","nom":"Ouled Bouachra","wilaya_id":"26"}, {"id":"926","code_postal":"26028","nom":"Sidi Zahar","wilaya_id":"26"}, {"id":"927","code_postal":"26029","nom":"Oued Harbil","wilaya_id":"26"}, {"id":"928","code_postal":"26030","nom":"Benchicao","wilaya_id":"26"}, {"id":"929","code_postal":"26031","nom":"Sidi Damed","wilaya_id":"26"}, {"id":"930","code_postal":"26032","nom":"Aziz","wilaya_id":"26"}, {"id":"931","code_postal":"26033","nom":"Souagui","wilaya_id":"26"}, {"id":"932","code_postal":"26034","nom":"Zoubiria","wilaya_id":"26"}, {"id":"933","code_postal":"26035","nom":"Ksar El Boukhari","wilaya_id":"26"}, {"id":"934","code_postal":"26036","nom":"El Azizia","wilaya_id":"26"}, {"id":"935","code_postal":"26037","nom":"Djouab","wilaya_id":"26"}, {"id":"936","code_postal":"26038","nom":"Chahbounia","wilaya_id":"26"}, {"id":"937","code_postal":"26039","nom":"Meghraoua","wilaya_id":"26"}, {"id":"938","code_postal":"26040","nom":"Cheniguel","wilaya_id":"26"}, {"id":"939","code_postal":"26041","nom":"Ain Ouksir","wilaya_id":"26"}, {"id":"940","code_postal":"26042","nom":"Oum El Djalil","wilaya_id":"26"}, {"id":"941","code_postal":"26043","nom":"Ouamri","wilaya_id":"26"}, {"id":"942","code_postal":"26044","nom":"Si Mahdjoub","wilaya_id":"26"}, {"id":"943","code_postal":"26045","nom":"Tlatet Eddoair","wilaya_id":"26"}, {"id":"944","code_postal":"26046","nom":"Beni Slimane","wilaya_id":"26"}, {"id":"945","code_postal":"26047","nom":"Berrouaghia","wilaya_id":"26"}, {"id":"946","code_postal":"26048","nom":"Seghouane","wilaya_id":"26"}, {"id":"947","code_postal":"26049","nom":"Meftaha","wilaya_id":"26"}, {"id":"948","code_postal":"26050","nom":"Mihoub","wilaya_id":"26"}, {"id":"949","code_postal":"26051","nom":"Boughezoul","wilaya_id":"26"}, {"id":"950","code_postal":"26052","nom":"Tablat","wilaya_id":"26"}, {"id":"951","code_postal":"26053","nom":"Deux Bassins","wilaya_id":"26"}, {"id":"952","code_postal":"26054","nom":"Draa Essamar","wilaya_id":"26"}, {"id":"953","code_postal":"26055","nom":"Sidi Errabia","wilaya_id":"26"}, {"id":"954","code_postal":"26056","nom":"Bir Ben Laabed","wilaya_id":"26"}, {"id":"955","code_postal":"26057","nom":"El Ouinet","wilaya_id":"26"}, {"id":"956","code_postal":"26058","nom":"Ouled Antar","wilaya_id":"26"}, {"id":"957","code_postal":"26059","nom":"Bouaichoune","wilaya_id":"26"}, {"id":"958","code_postal":"26060","nom":"Hannacha","wilaya_id":"26"}, {"id":"959","code_postal":"26061","nom":"Sedraia","wilaya_id":"26"}, {"id":"960","code_postal":"26062","nom":"Medjebar","wilaya_id":"26"}, {"id":"961","code_postal":"26063","nom":"Khams Djouamaa","wilaya_id":"26"}, {"id":"962","code_postal":"26064","nom":"Saneg","wilaya_id":"26"}, {"id":"963","code_postal":"27001","nom":"Mostaganem","wilaya_id":"27"}, {"id":"964","code_postal":"27002","nom":"Sayada","wilaya_id":"27"}, {"id":"965","code_postal":"27003","nom":"Fornaka","wilaya_id":"27"}, {"id":"966","code_postal":"27004","nom":"Stidia","wilaya_id":"27"}, {"id":"967","code_postal":"27005","nom":"Ain Nouissy","wilaya_id":"27"}, {"id":"968","code_postal":"27006","nom":"Hassi Maameche","wilaya_id":"27"}, {"id":"969","code_postal":"27007","nom":"Ain Tadles","wilaya_id":"27"}, {"id":"970","code_postal":"27008","nom":"Sour","wilaya_id":"27"}, {"id":"971","code_postal":"27009","nom":"Oued El Kheir","wilaya_id":"27"}, {"id":"972","code_postal":"27010","nom":"Sidi Bellater","wilaya_id":"27"}, {"id":"973","code_postal":"27011","nom":"Kheiredine\u00a0","wilaya_id":"27"}, {"id":"974","code_postal":"27012","nom":"Sidi Ali","wilaya_id":"27"}, {"id":"975","code_postal":"27013","nom":"Abdelmalek Ramdane","wilaya_id":"27"}, {"id":"976","code_postal":"27014","nom":"Hadjadj","wilaya_id":"27"}, {"id":"977","code_postal":"27015","nom":"Nekmaria","wilaya_id":"27"}, {"id":"978","code_postal":"27016","nom":"Sidi Lakhdar","wilaya_id":"27"}, {"id":"979","code_postal":"27017","nom":"Achaacha","wilaya_id":"27"}, {"id":"980","code_postal":"27018","nom":"Khadra","wilaya_id":"27"}, {"id":"981","code_postal":"27019","nom":"Bouguirat","wilaya_id":"27"}, {"id":"982","code_postal":"27020","nom":"Sirat","wilaya_id":"27"}, {"id":"983","code_postal":"27021","nom":"Ain Sidi Cherif","wilaya_id":"27"}, {"id":"984","code_postal":"27022","nom":"Mesra","wilaya_id":"27"}, {"id":"985","code_postal":"27023","nom":"Mansourah","wilaya_id":"27"}, {"id":"986","code_postal":"27024","nom":"Souaflia","wilaya_id":"27"}, {"id":"987","code_postal":"27025","nom":"Ouled Boughalem","wilaya_id":"27"}, {"id":"988","code_postal":"27026","nom":"Ouled Maallah","wilaya_id":"27"}, {"id":"989","code_postal":"27027","nom":"Mezghrane","wilaya_id":"27"}, {"id":"990","code_postal":"27028","nom":"Ain Boudinar","wilaya_id":"27"}, {"id":"991","code_postal":"27029","nom":"Tazgait","wilaya_id":"27"}, {"id":"992","code_postal":"27030","nom":"Safsaf","wilaya_id":"27"}, {"id":"993","code_postal":"27031","nom":"Touahria","wilaya_id":"27"}, {"id":"994","code_postal":"27032","nom":"El Hassiane","wilaya_id":"27"}, {"id":"995","code_postal":"28001","nom":"Msila","wilaya_id":"28"}, {"id":"996","code_postal":"28002","nom":"Maadid","wilaya_id":"28"}, {"id":"997","code_postal":"28003","nom":"Hammam Dhalaa","wilaya_id":"28"}, {"id":"998","code_postal":"28004","nom":"Ouled Derradj","wilaya_id":"28"}, {"id":"999","code_postal":"28005","nom":"Tarmount","wilaya_id":"28"}, {"id":"1000","code_postal":"28006","nom":"Mtarfa","wilaya_id":"28"}, {"id":"1001","code_postal":"28007","nom":"Khoubana","wilaya_id":"28"}, {"id":"1002","code_postal":"28008","nom":"Mcif","wilaya_id":"28"}, {"id":"1003","code_postal":"28009","nom":"Chellal","wilaya_id":"28"}, {"id":"1004","code_postal":"28010","nom":"Ouled Madhi","wilaya_id":"28"}, {"id":"1005","code_postal":"28011","nom":"Magra","wilaya_id":"28"}, {"id":"1006","code_postal":"28012","nom":"Berhoum","wilaya_id":"28"}, {"id":"1007","code_postal":"28013","nom":"Ain Khadra","wilaya_id":"28"}, {"id":"1008","code_postal":"28014","nom":"Ouled Addi Guebala","wilaya_id":"28"}, {"id":"1009","code_postal":"28015","nom":"Belaiba","wilaya_id":"28"}, {"id":"1010","code_postal":"28016","nom":"Sidi Aissa","wilaya_id":"28"}, {"id":"1011","code_postal":"28017","nom":"Ain El Hadjel","wilaya_id":"28"}, {"id":"1012","code_postal":"28018","nom":"Sidi Hadjeres","wilaya_id":"28"}, {"id":"1013","code_postal":"28019","nom":"Ouanougha","wilaya_id":"28"}, {"id":"1014","code_postal":"28020","nom":"Bou Saada","wilaya_id":"28"}, {"id":"1015","code_postal":"28021","nom":"Ouled Sidi Brahim","wilaya_id":"28"}, {"id":"1016","code_postal":"28022","nom":"Sidi Ameur","wilaya_id":"28"}, {"id":"1017","code_postal":"28023","nom":"Tamsa","wilaya_id":"28"}, {"id":"1018","code_postal":"28024","nom":"Ben Srour","wilaya_id":"28"}, {"id":"1019","code_postal":"28025","nom":"Ouled Slimane","wilaya_id":"28"}, {"id":"1020","code_postal":"28026","nom":"El Houamed","wilaya_id":"28"}, {"id":"1021","code_postal":"28027","nom":"El Hamel","wilaya_id":"28"}, {"id":"1022","code_postal":"28028","nom":"Ouled Mansour","wilaya_id":"28"}, {"id":"1023","code_postal":"28029","nom":"Maarif","wilaya_id":"28"}, {"id":"1024","code_postal":"28030","nom":"Dehahna","wilaya_id":"28"}, {"id":"1025","code_postal":"28031","nom":"Bouti Sayah","wilaya_id":"28"}, {"id":"1026","code_postal":"28032","nom":"Khettouti Sed Djir","wilaya_id":"28"}, {"id":"1027","code_postal":"28033","nom":"Zarzour","wilaya_id":"28"}, {"id":"1028","code_postal":"28034","nom":"Oued Chair","wilaya_id":"28"}, {"id":"1029","code_postal":"28035","nom":"Benzouh","wilaya_id":"28"}, {"id":"1030","code_postal":"28036","nom":"Bir Foda","wilaya_id":"28"}, {"id":"1031","code_postal":"28037","nom":"Ain Fares","wilaya_id":"28"}, {"id":"1032","code_postal":"28038","nom":"Sidi Mhamed","wilaya_id":"28"}, {"id":"1033","code_postal":"28039","nom":"Ouled Atia","wilaya_id":"28"}, {"id":"1034","code_postal":"28040","nom":"Souamaa","wilaya_id":"28"}, {"id":"1035","code_postal":"28041","nom":"Ain El Melh","wilaya_id":"28"}, {"id":"1036","code_postal":"28042","nom":"Medjedel","wilaya_id":"28"}, {"id":"1037","code_postal":"28043","nom":"Slim","wilaya_id":"28"}, {"id":"1038","code_postal":"28044","nom":"Ain Errich","wilaya_id":"28"}, {"id":"1039","code_postal":"28045","nom":"Beni Ilmane","wilaya_id":"28"}, {"id":"1040","code_postal":"28046","nom":"Oultene","wilaya_id":"28"}, {"id":"1041","code_postal":"28047","nom":"Djebel Messaad","wilaya_id":"28"}, {"id":"1042","code_postal":"29001","nom":"Mascara","wilaya_id":"29"}, {"id":"1043","code_postal":"29002","nom":"Bou Hanifia","wilaya_id":"29"}, {"id":"1044","code_postal":"29003","nom":"Tizi","wilaya_id":"29"}, {"id":"1045","code_postal":"29004","nom":"Hacine","wilaya_id":"29"}, {"id":"1046","code_postal":"29005","nom":"Maoussa","wilaya_id":"29"}, {"id":"1047","code_postal":"29006","nom":"Teghennif","wilaya_id":"29"}, {"id":"1048","code_postal":"29007","nom":"El Hachem","wilaya_id":"29"}, {"id":"1049","code_postal":"29008","nom":"Sidi Kada","wilaya_id":"29"}, {"id":"1050","code_postal":"29009","nom":"Zelmata","wilaya_id":"29"}, {"id":"1051","code_postal":"29010","nom":"Oued El Abtal","wilaya_id":"29"}, {"id":"1052","code_postal":"29011","nom":"Ain Ferah","wilaya_id":"29"}, {"id":"1053","code_postal":"29012","nom":"Ghriss","wilaya_id":"29"}, {"id":"1054","code_postal":"29013","nom":"Froha","wilaya_id":"29"}, {"id":"1055","code_postal":"29014","nom":"Matemore","wilaya_id":"29"}, {"id":"1056","code_postal":"29015","nom":"Makdha","wilaya_id":"29"}, {"id":"1057","code_postal":"29016","nom":"Sidi Boussaid","wilaya_id":"29"}, {"id":"1058","code_postal":"29017","nom":"El Bordj","wilaya_id":"29"}, {"id":"1059","code_postal":"29018","nom":"Ain Fekan","wilaya_id":"29"}, {"id":"1060","code_postal":"29019","nom":"Benian","wilaya_id":"29"}, {"id":"1061","code_postal":"29020","nom":"Khalouia","wilaya_id":"29"}, {"id":"1062","code_postal":"29021","nom":"El Menaouer","wilaya_id":"29"}, {"id":"1063","code_postal":"29022","nom":"Oued Taria","wilaya_id":"29"}, {"id":"1064","code_postal":"29023","nom":"Aouf","wilaya_id":"29"}, {"id":"1065","code_postal":"29024","nom":"Ain Fares","wilaya_id":"29"}, {"id":"1066","code_postal":"29025","nom":"Ain Frass","wilaya_id":"29"}, {"id":"1067","code_postal":"29026","nom":"Sig","wilaya_id":"29"}, {"id":"1068","code_postal":"29027","nom":"Oggaz","wilaya_id":"29"}, {"id":"1069","code_postal":"29028","nom":"Alaimia","wilaya_id":"29"}, {"id":"1070","code_postal":"29029","nom":"El Gaada","wilaya_id":"29"}, {"id":"1071","code_postal":"29030","nom":"Zahana","wilaya_id":"29"}, {"id":"1072","code_postal":"29031","nom":"Mohammadia","wilaya_id":"29"}, {"id":"1073","code_postal":"29032","nom":"Sidi Abdelmoumene","wilaya_id":"29"}, {"id":"1074","code_postal":"29033","nom":"Ferraguig","wilaya_id":"29"}, {"id":"1075","code_postal":"29034","nom":"El Ghomri","wilaya_id":"29"}, {"id":"1076","code_postal":"29035","nom":"Sedjerara","wilaya_id":"29"}, {"id":"1077","code_postal":"29036","nom":"Moctadouz","wilaya_id":"29"}, {"id":"1078","code_postal":"29037","nom":"Bou Henni","wilaya_id":"29"}, {"id":"1079","code_postal":"29038","nom":"Guettena","wilaya_id":"29"}, {"id":"1080","code_postal":"29039","nom":"El Mamounia","wilaya_id":"29"}, {"id":"1081","code_postal":"29040","nom":"El Keurt","wilaya_id":"29"}, {"id":"1082","code_postal":"29041","nom":"Gharrous","wilaya_id":"29"}, {"id":"1083","code_postal":"29042","nom":"Gherdjoum","wilaya_id":"29"}, {"id":"1084","code_postal":"29043","nom":"Chorfa","wilaya_id":"29"}, {"id":"1085","code_postal":"29044","nom":"Ras Ain Amirouche","wilaya_id":"29"}, {"id":"1086","code_postal":"29045","nom":"Nesmot","wilaya_id":"29"}, {"id":"1087","code_postal":"29046","nom":"Sidi Abdeldjebar","wilaya_id":"29"}, {"id":"1088","code_postal":"29047","nom":"Sehailia","wilaya_id":"29"}, {"id":"1089","code_postal":"30001","nom":"Ouargla","wilaya_id":"30"}, {"id":"1090","code_postal":"30002","nom":"Ain Beida","wilaya_id":"30"}, {"id":"1091","code_postal":"30003","nom":"Ngoussa","wilaya_id":"30"}, {"id":"1092","code_postal":"30004","nom":"Hassi Messaoud","wilaya_id":"30"}, {"id":"1093","code_postal":"30005","nom":"Rouissat","wilaya_id":"30"}, {"id":"1094","code_postal":"30006","nom":"Balidat Ameur","wilaya_id":"30"}, {"id":"1095","code_postal":"30007","nom":"Tebesbest","wilaya_id":"30"}, {"id":"1096","code_postal":"30008","nom":"Nezla","wilaya_id":"30"}, {"id":"1097","code_postal":"30009","nom":"Zaouia El Abidia","wilaya_id":"30"}, {"id":"1098","code_postal":"30010","nom":"Sidi Slimane","wilaya_id":"30"}, {"id":"1099","code_postal":"30011","nom":"Sidi Khouiled","wilaya_id":"30"}, {"id":"1100","code_postal":"30012","nom":"Hassi Ben Abdellah","wilaya_id":"30"}, {"id":"1101","code_postal":"30013","nom":"Touggourt","wilaya_id":"30"}, {"id":"1102","code_postal":"30014","nom":"El Hadjira","wilaya_id":"30"}, {"id":"1103","code_postal":"30015","nom":"Taibet","wilaya_id":"30"}, {"id":"1104","code_postal":"30016","nom":"Tamacine","wilaya_id":"30"}, {"id":"1105","code_postal":"30017","nom":"Benaceur","wilaya_id":"30"}, {"id":"1106","code_postal":"30018","nom":"Mnaguer","wilaya_id":"30"}, {"id":"1107","code_postal":"30019","nom":"Megarine","wilaya_id":"30"}, {"id":"1108","code_postal":"30020","nom":"El Allia","wilaya_id":"30"}, {"id":"1109","code_postal":"30021","nom":"El Borma","wilaya_id":"30"}, {"id":"1110","code_postal":"31001","nom":"Oran","wilaya_id":"31"}, {"id":"1111","code_postal":"31002","nom":"Gdyel","wilaya_id":"31"}, {"id":"1112","code_postal":"31003","nom":"Bir El Djir","wilaya_id":"31"}, {"id":"1113","code_postal":"31004","nom":"Hassi Bounif","wilaya_id":"31"}, {"id":"1114","code_postal":"31005","nom":"Es Senia","wilaya_id":"31"}, {"id":"1115","code_postal":"31006","nom":"Arzew","wilaya_id":"31"}, {"id":"1116","code_postal":"31007","nom":"Bethioua","wilaya_id":"31"}, {"id":"1117","code_postal":"31008","nom":"Marsat El Hadjadj","wilaya_id":"31"}, {"id":"1118","code_postal":"31009","nom":"Ain Turk","wilaya_id":"31"}, {"id":"1119","code_postal":"31010","nom":"El Ancar","wilaya_id":"31"}, {"id":"1120","code_postal":"31011","nom":"Oued Tlelat","wilaya_id":"31"}, {"id":"1121","code_postal":"31012","nom":"Tafraoui","wilaya_id":"31"}, {"id":"1122","code_postal":"31013","nom":"Sidi Chami","wilaya_id":"31"}, {"id":"1123","code_postal":"31014","nom":"Boufatis","wilaya_id":"31"}, {"id":"1124","code_postal":"31015","nom":"Mers El Kebir","wilaya_id":"31"}, {"id":"1125","code_postal":"31016","nom":"Bousfer","wilaya_id":"31"}, {"id":"1126","code_postal":"31017","nom":"El Karma","wilaya_id":"31"}, {"id":"1127","code_postal":"31018","nom":"El Braya","wilaya_id":"31"}, {"id":"1128","code_postal":"31019","nom":"Hassi Ben Okba","wilaya_id":"31"}, {"id":"1129","code_postal":"31020","nom":"Ben Freha","wilaya_id":"31"}, {"id":"1130","code_postal":"31021","nom":"Hassi Mefsoukh","wilaya_id":"31"}, {"id":"1131","code_postal":"31022","nom":"Sidi Ben Yabka","wilaya_id":"31"}, {"id":"1132","code_postal":"31023","nom":"Messerghin","wilaya_id":"31"}, {"id":"1133","code_postal":"31024","nom":"Boutlelis","wilaya_id":"31"}, {"id":"1134","code_postal":"31025","nom":"Ain Kerma","wilaya_id":"31"}, {"id":"1135","code_postal":"31026","nom":"Ain Biya","wilaya_id":"31"}, {"id":"1136","code_postal":"32001","nom":"El Bayadh","wilaya_id":"32"}, {"id":"1137","code_postal":"32002","nom":"Rogassa","wilaya_id":"32"}, {"id":"1138","code_postal":"32003","nom":"Stitten","wilaya_id":"32"}, {"id":"1139","code_postal":"32004","nom":"Brezina","wilaya_id":"32"}, {"id":"1140","code_postal":"32005","nom":"Ghassoul","wilaya_id":"32"}, {"id":"1141","code_postal":"32006","nom":"Boualem","wilaya_id":"32"}, {"id":"1142","code_postal":"32007","nom":"El Abiodh Sidi Cheikh","wilaya_id":"32"}, {"id":"1143","code_postal":"32008","nom":"Ain El Orak","wilaya_id":"32"}, {"id":"1144","code_postal":"32009","nom":"Arbaouat","wilaya_id":"32"}, {"id":"1145","code_postal":"32010","nom":"Bougtoub","wilaya_id":"32"}, {"id":"1146","code_postal":"32011","nom":"El Kheither","wilaya_id":"32"}, {"id":"1147","code_postal":"32012","nom":"Kef El Ahmar","wilaya_id":"32"}, {"id":"1148","code_postal":"32013","nom":"Boussemghoun","wilaya_id":"32"}, {"id":"1149","code_postal":"32014","nom":"Chellala","wilaya_id":"32"}, {"id":"1150","code_postal":"32015","nom":"Krakda","wilaya_id":"32"}, {"id":"1151","code_postal":"32016","nom":"El Bnoud","wilaya_id":"32"}, {"id":"1152","code_postal":"32017","nom":"Cheguig","wilaya_id":"32"}, {"id":"1153","code_postal":"32018","nom":"Sidi Ameur","wilaya_id":"32"}, {"id":"1154","code_postal":"32019","nom":"El Mehara","wilaya_id":"32"}, {"id":"1155","code_postal":"32020","nom":"Tousmouline","wilaya_id":"32"}, {"id":"1156","code_postal":"32021","nom":"Sidi Slimane","wilaya_id":"32"}, {"id":"1157","code_postal":"32022","nom":"Sidi Tifour","wilaya_id":"32"}, {"id":"1158","code_postal":"33001","nom":"Illizi","wilaya_id":"33"}, {"id":"1159","code_postal":"33002","nom":"Djanet","wilaya_id":"33"}, {"id":"1160","code_postal":"33003","nom":"Debdeb","wilaya_id":"33"}, {"id":"1161","code_postal":"33004","nom":"Bordj Omar Driss","wilaya_id":"33"}, {"id":"1162","code_postal":"33005","nom":"Bordj El Haouasse","wilaya_id":"33"}, {"id":"1163","code_postal":"33006","nom":"In Amenas","wilaya_id":"33"}, {"id":"1164","code_postal":"34001","nom":"Bordj Bou Arreridj","wilaya_id":"34"}, {"id":"1165","code_postal":"34002","nom":"Ras El Oued","wilaya_id":"34"}, {"id":"1166","code_postal":"34003","nom":"Bordj Zemoura","wilaya_id":"34"}, {"id":"1167","code_postal":"34004","nom":"Mansoura","wilaya_id":"34"}, {"id":"1168","code_postal":"34005","nom":"El Mhir","wilaya_id":"34"}, {"id":"1169","code_postal":"34006","nom":"Ben Daoud","wilaya_id":"34"}, {"id":"1170","code_postal":"34007","nom":"El Achir","wilaya_id":"34"}, {"id":"1171","code_postal":"34008","nom":"Ain Taghrout","wilaya_id":"34"}, {"id":"1172","code_postal":"34009","nom":"Bordj Ghdir","wilaya_id":"34"}, {"id":"1173","code_postal":"34010","nom":"Sidi Embarek","wilaya_id":"34"}, {"id":"1174","code_postal":"34011","nom":"El Hamadia","wilaya_id":"34"}, {"id":"1175","code_postal":"34012","nom":"Belimour","wilaya_id":"34"}, {"id":"1176","code_postal":"34013","nom":"Medjana","wilaya_id":"34"}, {"id":"1177","code_postal":"34014","nom":"Teniet En Nasr","wilaya_id":"34"}, {"id":"1178","code_postal":"34015","nom":"Djaafra","wilaya_id":"34"}, {"id":"1179","code_postal":"34016","nom":"El Main","wilaya_id":"34"}, {"id":"1180","code_postal":"34017","nom":"Ouled Brahem","wilaya_id":"34"}, {"id":"1181","code_postal":"34018","nom":"Ouled Dahmane","wilaya_id":"34"}, {"id":"1182","code_postal":"34019","nom":"Hasnaoua","wilaya_id":"34"}, {"id":"1183","code_postal":"34020","nom":"Khelil","wilaya_id":"34"}, {"id":"1184","code_postal":"34021","nom":"Taglait","wilaya_id":"34"}, {"id":"1185","code_postal":"34022","nom":"Ksour","wilaya_id":"34"}, {"id":"1186","code_postal":"34023","nom":"Ouled Sidi Brahim","wilaya_id":"34"}, {"id":"1187","code_postal":"34024","nom":"Tafreg","wilaya_id":"34"}, {"id":"1188","code_postal":"34025","nom":"Colla","wilaya_id":"34"}, {"id":"1189","code_postal":"34026","nom":"Tixter","wilaya_id":"34"}, {"id":"1190","code_postal":"34027","nom":"El Ach","wilaya_id":"34"}, {"id":"1191","code_postal":"34028","nom":"El Anseur","wilaya_id":"34"}, {"id":"1192","code_postal":"34029","nom":"Tesmart","wilaya_id":"34"}, {"id":"1193","code_postal":"34030","nom":"Ain Tesra","wilaya_id":"34"}, {"id":"1194","code_postal":"34031","nom":"Bir Kasdali","wilaya_id":"34"}, {"id":"1195","code_postal":"34032","nom":"Ghilassa","wilaya_id":"34"}, {"id":"1196","code_postal":"34033","nom":"Rabta","wilaya_id":"34"}, {"id":"1197","code_postal":"34034","nom":"Haraza","wilaya_id":"34"}, {"id":"1198","code_postal":"35001","nom":"Boumerdes","wilaya_id":"35"}, {"id":"1199","code_postal":"35002","nom":"Boudouaou","wilaya_id":"35"}, {"id":"1200","code_postal":"35004","nom":"Afir","wilaya_id":"35"}, {"id":"1201","code_postal":"35005","nom":"Bordj Menaiel","wilaya_id":"35"}, {"id":"1202","code_postal":"35006","nom":"Baghlia","wilaya_id":"35"}, {"id":"1203","code_postal":"35007","nom":"Sidi Daoud","wilaya_id":"35"}, {"id":"1204","code_postal":"35008","nom":"Naciria","wilaya_id":"35"}, {"id":"1205","code_postal":"35009","nom":"Djinet","wilaya_id":"35"}, {"id":"1206","code_postal":"35010","nom":"Isser","wilaya_id":"35"}, {"id":"1207","code_postal":"35011","nom":"Zemmouri","wilaya_id":"35"}, {"id":"1208","code_postal":"35012","nom":"Si Mustapha","wilaya_id":"35"}, {"id":"1209","code_postal":"35013","nom":"Tidjelabine","wilaya_id":"35"}, {"id":"1210","code_postal":"35014","nom":"Chabet El Ameur","wilaya_id":"35"}, {"id":"1211","code_postal":"35015","nom":"Thenia","wilaya_id":"35"}, {"id":"1212","code_postal":"35018","nom":"Timezrit","wilaya_id":"35"}, {"id":"1213","code_postal":"35019","nom":"Corso","wilaya_id":"35"}, {"id":"1214","code_postal":"35020","nom":"Ouled Moussa","wilaya_id":"35"}, {"id":"1215","code_postal":"35021","nom":"Larbatache","wilaya_id":"35"}, {"id":"1216","code_postal":"35022","nom":"Bouzegza Keddara","wilaya_id":"35"}, {"id":"1217","code_postal":"35025","nom":"Taourga","wilaya_id":"35"}, {"id":"1218","code_postal":"35026","nom":"Ouled Aissa","wilaya_id":"35"}, {"id":"1219","code_postal":"35027","nom":"Ben Choud","wilaya_id":"35"}, {"id":"1220","code_postal":"35028","nom":"Dellys","wilaya_id":"35"}, {"id":"1221","code_postal":"35029","nom":"Ammal","wilaya_id":"35"}, {"id":"1222","code_postal":"35030","nom":"Beni Amrane","wilaya_id":"35"}, {"id":"1223","code_postal":"35031","nom":"Souk El Had","wilaya_id":"35"}, {"id":"1224","code_postal":"35032","nom":"Boudouaou El Bahri","wilaya_id":"35"}, {"id":"1225","code_postal":"35033","nom":"Ouled Hedadj","wilaya_id":"35"}, {"id":"1226","code_postal":"35035","nom":"Laghata","wilaya_id":"35"}, {"id":"1227","code_postal":"35036","nom":"Hammedi","wilaya_id":"35"}, {"id":"1228","code_postal":"35037","nom":"Khemis El Khechna","wilaya_id":"35"}, {"id":"1229","code_postal":"35038","nom":"El Kharrouba","wilaya_id":"35"}, {"id":"1230","code_postal":"36001","nom":"El Tarf","wilaya_id":"36"}, {"id":"1231","code_postal":"36002","nom":"Bouhadjar","wilaya_id":"36"}, {"id":"1232","code_postal":"36003","nom":"Ben Mhidi","wilaya_id":"36"}, {"id":"1233","code_postal":"36004","nom":"Bougous","wilaya_id":"36"}, {"id":"1234","code_postal":"36005","nom":"El Kala","wilaya_id":"36"}, {"id":"1235","code_postal":"36006","nom":"Ain El Assel","wilaya_id":"36"}, {"id":"1236","code_postal":"36007","nom":"El Aioun","wilaya_id":"36"}, {"id":"1237","code_postal":"36008","nom":"Bouteldja","wilaya_id":"36"}, {"id":"1238","code_postal":"36009","nom":"Souarekh","wilaya_id":"36"}, {"id":"1239","code_postal":"36010","nom":"Berrihane","wilaya_id":"36"}, {"id":"1240","code_postal":"36011","nom":"Lac Des Oiseaux","wilaya_id":"36"}, {"id":"1241","code_postal":"36012","nom":"Chefia","wilaya_id":"36"}, {"id":"1242","code_postal":"36013","nom":"Drean","wilaya_id":"36"}, {"id":"1243","code_postal":"36014","nom":"Chihani","wilaya_id":"36"}, {"id":"1244","code_postal":"36015","nom":"Chebaita Mokhtar","wilaya_id":"36"}, {"id":"1245","code_postal":"36016","nom":"Besbes","wilaya_id":"36"}, {"id":"1246","code_postal":"36017","nom":"Asfour","wilaya_id":"36"}, {"id":"1247","code_postal":"36018","nom":"Echatt","wilaya_id":"36"}, {"id":"1248","code_postal":"36019","nom":"Zerizer","wilaya_id":"36"}, {"id":"1249","code_postal":"36020","nom":"Zitouna","wilaya_id":"36"}, {"id":"1250","code_postal":"36021","nom":"Ain Kerma","wilaya_id":"36"}, {"id":"1251","code_postal":"36022","nom":"Oued Zitoun","wilaya_id":"36"}, {"id":"1252","code_postal":"36023","nom":"Hammam Beni Salah","wilaya_id":"36"}, {"id":"1253","code_postal":"36024","nom":"Raml Souk","wilaya_id":"36"}, {"id":"1254","code_postal":"37001","nom":"Tindouf","wilaya_id":"37"}, {"id":"1255","code_postal":"37002","nom":"Oum El Assel","wilaya_id":"37"}, {"id":"1256","code_postal":"38001","nom":"Tissemsilt","wilaya_id":"38"}, {"id":"1257","code_postal":"38002","nom":"Bordj Bou Naama","wilaya_id":"38"}, {"id":"1258","code_postal":"38003","nom":"Theniet El Had","wilaya_id":"38"}, {"id":"1259","code_postal":"38004","nom":"Lazharia","wilaya_id":"38"}, {"id":"1260","code_postal":"38005","nom":"Beni Chaib","wilaya_id":"38"}, {"id":"1261","code_postal":"38006","nom":"Lardjem","wilaya_id":"38"}, {"id":"1262","code_postal":"38007","nom":"Melaab","wilaya_id":"38"}, {"id":"1263","code_postal":"38008","nom":"Sidi Lantri","wilaya_id":"38"}, {"id":"1264","code_postal":"38009","nom":"Bordj El Emir Abdelkader","wilaya_id":"38"}, {"id":"1265","code_postal":"38010","nom":"Layoune","wilaya_id":"38"}, {"id":"1266","code_postal":"38011","nom":"Khemisti","wilaya_id":"38"}, {"id":"1267","code_postal":"38012","nom":"Ouled Bessem","wilaya_id":"38"}, {"id":"1268","code_postal":"38013","nom":"Ammari","wilaya_id":"38"}, {"id":"1269","code_postal":"38014","nom":"Youssoufia","wilaya_id":"38"}, {"id":"1270","code_postal":"38015","nom":"Sidi Boutouchent","wilaya_id":"38"}, {"id":"1271","code_postal":"38016","nom":"Larbaa","wilaya_id":"38"}, {"id":"1272","code_postal":"38017","nom":"Maasem","wilaya_id":"38"}, {"id":"1273","code_postal":"38018","nom":"Sidi Abed","wilaya_id":"38"}, {"id":"1274","code_postal":"38019","nom":"Tamalaht","wilaya_id":"38"}, {"id":"1275","code_postal":"38020","nom":"Sidi Slimane","wilaya_id":"38"}, {"id":"1276","code_postal":"38021","nom":"Boucaid","wilaya_id":"38"}, {"id":"1277","code_postal":"38022","nom":"Beni Lahcene","wilaya_id":"38"}, {"id":"1278","code_postal":"39001","nom":"El Oued","wilaya_id":"39"}, {"id":"1279","code_postal":"39002","nom":"Robbah","wilaya_id":"39"}, {"id":"1280","code_postal":"39003","nom":"Oued El Alenda","wilaya_id":"39"}, {"id":"1281","code_postal":"39004","nom":"Bayadha","wilaya_id":"39"}, {"id":"1282","code_postal":"39005","nom":"Nakhla","wilaya_id":"39"}, {"id":"1283","code_postal":"39006","nom":"Guemar","wilaya_id":"39"}, {"id":"1284","code_postal":"39007","nom":"Kouinine","wilaya_id":"39"}, {"id":"1285","code_postal":"39008","nom":"Reguiba","wilaya_id":"39"}, {"id":"1286","code_postal":"39009","nom":"Hamraia","wilaya_id":"39"}, {"id":"1287","code_postal":"39010","nom":"Taghzout","wilaya_id":"39"}, {"id":"1288","code_postal":"39011","nom":"Debila","wilaya_id":"39"}, {"id":"1289","code_postal":"39012","nom":"Hassani Abdelkrim","wilaya_id":"39"}, {"id":"1290","code_postal":"39013","nom":"Hassi Khelifa","wilaya_id":"39"}, {"id":"1291","code_postal":"39014","nom":"Taleb Larbi","wilaya_id":"39"}, {"id":"1292","code_postal":"39015","nom":"Douar El Ma","wilaya_id":"39"}, {"id":"1293","code_postal":"39016","nom":"Sidi Aoun","wilaya_id":"39"}, {"id":"1294","code_postal":"39017","nom":"Trifaoui","wilaya_id":"39"}, {"id":"1295","code_postal":"39018","nom":"Magrane","wilaya_id":"39"}, {"id":"1296","code_postal":"39019","nom":"Beni Guecha","wilaya_id":"39"}, {"id":"1297","code_postal":"39020","nom":"Ourmas","wilaya_id":"39"}, {"id":"1298","code_postal":"39021","nom":"Still","wilaya_id":"39"}, {"id":"1299","code_postal":"39022","nom":"Mrara","wilaya_id":"39"}, {"id":"1300","code_postal":"39023","nom":"Sidi Khellil","wilaya_id":"39"}, {"id":"1301","code_postal":"39024","nom":"Tendla","wilaya_id":"39"}, {"id":"1302","code_postal":"39025","nom":"El Ogla","wilaya_id":"39"}, {"id":"1303","code_postal":"39026","nom":"Mih Ouansa","wilaya_id":"39"}, {"id":"1304","code_postal":"39027","nom":"El Mghair","wilaya_id":"39"}, {"id":"1305","code_postal":"39028","nom":"Djamaa","wilaya_id":"39"}, {"id":"1306","code_postal":"39029","nom":"Oum Touyour","wilaya_id":"39"}, {"id":"1307","code_postal":"39030","nom":"Sidi Amrane","wilaya_id":"39"}, {"id":"1308","code_postal":"40001","nom":"Khenchela","wilaya_id":"40"}, {"id":"1309","code_postal":"40002","nom":"Mtoussa","wilaya_id":"40"}, {"id":"1310","code_postal":"40003","nom":"Kais","wilaya_id":"40"}, {"id":"1311","code_postal":"40004","nom":"Baghai","wilaya_id":"40"}, {"id":"1312","code_postal":"40005","nom":"El Hamma","wilaya_id":"40"}, {"id":"1313","code_postal":"40006","nom":"Ain Touila","wilaya_id":"40"}, {"id":"1314","code_postal":"40007","nom":"Taouzianat","wilaya_id":"40"}, {"id":"1315","code_postal":"40008","nom":"Bouhmama","wilaya_id":"40"}, {"id":"1316","code_postal":"40009","nom":"El Oueldja","wilaya_id":"40"}, {"id":"1317","code_postal":"40010","nom":"Remila","wilaya_id":"40"}, {"id":"1318","code_postal":"40011","nom":"Cherchar","wilaya_id":"40"}, {"id":"1319","code_postal":"40012","nom":"Djellal","wilaya_id":"40"}, {"id":"1320","code_postal":"40013","nom":"Babar","wilaya_id":"40"}, {"id":"1321","code_postal":"40014","nom":"Tamza","wilaya_id":"40"}, {"id":"1322","code_postal":"40015","nom":"Ensigha","wilaya_id":"40"}, {"id":"1323","code_postal":"40016","nom":"Ouled Rechache","wilaya_id":"40"}, {"id":"1324","code_postal":"40017","nom":"El Mahmal","wilaya_id":"40"}, {"id":"1325","code_postal":"40018","nom":"Msara","wilaya_id":"40"}, {"id":"1326","code_postal":"40019","nom":"Yabous","wilaya_id":"40"}, {"id":"1327","code_postal":"40020","nom":"Khirane","wilaya_id":"40"}, {"id":"1328","code_postal":"40021","nom":"Chelia","wilaya_id":"40"}, {"id":"1329","code_postal":"41001","nom":"Souk Ahras","wilaya_id":"41"}, {"id":"1330","code_postal":"41002","nom":"Sedrata","wilaya_id":"41"}, {"id":"1331","code_postal":"41003","nom":"Hanancha","wilaya_id":"41"}, {"id":"1332","code_postal":"41004","nom":"Mechroha","wilaya_id":"41"}, {"id":"1333","code_postal":"41005","nom":"Ouled Driss","wilaya_id":"41"}, {"id":"1334","code_postal":"41006","nom":"Tiffech","wilaya_id":"41"}, {"id":"1335","code_postal":"41007","nom":"Zaarouria","wilaya_id":"41"}, {"id":"1336","code_postal":"41008","nom":"Taoura","wilaya_id":"41"}, {"id":"1337","code_postal":"41009","nom":"Drea","wilaya_id":"41"}, {"id":"1338","code_postal":"41010","nom":"Haddada","wilaya_id":"41"}, {"id":"1339","code_postal":"41011","nom":"Khedara","wilaya_id":"41"}, {"id":"1340","code_postal":"41012","nom":"Merahna","wilaya_id":"41"}, {"id":"1341","code_postal":"41013","nom":"Ouled Moumen","wilaya_id":"41"}, {"id":"1342","code_postal":"41014","nom":"Bir Bouhouche","wilaya_id":"41"}, {"id":"1343","code_postal":"41015","nom":"Mdaourouche","wilaya_id":"41"}, {"id":"1344","code_postal":"41016","nom":"Oum El Adhaim","wilaya_id":"41"}, {"id":"1345","code_postal":"41017","nom":"Ain Zana","wilaya_id":"41"}, {"id":"1346","code_postal":"41018","nom":"Ain Soltane","wilaya_id":"41"}, {"id":"1347","code_postal":"41019","nom":"Quillen","wilaya_id":"41"}, {"id":"1348","code_postal":"41020","nom":"Sidi Fredj","wilaya_id":"41"}, {"id":"1349","code_postal":"41021","nom":"Safel El Ouiden","wilaya_id":"41"}, {"id":"1350","code_postal":"41022","nom":"Ragouba","wilaya_id":"41"}, {"id":"1351","code_postal":"41023","nom":"Khemissa","wilaya_id":"41"}, {"id":"1352","code_postal":"41024","nom":"Oued Keberit","wilaya_id":"41"}, {"id":"1353","code_postal":"41025","nom":"Terraguelt","wilaya_id":"41"}, {"id":"1354","code_postal":"41026","nom":"Zouabi","wilaya_id":"41"}, {"id":"1355","code_postal":"42001","nom":"Tipaza","wilaya_id":"42"}, {"id":"1356","code_postal":"42002","nom":"Menaceur","wilaya_id":"42"}, {"id":"1357","code_postal":"42003","nom":"Larhat","wilaya_id":"42"}, {"id":"1358","code_postal":"42004","nom":"Douaouda","wilaya_id":"42"}, {"id":"1359","code_postal":"42005","nom":"Bourkika","wilaya_id":"42"}, {"id":"1360","code_postal":"42006","nom":"Khemisti","wilaya_id":"42"}, {"id":"1361","code_postal":"42010","nom":"Aghabal","wilaya_id":"42"}, {"id":"1362","code_postal":"42012","nom":"Hadjout","wilaya_id":"42"}, {"id":"1363","code_postal":"42013","nom":"Sidi Amar","wilaya_id":"42"}, {"id":"1364","code_postal":"42014","nom":"Gouraya","wilaya_id":"42"}, {"id":"1365","code_postal":"42015","nom":"Nodor","wilaya_id":"42"}, {"id":"1366","code_postal":"42016","nom":"Chaiba","wilaya_id":"42"}, {"id":"1367","code_postal":"42017","nom":"Ain Tagourait","wilaya_id":"42"}, {"id":"1368","code_postal":"42022","nom":"Cherchel","wilaya_id":"42"}, {"id":"1369","code_postal":"42023","nom":"Damous","wilaya_id":"42"}, {"id":"1370","code_postal":"42024","nom":"Meurad","wilaya_id":"42"}, {"id":"1371","code_postal":"42025","nom":"Fouka","wilaya_id":"42"}, {"id":"1372","code_postal":"42026","nom":"Bou Ismail","wilaya_id":"42"}, {"id":"1373","code_postal":"42027","nom":"Ahmer El Ain","wilaya_id":"42"}, {"id":"1374","code_postal":"42030","nom":"Bou Haroun","wilaya_id":"42"}, {"id":"1375","code_postal":"42032","nom":"Sidi Ghiles","wilaya_id":"42"}, {"id":"1376","code_postal":"42033","nom":"Messelmoun","wilaya_id":"42"}, {"id":"1377","code_postal":"42034","nom":"Sidi Rached","wilaya_id":"42"}, {"id":"1378","code_postal":"42035","nom":"Kolea","wilaya_id":"42"}, {"id":"1379","code_postal":"42036","nom":"Attatba","wilaya_id":"42"}, {"id":"1380","code_postal":"42040","nom":"Sidi Semiane","wilaya_id":"42"}, {"id":"1381","code_postal":"42041","nom":"Beni Milleuk","wilaya_id":"42"}, {"id":"1382","code_postal":"42042","nom":"Hadjerat Ennous","wilaya_id":"42"}, {"id":"1383","code_postal":"43001","nom":"Mila","wilaya_id":"43"}, {"id":"1384","code_postal":"43002","nom":"Ferdjioua","wilaya_id":"43"}, {"id":"1385","code_postal":"43003","nom":"Chelghoum Laid","wilaya_id":"43"}, {"id":"1386","code_postal":"43004","nom":"Oued Athmenia","wilaya_id":"43"}, {"id":"1387","code_postal":"43005","nom":"Ain Mellouk","wilaya_id":"43"}, {"id":"1388","code_postal":"43006","nom":"Telerghma","wilaya_id":"43"}, {"id":"1389","code_postal":"43007","nom":"Oued Seguen","wilaya_id":"43"}, {"id":"1390","code_postal":"43008","nom":"Tadjenanet","wilaya_id":"43"}, {"id":"1391","code_postal":"43009","nom":"Benyahia Abderrahmane","wilaya_id":"43"}, {"id":"1392","code_postal":"43010","nom":"Oued Endja","wilaya_id":"43"}, {"id":"1393","code_postal":"43011","nom":"Ahmed Rachedi","wilaya_id":"43"}, {"id":"1394","code_postal":"43012","nom":"Ouled Khalouf","wilaya_id":"43"}, {"id":"1395","code_postal":"43013","nom":"Tiberguent","wilaya_id":"43"}, {"id":"1396","code_postal":"43014","nom":"Bouhatem","wilaya_id":"43"}, {"id":"1397","code_postal":"43015","nom":"Rouached","wilaya_id":"43"}, {"id":"1398","code_postal":"43016","nom":"Tessala Lamatai","wilaya_id":"43"}, {"id":"1399","code_postal":"43017","nom":"Grarem Gouga","wilaya_id":"43"}, {"id":"1400","code_postal":"43018","nom":"Sidi Merouane","wilaya_id":"43"}, {"id":"1401","code_postal":"43019","nom":"Tassadane Haddada","wilaya_id":"43"}, {"id":"1402","code_postal":"43020","nom":"Derradji Bousselah","wilaya_id":"43"}, {"id":"1403","code_postal":"43021","nom":"Minar Zarza","wilaya_id":"43"}, {"id":"1404","code_postal":"43022","nom":"Amira Arras","wilaya_id":"43"}, {"id":"1405","code_postal":"43023","nom":"Terrai Bainen","wilaya_id":"43"}, {"id":"1406","code_postal":"43024","nom":"Hamala","wilaya_id":"43"}, {"id":"1407","code_postal":"43025","nom":"Ain Tine","wilaya_id":"43"}, {"id":"1408","code_postal":"43026","nom":"El Mechira","wilaya_id":"43"}, {"id":"1409","code_postal":"43027","nom":"Sidi Khelifa","wilaya_id":"43"}, {"id":"1410","code_postal":"43028","nom":"Zeghaia","wilaya_id":"43"}, {"id":"1411","code_postal":"43029","nom":"Elayadi Barbes","wilaya_id":"43"}, {"id":"1412","code_postal":"43030","nom":"Ain Beida Harriche","wilaya_id":"43"}, {"id":"1413","code_postal":"43031","nom":"Yahia Beniguecha","wilaya_id":"43"}, {"id":"1414","code_postal":"43032","nom":"Chigara","wilaya_id":"43"}, {"id":"1415","code_postal":"44001","nom":"Ain Defla","wilaya_id":"44"}, {"id":"1416","code_postal":"44002","nom":"Miliana","wilaya_id":"44"}, {"id":"1417","code_postal":"44003","nom":"Boumedfaa","wilaya_id":"44"}, {"id":"1418","code_postal":"44004","nom":"Khemis Miliana","wilaya_id":"44"}, {"id":"1419","code_postal":"44005","nom":"Hammam Righa","wilaya_id":"44"}, {"id":"1420","code_postal":"44006","nom":"Arib","wilaya_id":"44"}, {"id":"1421","code_postal":"44007","nom":"Djelida","wilaya_id":"44"}, {"id":"1422","code_postal":"44008","nom":"El Amra","wilaya_id":"44"}, {"id":"1423","code_postal":"44009","nom":"Bourached","wilaya_id":"44"}, {"id":"1424","code_postal":"44010","nom":"El Attaf","wilaya_id":"44"}, {"id":"1425","code_postal":"44011","nom":"El Abadia","wilaya_id":"44"}, {"id":"1426","code_postal":"44012","nom":"Djendel","wilaya_id":"44"}, {"id":"1427","code_postal":"44013","nom":"Oued Chorfa","wilaya_id":"44"}, {"id":"1428","code_postal":"44014","nom":"Ain Lechiakh","wilaya_id":"44"}, {"id":"1429","code_postal":"44015","nom":"Oued Djemaa","wilaya_id":"44"}, {"id":"1430","code_postal":"44016","nom":"Rouina","wilaya_id":"44"}, {"id":"1431","code_postal":"44017","nom":"Zeddine","wilaya_id":"44"}, {"id":"1432","code_postal":"44018","nom":"El Hassania","wilaya_id":"44"}, {"id":"1433","code_postal":"44019","nom":"Bir Ouled Khelifa","wilaya_id":"44"}, {"id":"1434","code_postal":"44020","nom":"Ain Soltane","wilaya_id":"44"}, {"id":"1435","code_postal":"44021","nom":"Tarik Ibn Ziad","wilaya_id":"44"}, {"id":"1436","code_postal":"44022","nom":"Bordj Emir Khaled","wilaya_id":"44"}, {"id":"1437","code_postal":"44023","nom":"Ain Torki","wilaya_id":"44"}, {"id":"1438","code_postal":"44024","nom":"Sidi Lakhdar","wilaya_id":"44"}, {"id":"1439","code_postal":"44025","nom":"Ben Allal","wilaya_id":"44"}, {"id":"1440","code_postal":"44026","nom":"Ain Benian","wilaya_id":"44"}, {"id":"1441","code_postal":"44027","nom":"Hoceinia","wilaya_id":"44"}, {"id":"1442","code_postal":"44028","nom":"Barbouche","wilaya_id":"44"}, {"id":"1443","code_postal":"44029","nom":"Djemaa Ouled Chikh","wilaya_id":"44"}, {"id":"1444","code_postal":"44030","nom":"Mekhatria","wilaya_id":"44"}, {"id":"1445","code_postal":"44031","nom":"Bathia","wilaya_id":"44"}, {"id":"1446","code_postal":"44032","nom":"Tachta Zegagha","wilaya_id":"44"}, {"id":"1447","code_postal":"44033","nom":"Ain Bouyahia","wilaya_id":"44"}, {"id":"1448","code_postal":"44034","nom":"El Maine","wilaya_id":"44"}, {"id":"1449","code_postal":"44035","nom":"Tiberkanine","wilaya_id":"44"}, {"id":"1450","code_postal":"44036","nom":"Belaas","wilaya_id":"44"}, {"id":"1451","code_postal":"45001","nom":"Naama","wilaya_id":"45"}, {"id":"1452","code_postal":"45002","nom":"Mechria","wilaya_id":"45"}, {"id":"1453","code_postal":"45003","nom":"Ain Sefra","wilaya_id":"45"}, {"id":"1454","code_postal":"45004","nom":"Tiout","wilaya_id":"45"}, {"id":"1455","code_postal":"45005","nom":"Sfissifa","wilaya_id":"45"}, {"id":"1456","code_postal":"45006","nom":"Moghrar","wilaya_id":"45"}, {"id":"1457","code_postal":"45007","nom":"Assela","wilaya_id":"45"}, {"id":"1458","code_postal":"45008","nom":"Djeniane Bourzeg","wilaya_id":"45"}, {"id":"1459","code_postal":"45009","nom":"Ain Ben Khelil","wilaya_id":"45"}, {"id":"1460","code_postal":"45010","nom":"Makman Ben Amer","wilaya_id":"45"}, {"id":"1461","code_postal":"45011","nom":"Kasdir","wilaya_id":"45"}, {"id":"1462","code_postal":"45012","nom":"El Biod","wilaya_id":"45"}, {"id":"1463","code_postal":"46001","nom":"Ain Temouchent","wilaya_id":"46"}, {"id":"1464","code_postal":"46002","nom":"Chaabet El Ham","wilaya_id":"46"}, {"id":"1465","code_postal":"46003","nom":"Ain Kihal","wilaya_id":"46"}, {"id":"1466","code_postal":"46004","nom":"Hammam Bouhadjar","wilaya_id":"46"}, {"id":"1467","code_postal":"46005","nom":"Bou Zedjar","wilaya_id":"46"}, {"id":"1468","code_postal":"46006","nom":"Oued Berkeche","wilaya_id":"46"}, {"id":"1469","code_postal":"46007","nom":"Aghlal","wilaya_id":"46"}, {"id":"1470","code_postal":"46008","nom":"Terga","wilaya_id":"46"}, {"id":"1471","code_postal":"46009","nom":"Ain El Arbaa","wilaya_id":"46"}, {"id":"1472","code_postal":"46010","nom":"Tamzoura","wilaya_id":"46"}, {"id":"1473","code_postal":"46011","nom":"Chentouf","wilaya_id":"46"}, {"id":"1474","code_postal":"46012","nom":"Sidi Ben Adda","wilaya_id":"46"}, {"id":"1475","code_postal":"46013","nom":"Aoubellil","wilaya_id":"46"}, {"id":"1476","code_postal":"46014","nom":"El Malah","wilaya_id":"46"}, {"id":"1477","code_postal":"46015","nom":"Sidi Boumediene","wilaya_id":"46"}, {"id":"1478","code_postal":"46016","nom":"Oued Sabah","wilaya_id":"46"}, {"id":"1479","code_postal":"46017","nom":"Ouled Boudjemaa","wilaya_id":"46"}, {"id":"1480","code_postal":"46018","nom":"Ain Tolba","wilaya_id":"46"}, {"id":"1481","code_postal":"46019","nom":"El Amria","wilaya_id":"46"}, {"id":"1482","code_postal":"46020","nom":"Hassi El Ghella","wilaya_id":"46"}, {"id":"1483","code_postal":"46021","nom":"Hassasna","wilaya_id":"46"}, {"id":"1484","code_postal":"46022","nom":"Ouled Kihal","wilaya_id":"46"}, {"id":"1485","code_postal":"46023","nom":"Beni Saf","wilaya_id":"46"}, {"id":"1486","code_postal":"46024","nom":"Sidi Safi","wilaya_id":"46"}, {"id":"1487","code_postal":"46025","nom":"Oulhaca El Gheraba","wilaya_id":"46"}, {"id":"1488","code_postal":"46026","nom":"Tadmaya","wilaya_id":"46"}, {"id":"1489","code_postal":"46027","nom":"El Emir Abdelkader","wilaya_id":"46"}, {"id":"1490","code_postal":"46028","nom":"El Messaid","wilaya_id":"46"}, {"id":"1491","code_postal":"47001","nom":"Ghardaia","wilaya_id":"47"}, {"id":"1492","code_postal":"47002","nom":"El Meniaa","wilaya_id":"47"}, {"id":"1493","code_postal":"47003","nom":"Dhayet Bendhahoua","wilaya_id":"47"}, {"id":"1494","code_postal":"47004","nom":"Berriane","wilaya_id":"47"}, {"id":"1495","code_postal":"47005","nom":"Metlili","wilaya_id":"47"}, {"id":"1496","code_postal":"47006","nom":"El Guerrara","wilaya_id":"47"}, {"id":"1497","code_postal":"47007","nom":"El Atteuf","wilaya_id":"47"}, {"id":"1498","code_postal":"47008","nom":"Zelfana","wilaya_id":"47"}, {"id":"1499","code_postal":"47009","nom":"Sebseb","wilaya_id":"47"}, {"id":"1500","code_postal":"47010","nom":"Bounoura","wilaya_id":"47"}, {"id":"1501","code_postal":"47011","nom":"Hassi Fehal","wilaya_id":"47"}, {"id":"1502","code_postal":"47012","nom":"Hassi Gara","wilaya_id":"47"}, {"id":"1503","code_postal":"47013","nom":"Mansoura","wilaya_id":"47"}, {"id":"1504","code_postal":"48001","nom":"Relizane","wilaya_id":"48"}, {"id":"1505","code_postal":"48002","nom":"Oued Rhiou","wilaya_id":"48"}, {"id":"1506","code_postal":"48003","nom":"Belaassel Bouzegza","wilaya_id":"48"}, {"id":"1507","code_postal":"48004","nom":"Sidi Saada","wilaya_id":"48"}, {"id":"1508","code_postal":"48005","nom":"Ouled Aiche","wilaya_id":"48"}, {"id":"1509","code_postal":"48006","nom":"Sidi Lazreg","wilaya_id":"48"}, {"id":"1510","code_postal":"48007","nom":"El Hamadna","wilaya_id":"48"}, {"id":"1511","code_postal":"48008","nom":"Sidi Mhamed Ben Ali","wilaya_id":"48"}, {"id":"1512","code_postal":"48009","nom":"Mediouna","wilaya_id":"48"}, {"id":"1513","code_postal":"48010","nom":"Sidi Khettab","wilaya_id":"48"}, {"id":"1514","code_postal":"48011","nom":"Ammi Moussa","wilaya_id":"48"}, {"id":"1515","code_postal":"48012","nom":"Zemmoura","wilaya_id":"48"}, {"id":"1516","code_postal":"48013","nom":"Beni Dergoun","wilaya_id":"48"}, {"id":"1517","code_postal":"48014","nom":"Djidiouia","wilaya_id":"48"}, {"id":"1518","code_postal":"48015","nom":"El Guettar","wilaya_id":"48"}, {"id":"1519","code_postal":"48016","nom":"Hamri","wilaya_id":"48"}, {"id":"1520","code_postal":"48017","nom":"El Matmar","wilaya_id":"48"}, {"id":"1521","code_postal":"48018","nom":"Sidi Mhamed Ben Aouda","wilaya_id":"48"}, {"id":"1522","code_postal":"48019","nom":"Ain Tarek","wilaya_id":"48"}, {"id":"1523","code_postal":"48020","nom":"Oued Essalem","wilaya_id":"48"}, {"id":"1524","code_postal":"48021","nom":"Ouarizane","wilaya_id":"48"}, {"id":"1525","code_postal":"48022","nom":"Mazouna","wilaya_id":"48"}, {"id":"1526","code_postal":"48023","nom":"Kalaa","wilaya_id":"48"}, {"id":"1527","code_postal":"48024","nom":"Ain Rahma","wilaya_id":"48"}, {"id":"1528","code_postal":"48025","nom":"Yellel","wilaya_id":"48"}, {"id":"1529","code_postal":"48026","nom":"Oued El Djemaa","wilaya_id":"48"}, {"id":"1530","code_postal":"48027","nom":"Ramka","wilaya_id":"48"}, {"id":"1531","code_postal":"48028","nom":"Mendes","wilaya_id":"48"}, {"id":"1532","code_postal":"48029","nom":"Lahlef","wilaya_id":"48"}, {"id":"1533","code_postal":"48030","nom":"Beni Zentis","wilaya_id":"48"}, {"id":"1534","code_postal":"48031","nom":"Souk El Haad","wilaya_id":"48"}, {"id":"1535","code_postal":"48032","nom":"Dar Ben Abdellah","wilaya_id":"48"}, {"id":"1536","code_postal":"48033","nom":"El Hassi","wilaya_id":"48"}, {"id":"1537","code_postal":"48034","nom":"Had Echkalla","wilaya_id":"48"}, {"id":"1538","code_postal":"48035","nom":"Bendaoud","wilaya_id":"48"}, {"id":"1539","code_postal":"48036","nom":"El Ouldja","wilaya_id":"48"}, {"id":"1540","code_postal":"48037","nom":"Merdja Sidi Abed","wilaya_id":"48"}, {"id":"1541","code_postal":"48038","nom":"Ouled Sidi Mihoub","wilaya_id":"48"}]
+[
+    {
+      "id": "1",
+      "code_postal": "01001",
+      "nom": "Adrar",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "2",
+      "code_postal": "01002",
+      "nom": "Tamest",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "3",
+      "code_postal": "01003",
+      "nom": "Charouine",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "4",
+      "code_postal": "01004",
+      "nom": "Reggane",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "5",
+      "code_postal": "01005",
+      "nom": "Inozghmir",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "6",
+      "code_postal": "01006",
+      "nom": "Tit",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "7",
+      "code_postal": "01007",
+      "nom": "Ksar Kaddour",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "8",
+      "code_postal": "01008",
+      "nom": "Tsabit",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "9",
+      "code_postal": "01009",
+      "nom": "Timimoun",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "10",
+      "code_postal": "01010",
+      "nom": "Ouled Said",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "11",
+      "code_postal": "01011",
+      "nom": "Zaouiet Kounta",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "12",
+      "code_postal": "01012",
+      "nom": "Aoulef",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "13",
+      "code_postal": "01013",
+      "nom": "Timokten",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "14",
+      "code_postal": "01014",
+      "nom": "Tamentit",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "15",
+      "code_postal": "01015",
+      "nom": "Fenoughil",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "16",
+      "code_postal": "01016",
+      "nom": "Tinerkouk",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "17",
+      "code_postal": "01017",
+      "nom": "Deldoul",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "18",
+      "code_postal": "01018",
+      "nom": "Sali",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "19",
+      "code_postal": "01019",
+      "nom": "Akabli",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "20",
+      "code_postal": "01020",
+      "nom": "Metarfa",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "21",
+      "code_postal": "01021",
+      "nom": "O Ahmed Timmi",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "22",
+      "code_postal": "01022",
+      "nom": "Bouda",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "23",
+      "code_postal": "01023",
+      "nom": "Aougrout",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "24",
+      "code_postal": "01024",
+      "nom": "Talmine",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "25",
+      "code_postal": "01025",
+      "nom": "B Badji Mokhtar",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "26",
+      "code_postal": "01026",
+      "nom": "Sbaa",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "27",
+      "code_postal": "01027",
+      "nom": "Ouled Aissa",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "28",
+      "code_postal": "01028",
+      "nom": "Timiaouine",
+      "wilaya_id": "1"
+    },
+    {
+      "id": "29",
+      "code_postal": "02001",
+      "nom": "Chlef",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "30",
+      "code_postal": "02002",
+      "nom": "Tenes",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "31",
+      "code_postal": "02003",
+      "nom": "Benairia",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "32",
+      "code_postal": "02004",
+      "nom": "El Karimia",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "33",
+      "code_postal": "02005",
+      "nom": "Tadjna",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "34",
+      "code_postal": "02006",
+      "nom": "Taougrite",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "35",
+      "code_postal": "02007",
+      "nom": "Beni Haoua",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "36",
+      "code_postal": "02008",
+      "nom": "Sobha",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "37",
+      "code_postal": "02009",
+      "nom": "Harchoun",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "38",
+      "code_postal": "02010",
+      "nom": "Ouled Fares",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "39",
+      "code_postal": "02011",
+      "nom": "Sidi Akacha",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "40",
+      "code_postal": "02012",
+      "nom": "Boukadir",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "41",
+      "code_postal": "02013",
+      "nom": "Beni Rached",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "42",
+      "code_postal": "02014",
+      "nom": "Talassa",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "43",
+      "code_postal": "02015",
+      "nom": "Herenfa",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "44",
+      "code_postal": "02016",
+      "nom": "Oued Goussine",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "45",
+      "code_postal": "02017",
+      "nom": "Dahra",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "46",
+      "code_postal": "02018",
+      "nom": "Ouled Abbes",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "47",
+      "code_postal": "02019",
+      "nom": "Sendjas",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "48",
+      "code_postal": "02020",
+      "nom": "Zeboudja",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "49",
+      "code_postal": "02021",
+      "nom": "Oued Sly",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "50",
+      "code_postal": "02022",
+      "nom": "Abou El Hassen",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "51",
+      "code_postal": "02023",
+      "nom": "El Marsa",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "52",
+      "code_postal": "02024",
+      "nom": "Chettia",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "53",
+      "code_postal": "02025",
+      "nom": "Sidi Abderrahmane",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "54",
+      "code_postal": "02026",
+      "nom": "Moussadek",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "55",
+      "code_postal": "02027",
+      "nom": "El Hadjadj",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "56",
+      "code_postal": "02028",
+      "nom": "Labiod Medjadja",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "57",
+      "code_postal": "02029",
+      "nom": "Oued Fodda",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "58",
+      "code_postal": "02030",
+      "nom": "Ouled Ben Abdelkader",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "59",
+      "code_postal": "02031",
+      "nom": "Bouzghaia",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "60",
+      "code_postal": "02032",
+      "nom": "Ain Merane",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "61",
+      "code_postal": "02033",
+      "nom": "Oum Drou",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "62",
+      "code_postal": "02034",
+      "nom": "Breira",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "63",
+      "code_postal": "02035",
+      "nom": "Ben Boutaleb",
+      "wilaya_id": "2"
+    },
+    {
+      "id": "64",
+      "code_postal": "03001",
+      "nom": "Laghouat",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "65",
+      "code_postal": "03002",
+      "nom": "Ksar El Hirane",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "66",
+      "code_postal": "03003",
+      "nom": "Benacer Ben Chohra",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "67",
+      "code_postal": "03004",
+      "nom": "Sidi Makhlouf",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "68",
+      "code_postal": "03005",
+      "nom": "Hassi Delaa",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "69",
+      "code_postal": "03006",
+      "nom": "Hassi R Mel",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "70",
+      "code_postal": "03007",
+      "nom": "Ain Mahdi",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "71",
+      "code_postal": "03008",
+      "nom": "Tadjmout",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "72",
+      "code_postal": "03009",
+      "nom": "Kheneg",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "73",
+      "code_postal": "03010",
+      "nom": "Gueltat Sidi Saad",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "74",
+      "code_postal": "03011",
+      "nom": "Ain Sidi Ali",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "75",
+      "code_postal": "03012",
+      "nom": "Beidha",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "76",
+      "code_postal": "03013",
+      "nom": "Brida",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "77",
+      "code_postal": "03014",
+      "nom": "El Ghicha",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "78",
+      "code_postal": "03015",
+      "nom": "Hadj Mechri",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "79",
+      "code_postal": "03016",
+      "nom": "Sebgag",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "80",
+      "code_postal": "03017",
+      "nom": "Taouiala",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "81",
+      "code_postal": "03018",
+      "nom": "Tadjrouna",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "82",
+      "code_postal": "03019",
+      "nom": "Aflou",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "83",
+      "code_postal": "03020",
+      "nom": "El Assafia",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "84",
+      "code_postal": "03021",
+      "nom": "Oued Morra",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "85",
+      "code_postal": "03022",
+      "nom": "Oued M Zi",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "86",
+      "code_postal": "03023",
+      "nom": "El Haouaita",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "87",
+      "code_postal": "03024",
+      "nom": "Sidi Bouzid",
+      "wilaya_id": "3"
+    },
+    {
+      "id": "88",
+      "code_postal": "04001",
+      "nom": "Oum El Bouaghi",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "89",
+      "code_postal": "04002",
+      "nom": "Ain Beida",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "90",
+      "code_postal": "04003",
+      "nom": "Ainmlila",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "91",
+      "code_postal": "04004",
+      "nom": "Behir Chergui",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "92",
+      "code_postal": "04005",
+      "nom": "El Amiria",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "93",
+      "code_postal": "04006",
+      "nom": "Sigus",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "94",
+      "code_postal": "04007",
+      "nom": "El Belala",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "95",
+      "code_postal": "04008",
+      "nom": "Ain Babouche",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "96",
+      "code_postal": "04009",
+      "nom": "Berriche",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "97",
+      "code_postal": "04010",
+      "nom": "Ouled Hamla",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "98",
+      "code_postal": "04011",
+      "nom": "Dhala",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "99",
+      "code_postal": "04012",
+      "nom": "Ain Kercha",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "100",
+      "code_postal": "04013",
+      "nom": "Hanchir Toumghani",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "101",
+      "code_postal": "04014",
+      "nom": "El Djazia",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "102",
+      "code_postal": "04015",
+      "nom": "Ain Diss",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "103",
+      "code_postal": "04016",
+      "nom": "Fkirina",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "104",
+      "code_postal": "04017",
+      "nom": "Souk Naamane",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "105",
+      "code_postal": "04018",
+      "nom": "Zorg",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "106",
+      "code_postal": "04019",
+      "nom": "El Fedjoudj Boughrar",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "107",
+      "code_postal": "04020",
+      "nom": "Ouled Zouai",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "108",
+      "code_postal": "04021",
+      "nom": "Bir Chouhada",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "109",
+      "code_postal": "04022",
+      "nom": "Ksar Sbahi",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "110",
+      "code_postal": "04023",
+      "nom": "Oued Nini",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "111",
+      "code_postal": "04024",
+      "nom": "Meskiana",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "112",
+      "code_postal": "04025",
+      "nom": "Ain Fekroune",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "113",
+      "code_postal": "04026",
+      "nom": "Rahia",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "114",
+      "code_postal": "04027",
+      "nom": "Ain Zitoun",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "115",
+      "code_postal": "04028",
+      "nom": "Ouled Gacem",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "116",
+      "code_postal": "04029",
+      "nom": "El Harmilia",
+      "wilaya_id": "4"
+    },
+    {
+      "id": "117",
+      "code_postal": "05001",
+      "nom": "Batna",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "118",
+      "code_postal": "05002",
+      "nom": "Ghassira",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "119",
+      "code_postal": "05003",
+      "nom": "Maafa",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "120",
+      "code_postal": "05004",
+      "nom": "Merouana",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "121",
+      "code_postal": "05005",
+      "nom": "Seriana",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "122",
+      "code_postal": "05006",
+      "nom": "Menaa",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "123",
+      "code_postal": "05007",
+      "nom": "El Madher",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "124",
+      "code_postal": "05008",
+      "nom": "Tazoult",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "125",
+      "code_postal": "05009",
+      "nom": "Ngaous",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "126",
+      "code_postal": "05010",
+      "nom": "Guigba",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "127",
+      "code_postal": "05011",
+      "nom": "Inoughissen",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "128",
+      "code_postal": "05012",
+      "nom": "Ouyoun El Assafir",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "129",
+      "code_postal": "05013",
+      "nom": "Djerma",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "130",
+      "code_postal": "05014",
+      "nom": "Bitam",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "131",
+      "code_postal": "05015",
+      "nom": "Metkaouak",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "132",
+      "code_postal": "05016",
+      "nom": "Arris",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "133",
+      "code_postal": "05017",
+      "nom": "Kimmel",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "134",
+      "code_postal": "05018",
+      "nom": "Tilatou",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "135",
+      "code_postal": "05019",
+      "nom": "Ain Djasser",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "136",
+      "code_postal": "05020",
+      "nom": "Ouled Selam",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "137",
+      "code_postal": "05021",
+      "nom": "Tigherghar",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "138",
+      "code_postal": "05022",
+      "nom": "Ain Yagout",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "139",
+      "code_postal": "05023",
+      "nom": "Fesdis",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "140",
+      "code_postal": "05024",
+      "nom": "Sefiane",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "141",
+      "code_postal": "05025",
+      "nom": "Rahbat",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "142",
+      "code_postal": "05026",
+      "nom": "Tighanimine",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "143",
+      "code_postal": "05027",
+      "nom": "Lemsane",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "144",
+      "code_postal": "05028",
+      "nom": "Ksar Belezma",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "145",
+      "code_postal": "05029",
+      "nom": "Seggana",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "146",
+      "code_postal": "05030",
+      "nom": "Ichmoul",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "147",
+      "code_postal": "05031",
+      "nom": "Foum Toub",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "148",
+      "code_postal": "05032",
+      "nom": "Beni Foudhala El Hakania",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "149",
+      "code_postal": "05033",
+      "nom": "Oued El Ma",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "150",
+      "code_postal": "05034",
+      "nom": "Talkhamt",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "151",
+      "code_postal": "05035",
+      "nom": "Bouzina",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "152",
+      "code_postal": "05036",
+      "nom": "Chemora",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "153",
+      "code_postal": "05037",
+      "nom": "Oued Chaaba",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "154",
+      "code_postal": "05038",
+      "nom": "Taxlent",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "155",
+      "code_postal": "05039",
+      "nom": "Gosbat",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "156",
+      "code_postal": "05040",
+      "nom": "Ouled Aouf",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "157",
+      "code_postal": "05041",
+      "nom": "Boumagueur",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "158",
+      "code_postal": "05042",
+      "nom": "Barika",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "159",
+      "code_postal": "05043",
+      "nom": "Djezzar",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "160",
+      "code_postal": "05044",
+      "nom": "Tkout",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "161",
+      "code_postal": "05045",
+      "nom": "Ain Touta",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "162",
+      "code_postal": "05046",
+      "nom": "Hidoussa",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "163",
+      "code_postal": "05047",
+      "nom": "Teniet El Abed",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "164",
+      "code_postal": "05048",
+      "nom": "Oued Taga",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "165",
+      "code_postal": "05049",
+      "nom": "Ouled Fadel",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "166",
+      "code_postal": "05050",
+      "nom": "Timgad",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "167",
+      "code_postal": "05051",
+      "nom": "Ras El Aioun",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "168",
+      "code_postal": "05052",
+      "nom": "Chir",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "169",
+      "code_postal": "05053",
+      "nom": "Ouled Si Slimane",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "170",
+      "code_postal": "05054",
+      "nom": "Zanat El Beida",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "171",
+      "code_postal": "05055",
+      "nom": "Amdoukal",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "172",
+      "code_postal": "05056",
+      "nom": "Ouled Ammar",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "173",
+      "code_postal": "05057",
+      "nom": "El Hassi",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "174",
+      "code_postal": "05058",
+      "nom": "Lazrou",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "175",
+      "code_postal": "05059",
+      "nom": "Boumia",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "176",
+      "code_postal": "05060",
+      "nom": "Boulhilat",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "177",
+      "code_postal": "05061",
+      "nom": "Larbaa",
+      "wilaya_id": "5"
+    },
+    {
+      "id": "178",
+      "code_postal": "06001",
+      "nom": "Bejaia",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "179",
+      "code_postal": "06002",
+      "nom": "Amizour",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "180",
+      "code_postal": "06003",
+      "nom": "Ferraoun",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "181",
+      "code_postal": "06004",
+      "nom": "Taourirt Ighil",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "182",
+      "code_postal": "06005",
+      "nom": "Chelata",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "183",
+      "code_postal": "06006",
+      "nom": "Tamokra",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "184",
+      "code_postal": "06007",
+      "nom": "Timzrit",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "185",
+      "code_postal": "06008",
+      "nom": "Souk El Thenine",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "186",
+      "code_postal": "06009",
+      "nom": "Mcisna",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "187",
+      "code_postal": "06010",
+      "nom": "Thinabdher",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "188",
+      "code_postal": "06011",
+      "nom": "Tichi",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "189",
+      "code_postal": "06012",
+      "nom": "Semaoun",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "190",
+      "code_postal": "06013",
+      "nom": "Kendira",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "191",
+      "code_postal": "06014",
+      "nom": "Tifra",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "192",
+      "code_postal": "06015",
+      "nom": "Ighram",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "193",
+      "code_postal": "06016",
+      "nom": "Amalou",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "194",
+      "code_postal": "06017",
+      "nom": "Ighil Ali",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "195",
+      "code_postal": "06018",
+      "nom": "Ifelain Ilmathen",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "196",
+      "code_postal": "06019",
+      "nom": "Toudja",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "197",
+      "code_postal": "06020",
+      "nom": "Darguina",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "198",
+      "code_postal": "06021",
+      "nom": "Sidi Ayad",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "199",
+      "code_postal": "06022",
+      "nom": "Aokas",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "200",
+      "code_postal": "06023",
+      "nom": "Beni Djellil",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "201",
+      "code_postal": "06024",
+      "nom": "Adekar",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "202",
+      "code_postal": "06025",
+      "nom": "Akbou",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "203",
+      "code_postal": "06026",
+      "nom": "Seddouk",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "204",
+      "code_postal": "06027",
+      "nom": "Tazmalt",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "205",
+      "code_postal": "06028",
+      "nom": "Ait Rizine",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "206",
+      "code_postal": "06029",
+      "nom": "Chemini",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "207",
+      "code_postal": "06030",
+      "nom": "Souk Oufella",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "208",
+      "code_postal": "06031",
+      "nom": "Taskriout",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "209",
+      "code_postal": "06032",
+      "nom": "Tibane",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "210",
+      "code_postal": "06033",
+      "nom": "Tala Hamza",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "211",
+      "code_postal": "06034",
+      "nom": "Barbacha",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "212",
+      "code_postal": "06035",
+      "nom": "Beni Ksila",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "213",
+      "code_postal": "06036",
+      "nom": "Ouzallaguen",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "214",
+      "code_postal": "06037",
+      "nom": "Bouhamza",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "215",
+      "code_postal": "06038",
+      "nom": "Beni Melikeche",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "216",
+      "code_postal": "06039",
+      "nom": "Sidi Aich",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "217",
+      "code_postal": "06040",
+      "nom": "El Kseur",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "218",
+      "code_postal": "06041",
+      "nom": "Melbou",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "219",
+      "code_postal": "06042",
+      "nom": "Akfadou",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "220",
+      "code_postal": "06043",
+      "nom": "Leflaye",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "221",
+      "code_postal": "06044",
+      "nom": "Kherrata",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "222",
+      "code_postal": "06045",
+      "nom": "Draa Kaid",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "223",
+      "code_postal": "06046",
+      "nom": "Tamridjet",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "224",
+      "code_postal": "06047",
+      "nom": "Ait Smail",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "225",
+      "code_postal": "06048",
+      "nom": "Boukhelifa",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "226",
+      "code_postal": "06049",
+      "nom": "Tizi Nberber",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "227",
+      "code_postal": "06050",
+      "nom": "Beni Maouch",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "228",
+      "code_postal": "06051",
+      "nom": "Oued Ghir",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "229",
+      "code_postal": "06052",
+      "nom": "Boudjellil",
+      "wilaya_id": "6"
+    },
+    {
+      "id": "230",
+      "code_postal": "07001",
+      "nom": "Biskra",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "231",
+      "code_postal": "07002",
+      "nom": "Oumache",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "232",
+      "code_postal": "07003",
+      "nom": "Branis",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "233",
+      "code_postal": "07004",
+      "nom": "Chetma",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "234",
+      "code_postal": "07005",
+      "nom": "Ouled Djellal",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "235",
+      "code_postal": "07006",
+      "nom": "Ras El Miaad",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "236",
+      "code_postal": "07007",
+      "nom": "Besbes",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "237",
+      "code_postal": "07008",
+      "nom": "Sidi Khaled",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "238",
+      "code_postal": "07009",
+      "nom": "Doucen",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "239",
+      "code_postal": "07010",
+      "nom": "Ech Chaiba",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "240",
+      "code_postal": "07011",
+      "nom": "Sidi Okba",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "241",
+      "code_postal": "07012",
+      "nom": "Mchouneche",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "242",
+      "code_postal": "07013",
+      "nom": "El Haouch",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "243",
+      "code_postal": "07014",
+      "nom": "Ain Naga",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "244",
+      "code_postal": "07015",
+      "nom": "Zeribet El Oued",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "245",
+      "code_postal": "07016",
+      "nom": "El Feidh",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "246",
+      "code_postal": "07017",
+      "nom": "El Kantara",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "247",
+      "code_postal": "07018",
+      "nom": "Ain Zaatout",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "248",
+      "code_postal": "07019",
+      "nom": "El Outaya",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "249",
+      "code_postal": "07020",
+      "nom": "Djemorah",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "250",
+      "code_postal": "07021",
+      "nom": "Tolga",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "251",
+      "code_postal": "07022",
+      "nom": "Lioua",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "252",
+      "code_postal": "07023",
+      "nom": "Lichana",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "253",
+      "code_postal": "07024",
+      "nom": "Ourlal",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "254",
+      "code_postal": "07025",
+      "nom": "Mlili",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "255",
+      "code_postal": "07026",
+      "nom": "Foughala",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "256",
+      "code_postal": "07027",
+      "nom": "Bordj Ben Azzouz",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "257",
+      "code_postal": "07028",
+      "nom": "Meziraa",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "258",
+      "code_postal": "07029",
+      "nom": "Bouchagroun",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "259",
+      "code_postal": "07030",
+      "nom": "Mekhadma",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "260",
+      "code_postal": "07031",
+      "nom": "El Ghrous",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "261",
+      "code_postal": "07032",
+      "nom": "El Hadjab",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "262",
+      "code_postal": "07033",
+      "nom": "Khanguet Sidinadji",
+      "wilaya_id": "7"
+    },
+    {
+      "id": "263",
+      "code_postal": "08001",
+      "nom": "Bechar",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "264",
+      "code_postal": "08002",
+      "nom": "Erg Ferradj",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "265",
+      "code_postal": "08003",
+      "nom": "Ouled Khoudir",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "266",
+      "code_postal": "08004",
+      "nom": "Meridja",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "267",
+      "code_postal": "08005",
+      "nom": "Timoudi",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "268",
+      "code_postal": "08006",
+      "nom": "Lahmar",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "269",
+      "code_postal": "08007",
+      "nom": "Beni Abbes",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "270",
+      "code_postal": "08008",
+      "nom": "Beni Ikhlef",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "271",
+      "code_postal": "08009",
+      "nom": "Mechraa Houari B",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "272",
+      "code_postal": "08010",
+      "nom": "Kenedsa",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "273",
+      "code_postal": "08011",
+      "nom": "Igli",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "274",
+      "code_postal": "08012",
+      "nom": "Tabalbala",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "275",
+      "code_postal": "08013",
+      "nom": "Taghit",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "276",
+      "code_postal": "08014",
+      "nom": "El Ouata",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "277",
+      "code_postal": "08015",
+      "nom": "Boukais",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "278",
+      "code_postal": "08016",
+      "nom": "Mogheul",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "279",
+      "code_postal": "08017",
+      "nom": "Abadla",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "280",
+      "code_postal": "08018",
+      "nom": "Kerzaz",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "281",
+      "code_postal": "08019",
+      "nom": "Ksabi",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "282",
+      "code_postal": "08020",
+      "nom": "Tamtert",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "283",
+      "code_postal": "08021",
+      "nom": "Beni Ounif",
+      "wilaya_id": "8"
+    },
+    {
+      "id": "284",
+      "code_postal": "09001",
+      "nom": "Blida",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "285",
+      "code_postal": "09002",
+      "nom": "Chebli",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "286",
+      "code_postal": "09003",
+      "nom": "Bouinan",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "287",
+      "code_postal": "09004",
+      "nom": "Oued El Alleug",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "288",
+      "code_postal": "09007",
+      "nom": "Ouled Yaich",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "289",
+      "code_postal": "09008",
+      "nom": "Chrea",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "290",
+      "code_postal": "09010",
+      "nom": "El Affroun",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "291",
+      "code_postal": "09011",
+      "nom": "Chiffa",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "292",
+      "code_postal": "09012",
+      "nom": "Hammam Melouane",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "293",
+      "code_postal": "09013",
+      "nom": "Ben Khlil",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "294",
+      "code_postal": "09014",
+      "nom": "Soumaa",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "295",
+      "code_postal": "09016",
+      "nom": "Mouzaia",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "296",
+      "code_postal": "09017",
+      "nom": "Souhane",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "297",
+      "code_postal": "09018",
+      "nom": "Meftah",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "298",
+      "code_postal": "09019",
+      "nom": "Ouled Selama",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "299",
+      "code_postal": "09020",
+      "nom": "Boufarik",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "300",
+      "code_postal": "09021",
+      "nom": "Larbaa",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "301",
+      "code_postal": "09022",
+      "nom": "Oued Djer",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "302",
+      "code_postal": "09023",
+      "nom": "Beni Tamou",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "303",
+      "code_postal": "09024",
+      "nom": "Bouarfa",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "304",
+      "code_postal": "09025",
+      "nom": "Beni Mered",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "305",
+      "code_postal": "09026",
+      "nom": "Bougara",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "306",
+      "code_postal": "09027",
+      "nom": "Guerrouaou",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "307",
+      "code_postal": "09028",
+      "nom": "Ain Romana",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "308",
+      "code_postal": "09029",
+      "nom": "Djebabra",
+      "wilaya_id": "9"
+    },
+    {
+      "id": "309",
+      "code_postal": "10001",
+      "nom": "Bouira",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "310",
+      "code_postal": "10002",
+      "nom": "El Asnam",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "311",
+      "code_postal": "10003",
+      "nom": "Guerrouma",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "312",
+      "code_postal": "10004",
+      "nom": "Souk El Khemis",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "313",
+      "code_postal": "10005",
+      "nom": "Kadiria",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "314",
+      "code_postal": "10006",
+      "nom": "Hanif",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "315",
+      "code_postal": "10007",
+      "nom": "Dirah",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "316",
+      "code_postal": "10008",
+      "nom": "Ait Laaziz",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "317",
+      "code_postal": "10009",
+      "nom": "Taghzout",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "318",
+      "code_postal": "10010",
+      "nom": "Raouraoua",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "319",
+      "code_postal": "10011",
+      "nom": "Mezdour",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "320",
+      "code_postal": "10012",
+      "nom": "Haizer",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "321",
+      "code_postal": "10013",
+      "nom": "Lakhdaria",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "322",
+      "code_postal": "10014",
+      "nom": "Maala",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "323",
+      "code_postal": "10015",
+      "nom": "El Hachimia",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "324",
+      "code_postal": "10016",
+      "nom": "Aomar",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "325",
+      "code_postal": "10017",
+      "nom": "Chorfa",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "326",
+      "code_postal": "10018",
+      "nom": "Bordj Oukhriss",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "327",
+      "code_postal": "10019",
+      "nom": "El Adjiba",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "328",
+      "code_postal": "10020",
+      "nom": "El Hakimia",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "329",
+      "code_postal": "10021",
+      "nom": "El Khebouzia",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "330",
+      "code_postal": "10022",
+      "nom": "Ahl El Ksar",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "331",
+      "code_postal": "10023",
+      "nom": "Bouderbala",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "332",
+      "code_postal": "10024",
+      "nom": "Zbarbar",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "333",
+      "code_postal": "10025",
+      "nom": "Ain El Hadjar",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "334",
+      "code_postal": "10026",
+      "nom": "Djebahia",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "335",
+      "code_postal": "10027",
+      "nom": "Aghbalou",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "336",
+      "code_postal": "10028",
+      "nom": "Taguedit",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "337",
+      "code_postal": "10029",
+      "nom": "Ain Turk",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "338",
+      "code_postal": "10030",
+      "nom": "Saharidj",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "339",
+      "code_postal": "10031",
+      "nom": "Dechmia",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "340",
+      "code_postal": "10032",
+      "nom": "Ridane",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "341",
+      "code_postal": "10033",
+      "nom": "Bechloul",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "342",
+      "code_postal": "10034",
+      "nom": "Boukram",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "343",
+      "code_postal": "10035",
+      "nom": "Ain Bessam",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "344",
+      "code_postal": "10036",
+      "nom": "Bir Ghbalou",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "345",
+      "code_postal": "10037",
+      "nom": "Mchedallah",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "346",
+      "code_postal": "10038",
+      "nom": "Sour El Ghozlane",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "347",
+      "code_postal": "10039",
+      "nom": "Maamora",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "348",
+      "code_postal": "10040",
+      "nom": "Ouled Rached",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "349",
+      "code_postal": "10041",
+      "nom": "Ain Laloui",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "350",
+      "code_postal": "10042",
+      "nom": "Hadjera Zerga",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "351",
+      "code_postal": "10043",
+      "nom": "Ath Mansour",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "352",
+      "code_postal": "10044",
+      "nom": "El Mokrani",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "353",
+      "code_postal": "10045",
+      "nom": "Oued El Berdi",
+      "wilaya_id": "10"
+    },
+    {
+      "id": "354",
+      "code_postal": "11001",
+      "nom": "Tamanghasset",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "355",
+      "code_postal": "11002",
+      "nom": "Abalessa",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "356",
+      "code_postal": "11003",
+      "nom": "In Ghar",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "357",
+      "code_postal": "11004",
+      "nom": "In Guezzam",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "358",
+      "code_postal": "11005",
+      "nom": "Idles",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "359",
+      "code_postal": "11006",
+      "nom": "Tazouk",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "360",
+      "code_postal": "11007",
+      "nom": "Tinzaouatine",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "361",
+      "code_postal": "11008",
+      "nom": "In Salah",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "362",
+      "code_postal": "11009",
+      "nom": "In Amguel",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "363",
+      "code_postal": "11010",
+      "nom": "Foggaret Ezzaouia",
+      "wilaya_id": "11"
+    },
+    {
+      "id": "364",
+      "code_postal": "12001",
+      "nom": "Tebessa",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "365",
+      "code_postal": "12002",
+      "nom": "Bir El Ater",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "366",
+      "code_postal": "12003",
+      "nom": "Cheria",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "367",
+      "code_postal": "12004",
+      "nom": "Stah Guentis",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "368",
+      "code_postal": "12005",
+      "nom": "El Aouinet",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "369",
+      "code_postal": "12006",
+      "nom": "Lahouidjbet",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "370",
+      "code_postal": "12007",
+      "nom": "Safsaf El Ouesra",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "371",
+      "code_postal": "12008",
+      "nom": "Hammamet",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "372",
+      "code_postal": "12009",
+      "nom": "Negrine",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "373",
+      "code_postal": "12010",
+      "nom": "Bir El Mokadem",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "374",
+      "code_postal": "12011",
+      "nom": "El Kouif",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "375",
+      "code_postal": "12012",
+      "nom": "Morsott",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "376",
+      "code_postal": "12013",
+      "nom": "El Ogla",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "377",
+      "code_postal": "12014",
+      "nom": "Bir Dheheb",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "378",
+      "code_postal": "12015",
+      "nom": "El Ogla El Malha",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "379",
+      "code_postal": "12016",
+      "nom": "Gorriguer",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "380",
+      "code_postal": "12017",
+      "nom": "Bekkaria",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "381",
+      "code_postal": "12018",
+      "nom": "Boukhadra",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "382",
+      "code_postal": "12019",
+      "nom": "Ouenza",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "383",
+      "code_postal": "12020",
+      "nom": "El Ma El Biodh",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "384",
+      "code_postal": "12021",
+      "nom": "Oum Ali",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "385",
+      "code_postal": "12022",
+      "nom": "Thlidjene",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "386",
+      "code_postal": "12023",
+      "nom": "Ain Zerga",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "387",
+      "code_postal": "12024",
+      "nom": "El Meridj",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "388",
+      "code_postal": "12025",
+      "nom": "Boulhaf Dyr",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "389",
+      "code_postal": "12026",
+      "nom": "Bedjene",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "390",
+      "code_postal": "12027",
+      "nom": "El Mazeraa",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "391",
+      "code_postal": "12028",
+      "nom": "Ferkane",
+      "wilaya_id": "12"
+    },
+    {
+      "id": "392",
+      "code_postal": "13001",
+      "nom": "Tlemcen",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "393",
+      "code_postal": "13002",
+      "nom": "Beni Mester",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "394",
+      "code_postal": "13003",
+      "nom": "Ain Tallout",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "395",
+      "code_postal": "13004",
+      "nom": "Remchi",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "396",
+      "code_postal": "13005",
+      "nom": "El Fehoul",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "397",
+      "code_postal": "13006",
+      "nom": "Sabra",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "398",
+      "code_postal": "13007",
+      "nom": "Ghazaouet",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "399",
+      "code_postal": "13008",
+      "nom": "Souani",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "400",
+      "code_postal": "13009",
+      "nom": "Djebala",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "401",
+      "code_postal": "13010",
+      "nom": "El Gor",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "402",
+      "code_postal": "13011",
+      "nom": "Oued Chouly",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "403",
+      "code_postal": "13012",
+      "nom": "Ain Fezza",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "404",
+      "code_postal": "13013",
+      "nom": "Ouled Mimoun",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "405",
+      "code_postal": "13014",
+      "nom": "Amieur",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "406",
+      "code_postal": "13015",
+      "nom": "Ain Youcef",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "407",
+      "code_postal": "13016",
+      "nom": "Zenata",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "408",
+      "code_postal": "13017",
+      "nom": "Beni Snous",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "409",
+      "code_postal": "13018",
+      "nom": "Bab El Assa",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "410",
+      "code_postal": "13019",
+      "nom": "Dar Yaghmouracene",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "411",
+      "code_postal": "13020",
+      "nom": "Fellaoucene",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "412",
+      "code_postal": "13021",
+      "nom": "Azails",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "413",
+      "code_postal": "13022",
+      "nom": "Sebbaa Chioukh",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "414",
+      "code_postal": "13023",
+      "nom": "Terni Beni Hediel",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "415",
+      "code_postal": "13024",
+      "nom": "Bensekrane",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "416",
+      "code_postal": "13025",
+      "nom": "Ain Nehala",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "417",
+      "code_postal": "13026",
+      "nom": "Hennaya",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "418",
+      "code_postal": "13027",
+      "nom": "Maghnia",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "419",
+      "code_postal": "13028",
+      "nom": "Hammam Boughrara",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "420",
+      "code_postal": "13029",
+      "nom": "Souahlia",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "421",
+      "code_postal": "13030",
+      "nom": "Msirda Fouaga",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "422",
+      "code_postal": "13031",
+      "nom": "Ain Fetah",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "423",
+      "code_postal": "13032",
+      "nom": "El Aricha",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "424",
+      "code_postal": "13033",
+      "nom": "Souk Thlata",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "425",
+      "code_postal": "13034",
+      "nom": "Sidi Abdelli",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "426",
+      "code_postal": "13035",
+      "nom": "Sebdou",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "427",
+      "code_postal": "13036",
+      "nom": "Beni Ouarsous",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "428",
+      "code_postal": "13037",
+      "nom": "Sidi Medjahed",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "429",
+      "code_postal": "13038",
+      "nom": "Beni Boussaid",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "430",
+      "code_postal": "13039",
+      "nom": "Marsa Ben Mhidi",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "431",
+      "code_postal": "13040",
+      "nom": "Nedroma",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "432",
+      "code_postal": "13041",
+      "nom": "Sidi Djillali",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "433",
+      "code_postal": "13042",
+      "nom": "Beni Bahdel",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "434",
+      "code_postal": "13043",
+      "nom": "El Bouihi",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "435",
+      "code_postal": "13044",
+      "nom": "Honaine",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "436",
+      "code_postal": "13045",
+      "nom": "Tianet",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "437",
+      "code_postal": "13046",
+      "nom": "Ouled Riyah",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "438",
+      "code_postal": "13047",
+      "nom": "Bouhlou",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "439",
+      "code_postal": "13048",
+      "nom": "Souk El Khemis",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "440",
+      "code_postal": "13049",
+      "nom": "Ain Ghoraba",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "441",
+      "code_postal": "13050",
+      "nom": "Chetouane",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "442",
+      "code_postal": "13051",
+      "nom": "Mansourah",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "443",
+      "code_postal": "13052",
+      "nom": "Beni Semiel",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "444",
+      "code_postal": "13053",
+      "nom": "Ain Kebira",
+      "wilaya_id": "13"
+    },
+    {
+      "id": "445",
+      "code_postal": "14001",
+      "nom": "Tiaret",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "446",
+      "code_postal": "14002",
+      "nom": "Medroussa",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "447",
+      "code_postal": "14003",
+      "nom": "Ain Bouchekif",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "448",
+      "code_postal": "14004",
+      "nom": "Sidi Ali Mellal",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "449",
+      "code_postal": "14005",
+      "nom": "Ain Zarit",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "450",
+      "code_postal": "14006",
+      "nom": "Ain Deheb",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "451",
+      "code_postal": "14007",
+      "nom": "Sidi Bakhti",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "452",
+      "code_postal": "14008",
+      "nom": "Medrissa",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "453",
+      "code_postal": "14009",
+      "nom": "Zmalet El Emir Aek",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "454",
+      "code_postal": "14010",
+      "nom": "Madna",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "455",
+      "code_postal": "14011",
+      "nom": "Sebt",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "456",
+      "code_postal": "14012",
+      "nom": "Mellakou",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "457",
+      "code_postal": "14013",
+      "nom": "Dahmouni",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "458",
+      "code_postal": "14014",
+      "nom": "Rahouia",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "459",
+      "code_postal": "14015",
+      "nom": "Mahdia",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "460",
+      "code_postal": "14016",
+      "nom": "Sougueur",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "461",
+      "code_postal": "14017",
+      "nom": "Sidi Abdelghani",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "462",
+      "code_postal": "14018",
+      "nom": "Ain El Hadid",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "463",
+      "code_postal": "14019",
+      "nom": "Ouled Djerad",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "464",
+      "code_postal": "14020",
+      "nom": "Naima",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "465",
+      "code_postal": "14021",
+      "nom": "Meghila",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "466",
+      "code_postal": "14022",
+      "nom": "Guertoufa",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "467",
+      "code_postal": "14023",
+      "nom": "Sidi Hosni",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "468",
+      "code_postal": "14024",
+      "nom": "Djillali Ben Amar",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "469",
+      "code_postal": "14025",
+      "nom": "Sebaine",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "470",
+      "code_postal": "14026",
+      "nom": "Tousnina",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "471",
+      "code_postal": "14027",
+      "nom": "Frenda",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "472",
+      "code_postal": "14028",
+      "nom": "Ain Kermes",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "473",
+      "code_postal": "14029",
+      "nom": "Ksar Chellala",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "474",
+      "code_postal": "14030",
+      "nom": "Rechaiga",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "475",
+      "code_postal": "14031",
+      "nom": "Nadorah",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "476",
+      "code_postal": "14032",
+      "nom": "Tagdemt",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "477",
+      "code_postal": "14033",
+      "nom": "Oued Lilli",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "478",
+      "code_postal": "14034",
+      "nom": "Mechraa Safa",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "479",
+      "code_postal": "14035",
+      "nom": "Hamadia",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "480",
+      "code_postal": "14036",
+      "nom": "Chehaima",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "481",
+      "code_postal": "14037",
+      "nom": "Takhemaret",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "482",
+      "code_postal": "14038",
+      "nom": "Sidi Abderrahmane",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "483",
+      "code_postal": "14039",
+      "nom": "Serghine",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "484",
+      "code_postal": "14040",
+      "nom": "Bougara",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "485",
+      "code_postal": "14041",
+      "nom": "Faidja",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "486",
+      "code_postal": "14042",
+      "nom": "Tidda",
+      "wilaya_id": "14"
+    },
+    {
+      "id": "487",
+      "code_postal": "15001",
+      "nom": "Tizi Ouzou",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "488",
+      "code_postal": "15002",
+      "nom": "Ain El Hammam",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "489",
+      "code_postal": "15003",
+      "nom": "Akbil",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "490",
+      "code_postal": "15004",
+      "nom": "Freha",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "491",
+      "code_postal": "15005",
+      "nom": "Souamaa",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "492",
+      "code_postal": "15006",
+      "nom": "Mechtrass",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "493",
+      "code_postal": "15007",
+      "nom": "Irdjen",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "494",
+      "code_postal": "15008",
+      "nom": "Timizart",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "495",
+      "code_postal": "15009",
+      "nom": "Makouda",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "496",
+      "code_postal": "15010",
+      "nom": "Draa El Mizan",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "497",
+      "code_postal": "15011",
+      "nom": "Tizi Ghenif",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "498",
+      "code_postal": "15012",
+      "nom": "Bounouh",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "499",
+      "code_postal": "15013",
+      "nom": "Ait Chaffaa",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "500",
+      "code_postal": "15014",
+      "nom": "Frikat",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "501",
+      "code_postal": "15015",
+      "nom": "Beni Aissi",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "502",
+      "code_postal": "15016",
+      "nom": "Beni Zmenzer",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "503",
+      "code_postal": "15017",
+      "nom": "Iferhounene",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "504",
+      "code_postal": "15018",
+      "nom": "Azazga",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "505",
+      "code_postal": "15019",
+      "nom": "Iloula Oumalou",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "506",
+      "code_postal": "15020",
+      "nom": "Yakouren",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "507",
+      "code_postal": "15021",
+      "nom": "Larba Nait Irathen",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "508",
+      "code_postal": "15022",
+      "nom": "Tizi Rached",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "509",
+      "code_postal": "15023",
+      "nom": "Zekri",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "510",
+      "code_postal": "15024",
+      "nom": "Ouaguenoun",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "511",
+      "code_postal": "15025",
+      "nom": "Ain Zaouia",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "512",
+      "code_postal": "15026",
+      "nom": "Mkira",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "513",
+      "code_postal": "15027",
+      "nom": "Ait Yahia",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "514",
+      "code_postal": "15028",
+      "nom": "Ait Mahmoud",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "515",
+      "code_postal": "15029",
+      "nom": "Maatka",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "516",
+      "code_postal": "15030",
+      "nom": "Ait Boumehdi",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "517",
+      "code_postal": "15031",
+      "nom": "Abi Youcef",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "518",
+      "code_postal": "15032",
+      "nom": "Beni Douala",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "519",
+      "code_postal": "15033",
+      "nom": "Illilten",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "520",
+      "code_postal": "15034",
+      "nom": "Bouzguen",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "521",
+      "code_postal": "15035",
+      "nom": "Ait Aggouacha",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "522",
+      "code_postal": "15036",
+      "nom": "Ouadhia",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "523",
+      "code_postal": "15037",
+      "nom": "Azzefoun",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "524",
+      "code_postal": "15038",
+      "nom": "Tigzirt",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "525",
+      "code_postal": "15039",
+      "nom": "Ait Aissa Mimoun",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "526",
+      "code_postal": "15040",
+      "nom": "Boghni",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "527",
+      "code_postal": "15041",
+      "nom": "Ifigha",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "528",
+      "code_postal": "15042",
+      "nom": "Ait Oumalou",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "529",
+      "code_postal": "15043",
+      "nom": "Tirmitine",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "530",
+      "code_postal": "15044",
+      "nom": "Akerrou",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "531",
+      "code_postal": "15045",
+      "nom": "Yatafen",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "532",
+      "code_postal": "15046",
+      "nom": "Beni Ziki",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "533",
+      "code_postal": "15047",
+      "nom": "Draa Ben Khedda",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "534",
+      "code_postal": "15048",
+      "nom": "Ouacif",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "535",
+      "code_postal": "15049",
+      "nom": "Idjeur",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "536",
+      "code_postal": "15050",
+      "nom": "Mekla",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "537",
+      "code_postal": "15051",
+      "nom": "Tizi Nthlata",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "538",
+      "code_postal": "15052",
+      "nom": "Beni Yenni",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "539",
+      "code_postal": "15053",
+      "nom": "Aghrib",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "540",
+      "code_postal": "15054",
+      "nom": "Iflissen",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "541",
+      "code_postal": "15055",
+      "nom": "Boudjima",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "542",
+      "code_postal": "15056",
+      "nom": "Ait Yahia Moussa",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "543",
+      "code_postal": "15057",
+      "nom": "Souk El Thenine",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "544",
+      "code_postal": "15058",
+      "nom": "Ait Khelil",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "545",
+      "code_postal": "15059",
+      "nom": "Sidi Naamane",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "546",
+      "code_postal": "15060",
+      "nom": "Iboudraren",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "547",
+      "code_postal": "15061",
+      "nom": "Aghni Goughran",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "548",
+      "code_postal": "15062",
+      "nom": "Mizrana",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "549",
+      "code_postal": "15063",
+      "nom": "Imsouhal",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "550",
+      "code_postal": "15064",
+      "nom": "Tadmait",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "551",
+      "code_postal": "15065",
+      "nom": "Ait Bouadou",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "552",
+      "code_postal": "15066",
+      "nom": "Assi Youcef",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "553",
+      "code_postal": "15067",
+      "nom": "Ait Toudert",
+      "wilaya_id": "15"
+    },
+    {
+      "id": "554",
+      "code_postal": "16001",
+      "nom": "Alger Centre",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "555",
+      "code_postal": "16002",
+      "nom": "Sidi Mhamed",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "556",
+      "code_postal": "16003",
+      "nom": "El Madania",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "557",
+      "code_postal": "16004",
+      "nom": "Hamma Anassers",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "558",
+      "code_postal": "16005",
+      "nom": "Bab El Oued",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "559",
+      "code_postal": "16006",
+      "nom": "Bologhine Ibn Ziri",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "560",
+      "code_postal": "16007",
+      "nom": "Casbah",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "561",
+      "code_postal": "16008",
+      "nom": "Oued Koriche",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "562",
+      "code_postal": "16009",
+      "nom": "Bir Mourad Rais",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "563",
+      "code_postal": "16010",
+      "nom": "El Biar",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "564",
+      "code_postal": "16011",
+      "nom": "Bouzareah",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "565",
+      "code_postal": "16012",
+      "nom": "Birkhadem",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "566",
+      "code_postal": "16013",
+      "nom": "El Harrach",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "567",
+      "code_postal": "16014",
+      "nom": "Baraki",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "568",
+      "code_postal": "16015",
+      "nom": "Oued Smar",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "569",
+      "code_postal": "16016",
+      "nom": "Bourouba",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "570",
+      "code_postal": "16017",
+      "nom": "Hussein Dey",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "571",
+      "code_postal": "16018",
+      "nom": "Kouba",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "572",
+      "code_postal": "16019",
+      "nom": "Bachedjerah",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "573",
+      "code_postal": "16020",
+      "nom": "Dar El Beida",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "574",
+      "code_postal": "16021",
+      "nom": "Bab Azzouar",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "575",
+      "code_postal": "16022",
+      "nom": "Ben Aknoun",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "576",
+      "code_postal": "16023",
+      "nom": "Dely Ibrahim",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "577",
+      "code_postal": "16024",
+      "nom": "Bains Romains",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "578",
+      "code_postal": "16025",
+      "nom": "Rais Hamidou",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "579",
+      "code_postal": "16026",
+      "nom": "Djasr Kasentina",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "580",
+      "code_postal": "16027",
+      "nom": "El Mouradia",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "581",
+      "code_postal": "16028",
+      "nom": "Hydra",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "582",
+      "code_postal": "16029",
+      "nom": "Mohammadia",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "583",
+      "code_postal": "16030",
+      "nom": "Bordj El Kiffan",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "584",
+      "code_postal": "16031",
+      "nom": "El Magharia",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "585",
+      "code_postal": "16032",
+      "nom": "Beni Messous",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "586",
+      "code_postal": "16033",
+      "nom": "Les Eucalyptus",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "587",
+      "code_postal": "16034",
+      "nom": "Birtouta",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "588",
+      "code_postal": "16035",
+      "nom": "Tassala El Merdja",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "589",
+      "code_postal": "16036",
+      "nom": "Ouled Chebel",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "590",
+      "code_postal": "16037",
+      "nom": "Sidi Moussa",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "591",
+      "code_postal": "16038",
+      "nom": "Ain Taya",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "592",
+      "code_postal": "16039",
+      "nom": "Bordj El Bahri",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "593",
+      "code_postal": "16040",
+      "nom": "Marsa",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "594",
+      "code_postal": "16041",
+      "nom": "Haraoua",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "595",
+      "code_postal": "16042",
+      "nom": "Rouiba",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "596",
+      "code_postal": "16043",
+      "nom": "Reghaia",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "597",
+      "code_postal": "16044",
+      "nom": "Ain Benian",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "598",
+      "code_postal": "16045",
+      "nom": "Staoueli",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "599",
+      "code_postal": "16046",
+      "nom": "Zeralda",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "600",
+      "code_postal": "16047",
+      "nom": "Mahelma",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "601",
+      "code_postal": "16048",
+      "nom": "Rahmania",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "602",
+      "code_postal": "16049",
+      "nom": "Souidania",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "603",
+      "code_postal": "16050",
+      "nom": "Cheraga",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "604",
+      "code_postal": "16051",
+      "nom": "Ouled Fayet",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "605",
+      "code_postal": "16052",
+      "nom": "El Achour",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "606",
+      "code_postal": "16053",
+      "nom": "Draria",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "607",
+      "code_postal": "16054",
+      "nom": "Douera",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "608",
+      "code_postal": "16055",
+      "nom": "Baba Hassen",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "609",
+      "code_postal": "16056",
+      "nom": "Khracia",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "610",
+      "code_postal": "16057",
+      "nom": "Saoula",
+      "wilaya_id": "16"
+    },
+    {
+      "id": "611",
+      "code_postal": "17001",
+      "nom": "Djelfa",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "612",
+      "code_postal": "17002",
+      "nom": "Moudjebara",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "613",
+      "code_postal": "17003",
+      "nom": "El Guedid",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "614",
+      "code_postal": "17004",
+      "nom": "Hassi Bahbah",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "615",
+      "code_postal": "17005",
+      "nom": "Ain Maabed",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "616",
+      "code_postal": "17006",
+      "nom": "Sed Rahal",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "617",
+      "code_postal": "17007",
+      "nom": "Feidh El Botma",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "618",
+      "code_postal": "17008",
+      "nom": "Birine",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "619",
+      "code_postal": "17009",
+      "nom": "Bouira Lahdeb",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "620",
+      "code_postal": "17010",
+      "nom": "Zaccar",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "621",
+      "code_postal": "17011",
+      "nom": "El Khemis",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "622",
+      "code_postal": "17012",
+      "nom": "Sidi Baizid",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "623",
+      "code_postal": "17013",
+      "nom": "Mliliha",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "624",
+      "code_postal": "17014",
+      "nom": "El Idrissia",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "625",
+      "code_postal": "17015",
+      "nom": "Douis",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "626",
+      "code_postal": "17016",
+      "nom": "Hassi El Euch",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "627",
+      "code_postal": "17017",
+      "nom": "Messaad",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "628",
+      "code_postal": "17018",
+      "nom": "Guettara",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "629",
+      "code_postal": "17019",
+      "nom": "Sidi Ladjel",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "630",
+      "code_postal": "17020",
+      "nom": "Had Sahary",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "631",
+      "code_postal": "17021",
+      "nom": "Guernini",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "632",
+      "code_postal": "17022",
+      "nom": "Selmana",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "633",
+      "code_postal": "17023",
+      "nom": "Ain Chouhada",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "634",
+      "code_postal": "17024",
+      "nom": "Oum Laadham",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "635",
+      "code_postal": "17025",
+      "nom": "Dar Chouikh",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "636",
+      "code_postal": "17026",
+      "nom": "Charef",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "637",
+      "code_postal": "17027",
+      "nom": "Beni Yacoub",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "638",
+      "code_postal": "17028",
+      "nom": "Zaafrane",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "639",
+      "code_postal": "17029",
+      "nom": "Deldoul",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "640",
+      "code_postal": "17030",
+      "nom": "Ain El Ibel",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "641",
+      "code_postal": "17031",
+      "nom": "Ain Oussera",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "642",
+      "code_postal": "17032",
+      "nom": "Benhar",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "643",
+      "code_postal": "17033",
+      "nom": "Hassi Fedoul",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "644",
+      "code_postal": "17034",
+      "nom": "Amourah",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "645",
+      "code_postal": "17035",
+      "nom": "Ain Fekka",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "646",
+      "code_postal": "17036",
+      "nom": "Tadmit",
+      "wilaya_id": "17"
+    },
+    {
+      "id": "647",
+      "code_postal": "18001",
+      "nom": "Jijel",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "648",
+      "code_postal": "18002",
+      "nom": "Erraguene",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "649",
+      "code_postal": "18003",
+      "nom": "El Aouana",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "650",
+      "code_postal": "18004",
+      "nom": "Ziamma Mansouriah",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "651",
+      "code_postal": "18005",
+      "nom": "Taher",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "652",
+      "code_postal": "18006",
+      "nom": "Emir Abdelkader",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "653",
+      "code_postal": "18007",
+      "nom": "Chekfa",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "654",
+      "code_postal": "18008",
+      "nom": "Chahna",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "655",
+      "code_postal": "18009",
+      "nom": "El Milia",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "656",
+      "code_postal": "18010",
+      "nom": "Sidi Maarouf",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "657",
+      "code_postal": "18011",
+      "nom": "Settara",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "658",
+      "code_postal": "18012",
+      "nom": "El Ancer",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "659",
+      "code_postal": "18013",
+      "nom": "Sidi Abdelaziz",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "660",
+      "code_postal": "18014",
+      "nom": "Kaous",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "661",
+      "code_postal": "18015",
+      "nom": "Ghebala",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "662",
+      "code_postal": "18016",
+      "nom": "Bouraoui Belhadef",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "663",
+      "code_postal": "18017",
+      "nom": "Djmila",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "664",
+      "code_postal": "18018",
+      "nom": "Selma Benziada",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "665",
+      "code_postal": "18019",
+      "nom": "Boussif Ouled Askeur",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "666",
+      "code_postal": "18020",
+      "nom": "El Kennar Nouchfi",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "667",
+      "code_postal": "18021",
+      "nom": "Ouled Yahia Khadrouch",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "668",
+      "code_postal": "18022",
+      "nom": "Boudria Beni Yadjis",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "669",
+      "code_postal": "18023",
+      "nom": "Kemir Oued Adjoul",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "670",
+      "code_postal": "18024",
+      "nom": "Texena",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "671",
+      "code_postal": "18025",
+      "nom": "Djemaa Beni Habibi",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "672",
+      "code_postal": "18026",
+      "nom": "Bordj Taher",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "673",
+      "code_postal": "18027",
+      "nom": "Ouled Rabah",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "674",
+      "code_postal": "18028",
+      "nom": "Ouadjana",
+      "wilaya_id": "18"
+    },
+    {
+      "id": "675",
+      "code_postal": "19001",
+      "nom": "Setif",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "676",
+      "code_postal": "19002",
+      "nom": "Ain El Kebira",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "677",
+      "code_postal": "19003",
+      "nom": "Beni Aziz",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "678",
+      "code_postal": "19004",
+      "nom": "Ouled Sidi Ahmed",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "679",
+      "code_postal": "19005",
+      "nom": "Boutaleb",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "680",
+      "code_postal": "19006",
+      "nom": "Ain Roua",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "681",
+      "code_postal": "19007",
+      "nom": "Draa Kebila",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "682",
+      "code_postal": "19008",
+      "nom": "Bir El Arch",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "683",
+      "code_postal": "19009",
+      "nom": "Beni Chebana",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "684",
+      "code_postal": "19010",
+      "nom": "Ouled Tebben",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "685",
+      "code_postal": "19011",
+      "nom": "Hamma",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "686",
+      "code_postal": "19012",
+      "nom": "Maaouia",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "687",
+      "code_postal": "19013",
+      "nom": "Ain Legraj",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "688",
+      "code_postal": "19014",
+      "nom": "Ain Abessa",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "689",
+      "code_postal": "19015",
+      "nom": "Dehamcha",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "690",
+      "code_postal": "19016",
+      "nom": "Babor",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "691",
+      "code_postal": "19017",
+      "nom": "Guidjel",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "692",
+      "code_postal": "19018",
+      "nom": "Ain Lahdjar",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "693",
+      "code_postal": "19019",
+      "nom": "Bousselam",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "694",
+      "code_postal": "19020",
+      "nom": "El Eulma",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "695",
+      "code_postal": "19021",
+      "nom": "Djemila",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "696",
+      "code_postal": "19022",
+      "nom": "Beni Ouartilane",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "697",
+      "code_postal": "19023",
+      "nom": "Rosfa",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "698",
+      "code_postal": "19024",
+      "nom": "Ouled Addouane",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "699",
+      "code_postal": "19025",
+      "nom": "Belaa",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "700",
+      "code_postal": "19026",
+      "nom": "Ain Arnat",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "701",
+      "code_postal": "19027",
+      "nom": "Amoucha",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "702",
+      "code_postal": "19028",
+      "nom": "Ain Oulmane",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "703",
+      "code_postal": "19029",
+      "nom": "Beidha Bordj",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "704",
+      "code_postal": "19030",
+      "nom": "Bouandas",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "705",
+      "code_postal": "19031",
+      "nom": "Bazer Sakhra",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "706",
+      "code_postal": "19032",
+      "nom": "Hammam Essokhna",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "707",
+      "code_postal": "19033",
+      "nom": "Mezloug",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "708",
+      "code_postal": "19034",
+      "nom": "Bir Haddada",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "709",
+      "code_postal": "19035",
+      "nom": "Serdj El Ghoul",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "710",
+      "code_postal": "19036",
+      "nom": "Harbil",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "711",
+      "code_postal": "19037",
+      "nom": "El Ouricia",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "712",
+      "code_postal": "19038",
+      "nom": "Tizi Nbechar",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "713",
+      "code_postal": "19039",
+      "nom": "Salah Bey",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "714",
+      "code_postal": "19040",
+      "nom": "Ain Azal",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "715",
+      "code_postal": "19041",
+      "nom": "Guenzet",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "716",
+      "code_postal": "19042",
+      "nom": "Talaifacene",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "717",
+      "code_postal": "19043",
+      "nom": "Bougaa",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "718",
+      "code_postal": "19044",
+      "nom": "Beni Fouda",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "719",
+      "code_postal": "19045",
+      "nom": "Tachouda",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "720",
+      "code_postal": "19046",
+      "nom": "Beni Mouhli",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "721",
+      "code_postal": "19047",
+      "nom": "Ouled Sabor",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "722",
+      "code_postal": "19048",
+      "nom": "Guellal",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "723",
+      "code_postal": "19049",
+      "nom": "Ain Sebt",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "724",
+      "code_postal": "19050",
+      "nom": "Hammam Guergour",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "725",
+      "code_postal": "19051",
+      "nom": "Ait Naoual Mezada",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "726",
+      "code_postal": "19052",
+      "nom": "Ksar El Abtal",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "727",
+      "code_postal": "19053",
+      "nom": "Beni Hocine",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "728",
+      "code_postal": "19054",
+      "nom": "Ait Tizi",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "729",
+      "code_postal": "19055",
+      "nom": "Maouklane",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "730",
+      "code_postal": "19056",
+      "nom": "Guelta Zerka",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "731",
+      "code_postal": "19057",
+      "nom": "Oued El Barad",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "732",
+      "code_postal": "19058",
+      "nom": "Taya",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "733",
+      "code_postal": "19059",
+      "nom": "El Ouldja",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "734",
+      "code_postal": "19060",
+      "nom": "Tella",
+      "wilaya_id": "19"
+    },
+    {
+      "id": "735",
+      "code_postal": "20001",
+      "nom": "Saida",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "736",
+      "code_postal": "20002",
+      "nom": "Doui Thabet",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "737",
+      "code_postal": "20003",
+      "nom": "Ain El Hadjar",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "738",
+      "code_postal": "20004",
+      "nom": "Ouled Khaled",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "739",
+      "code_postal": "20005",
+      "nom": "Moulay Larbi",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "740",
+      "code_postal": "20006",
+      "nom": "Youb",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "741",
+      "code_postal": "20007",
+      "nom": "Hounet",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "742",
+      "code_postal": "20008",
+      "nom": "Sidi Amar",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "743",
+      "code_postal": "20009",
+      "nom": "Sidi Boubekeur",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "744",
+      "code_postal": "20010",
+      "nom": "El Hassasna",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "745",
+      "code_postal": "20011",
+      "nom": "Maamora",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "746",
+      "code_postal": "20012",
+      "nom": "Sidi Ahmed",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "747",
+      "code_postal": "20013",
+      "nom": "Ain Sekhouna",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "748",
+      "code_postal": "20014",
+      "nom": "Ouled Brahim",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "749",
+      "code_postal": "20015",
+      "nom": "Tircine",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "750",
+      "code_postal": "20016",
+      "nom": "Ain Soltane",
+      "wilaya_id": "20"
+    },
+    {
+      "id": "751",
+      "code_postal": "21001",
+      "nom": "Skikda",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "752",
+      "code_postal": "21002",
+      "nom": "Ain Zouit",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "753",
+      "code_postal": "21003",
+      "nom": "El Hadaik",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "754",
+      "code_postal": "21004",
+      "nom": "Azzaba",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "755",
+      "code_postal": "21005",
+      "nom": "Djendel Saadi Mohamed",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "756",
+      "code_postal": "21006",
+      "nom": "Ain Cherchar",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "757",
+      "code_postal": "21007",
+      "nom": "Bekkouche Lakhdar",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "758",
+      "code_postal": "21008",
+      "nom": "Benazouz",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "759",
+      "code_postal": "21009",
+      "nom": "Es Sebt",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "760",
+      "code_postal": "21010",
+      "nom": "Collo",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "761",
+      "code_postal": "21011",
+      "nom": "Beni Zid",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "762",
+      "code_postal": "21012",
+      "nom": "Kerkera",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "763",
+      "code_postal": "21013",
+      "nom": "Ouled Attia",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "764",
+      "code_postal": "21014",
+      "nom": "Oued Zehour",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "765",
+      "code_postal": "21015",
+      "nom": "Zitouna",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "766",
+      "code_postal": "21016",
+      "nom": "El Harrouch",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "767",
+      "code_postal": "21017",
+      "nom": "Zerdazas",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "768",
+      "code_postal": "21018",
+      "nom": "Ouled Hebaba",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "769",
+      "code_postal": "21019",
+      "nom": "Sidi Mezghiche",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "770",
+      "code_postal": "21020",
+      "nom": "Emdjez Edchich",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "771",
+      "code_postal": "21021",
+      "nom": "Beni Oulbane",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "772",
+      "code_postal": "21022",
+      "nom": "Ain Bouziane",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "773",
+      "code_postal": "21023",
+      "nom": "Ramdane Djamel",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "774",
+      "code_postal": "21024",
+      "nom": "Beni Bachir",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "775",
+      "code_postal": "21025",
+      "nom": "Salah Bouchaour",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "776",
+      "code_postal": "21026",
+      "nom": "Tamalous",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "777",
+      "code_postal": "21027",
+      "nom": "Ain Kechra",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "778",
+      "code_postal": "21028",
+      "nom": "Oum Toub",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "779",
+      "code_postal": "21029",
+      "nom": "Bein El Ouiden",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "780",
+      "code_postal": "21030",
+      "nom": "Fil Fila",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "781",
+      "code_postal": "21031",
+      "nom": "Cheraia",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "782",
+      "code_postal": "21032",
+      "nom": "Kanoua",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "783",
+      "code_postal": "21033",
+      "nom": "El Ghedir",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "784",
+      "code_postal": "21034",
+      "nom": "Bouchtata",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "785",
+      "code_postal": "21035",
+      "nom": "Ouldja Boulbalout",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "786",
+      "code_postal": "21036",
+      "nom": "Kheneg Mayoum",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "787",
+      "code_postal": "21037",
+      "nom": "Hamadi Krouma",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "788",
+      "code_postal": "21038",
+      "nom": "El Marsa",
+      "wilaya_id": "21"
+    },
+    {
+      "id": "789",
+      "code_postal": "22001",
+      "nom": "Sidi Bel Abbes",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "790",
+      "code_postal": "22002",
+      "nom": "Tessala",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "791",
+      "code_postal": "22003",
+      "nom": "Sidi Brahim",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "792",
+      "code_postal": "22004",
+      "nom": "Mostefa Ben Brahim",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "793",
+      "code_postal": "22005",
+      "nom": "Telagh",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "794",
+      "code_postal": "22006",
+      "nom": "Mezaourou",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "795",
+      "code_postal": "22007",
+      "nom": "Boukhanafis",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "796",
+      "code_postal": "22008",
+      "nom": "Sidi Ali Boussidi",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "797",
+      "code_postal": "22009",
+      "nom": "Badredine El Mokrani",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "798",
+      "code_postal": "22010",
+      "nom": "Marhoum",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "799",
+      "code_postal": "22011",
+      "nom": "Tafissour",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "800",
+      "code_postal": "22012",
+      "nom": "Amarnas",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "801",
+      "code_postal": "22013",
+      "nom": "Tilmouni",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "802",
+      "code_postal": "22014",
+      "nom": "Sidi Lahcene",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "803",
+      "code_postal": "22015",
+      "nom": "Ain Thrid",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "804",
+      "code_postal": "22016",
+      "nom": "Makedra",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "805",
+      "code_postal": "22017",
+      "nom": "Tenira",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "806",
+      "code_postal": "22018",
+      "nom": "Moulay Slissen",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "807",
+      "code_postal": "22019",
+      "nom": "El Hacaiba",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "808",
+      "code_postal": "22020",
+      "nom": "Hassi Zehana",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "809",
+      "code_postal": "22021",
+      "nom": "Tabia",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "810",
+      "code_postal": "22022",
+      "nom": "Merine",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "811",
+      "code_postal": "22023",
+      "nom": "Ras El Ma",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "812",
+      "code_postal": "22024",
+      "nom": "Ain Tindamine",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "813",
+      "code_postal": "22025",
+      "nom": "Ain Kada",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "814",
+      "code_postal": "22026",
+      "nom": "Mcid",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "815",
+      "code_postal": "22027",
+      "nom": "Sidi Khaled",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "816",
+      "code_postal": "22028",
+      "nom": "Ain El Berd",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "817",
+      "code_postal": "22029",
+      "nom": "Sfissef",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "818",
+      "code_postal": "22030",
+      "nom": "Ain Adden",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "819",
+      "code_postal": "22031",
+      "nom": "Oued Taourira",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "820",
+      "code_postal": "22032",
+      "nom": "Dhaya",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "821",
+      "code_postal": "22033",
+      "nom": "Zerouala",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "822",
+      "code_postal": "22034",
+      "nom": "Lamtar",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "823",
+      "code_postal": "22035",
+      "nom": "Sidi Chaib",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "824",
+      "code_postal": "22036",
+      "nom": "Sidi Dahou Dezairs",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "825",
+      "code_postal": "22037",
+      "nom": "Oued Sbaa",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "826",
+      "code_postal": "22038",
+      "nom": "Boudjebaa El Bordj",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "827",
+      "code_postal": "22039",
+      "nom": "Sehala Thaoura",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "828",
+      "code_postal": "22040",
+      "nom": "Sidi Yacoub",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "829",
+      "code_postal": "22041",
+      "nom": "Sidi Hamadouche",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "830",
+      "code_postal": "22042",
+      "nom": "Belarbi",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "831",
+      "code_postal": "22043",
+      "nom": "Oued Sefioun",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "832",
+      "code_postal": "22044",
+      "nom": "Teghalimet",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "833",
+      "code_postal": "22045",
+      "nom": "Ben Badis",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "834",
+      "code_postal": "22046",
+      "nom": "Sidi Ali Benyoub",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "835",
+      "code_postal": "22047",
+      "nom": "Chetouane Belaila",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "836",
+      "code_postal": "22048",
+      "nom": "Bir El Hammam",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "837",
+      "code_postal": "22049",
+      "nom": "Taoudmout",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "838",
+      "code_postal": "22050",
+      "nom": "Redjem Demouche",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "839",
+      "code_postal": "22051",
+      "nom": "Benachiba Chelia",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "840",
+      "code_postal": "22052",
+      "nom": "Hassi Dahou",
+      "wilaya_id": "22"
+    },
+    {
+      "id": "841",
+      "code_postal": "23001",
+      "nom": "Annaba",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "842",
+      "code_postal": "23002",
+      "nom": "Berrahel",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "843",
+      "code_postal": "23003",
+      "nom": "El Hadjar",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "844",
+      "code_postal": "23004",
+      "nom": "Eulma",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "845",
+      "code_postal": "23005",
+      "nom": "El Bouni",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "846",
+      "code_postal": "23006",
+      "nom": "Oued El Aneb",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "847",
+      "code_postal": "23007",
+      "nom": "Cheurfa",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "848",
+      "code_postal": "23008",
+      "nom": "Seraidi",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "849",
+      "code_postal": "23009",
+      "nom": "Ain Berda",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "850",
+      "code_postal": "23010",
+      "nom": "Chetaibi",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "851",
+      "code_postal": "23011",
+      "nom": "Sidi Amer",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "852",
+      "code_postal": "23012",
+      "nom": "Treat",
+      "wilaya_id": "23"
+    },
+    {
+      "id": "853",
+      "code_postal": "24001",
+      "nom": "Guelma",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "854",
+      "code_postal": "24002",
+      "nom": "Nechmaya",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "855",
+      "code_postal": "24003",
+      "nom": "Bouati Mahmoud",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "856",
+      "code_postal": "24004",
+      "nom": "Oued Zenati",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "857",
+      "code_postal": "24005",
+      "nom": "Tamlouka",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "858",
+      "code_postal": "24006",
+      "nom": "Oued Fragha",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "859",
+      "code_postal": "24007",
+      "nom": "Ain Sandel",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "860",
+      "code_postal": "24008",
+      "nom": "Ras El Agba",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "861",
+      "code_postal": "24009",
+      "nom": "Dahouara",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "862",
+      "code_postal": "24010",
+      "nom": "Belkhir",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "863",
+      "code_postal": "24011",
+      "nom": "Ben Djarah",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "864",
+      "code_postal": "24012",
+      "nom": "Bou Hamdane",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "865",
+      "code_postal": "24013",
+      "nom": "Ain Makhlouf",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "866",
+      "code_postal": "24014",
+      "nom": "Ain Ben Beida",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "867",
+      "code_postal": "24015",
+      "nom": "Khezara",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "868",
+      "code_postal": "24016",
+      "nom": "Beni Mezline",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "869",
+      "code_postal": "24017",
+      "nom": "Bou Hachana",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "870",
+      "code_postal": "24018",
+      "nom": "Guelaat Bou Sbaa",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "871",
+      "code_postal": "24019",
+      "nom": "Hammam Maskhoutine",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "872",
+      "code_postal": "24020",
+      "nom": "El Fedjoudj",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "873",
+      "code_postal": "24021",
+      "nom": "Bordj Sabat",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "874",
+      "code_postal": "24022",
+      "nom": "Hamman Nbail",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "875",
+      "code_postal": "24023",
+      "nom": "Ain Larbi",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "876",
+      "code_postal": "24024",
+      "nom": "Medjez Amar",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "877",
+      "code_postal": "24025",
+      "nom": "Bouchegouf",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "878",
+      "code_postal": "24026",
+      "nom": "Heliopolis",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "879",
+      "code_postal": "24027",
+      "nom": "Ain Hessania",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "880",
+      "code_postal": "24028",
+      "nom": "Roknia",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "881",
+      "code_postal": "24029",
+      "nom": "Salaoua Announa",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "882",
+      "code_postal": "24030",
+      "nom": "Medjez Sfa",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "883",
+      "code_postal": "24031",
+      "nom": "Boumahra Ahmed",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "884",
+      "code_postal": "24032",
+      "nom": "Ain Reggada",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "885",
+      "code_postal": "24033",
+      "nom": "Oued Cheham",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "886",
+      "code_postal": "24034",
+      "nom": "Djeballah Khemissi",
+      "wilaya_id": "24"
+    },
+    {
+      "id": "887",
+      "code_postal": "25001",
+      "nom": "Constantine",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "888",
+      "code_postal": "25002",
+      "nom": "Hamma Bouziane",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "889",
+      "code_postal": "25003",
+      "nom": "El Haria",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "890",
+      "code_postal": "25004",
+      "nom": "Zighoud Youcef",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "891",
+      "code_postal": "25005",
+      "nom": "Didouche Mourad",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "892",
+      "code_postal": "25006",
+      "nom": "El Khroub",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "893",
+      "code_postal": "25007",
+      "nom": "Ain Abid",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "894",
+      "code_postal": "25008",
+      "nom": "Beni Hamiden",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "895",
+      "code_postal": "25009",
+      "nom": "Ouled Rahmoune",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "896",
+      "code_postal": "25010",
+      "nom": "Ain Smara",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "897",
+      "code_postal": "25011",
+      "nom": "Mesaoud Boudjeriou",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "898",
+      "code_postal": "25012",
+      "nom": "Ibn Ziad",
+      "wilaya_id": "25"
+    },
+    {
+      "id": "899",
+      "code_postal": "26001",
+      "nom": "Medea",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "900",
+      "code_postal": "26002",
+      "nom": "Ouzera",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "901",
+      "code_postal": "26003",
+      "nom": "Ouled Maaref",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "902",
+      "code_postal": "26004",
+      "nom": "Ain Boucif",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "903",
+      "code_postal": "26005",
+      "nom": "Aissaouia",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "904",
+      "code_postal": "26006",
+      "nom": "Ouled Deide",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "905",
+      "code_postal": "26007",
+      "nom": "El Omaria",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "906",
+      "code_postal": "26008",
+      "nom": "Derrag",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "907",
+      "code_postal": "26009",
+      "nom": "El Guelbelkebir",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "908",
+      "code_postal": "26010",
+      "nom": "Bouaiche",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "909",
+      "code_postal": "26011",
+      "nom": "Mezerena",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "910",
+      "code_postal": "26012",
+      "nom": "Ouled Brahim",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "911",
+      "code_postal": "26013",
+      "nom": "Damiat",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "912",
+      "code_postal": "26014",
+      "nom": "Sidi Ziane",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "913",
+      "code_postal": "26015",
+      "nom": "Tamesguida",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "914",
+      "code_postal": "26016",
+      "nom": "El Hamdania",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "915",
+      "code_postal": "26017",
+      "nom": "Kef Lakhdar",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "916",
+      "code_postal": "26018",
+      "nom": "Chelalet El Adhaoura",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "917",
+      "code_postal": "26019",
+      "nom": "Bouskene",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "918",
+      "code_postal": "26020",
+      "nom": "Rebaia",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "919",
+      "code_postal": "26021",
+      "nom": "Bouchrahil",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "920",
+      "code_postal": "26022",
+      "nom": "Ouled Hellal",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "921",
+      "code_postal": "26023",
+      "nom": "Tafraout",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "922",
+      "code_postal": "26024",
+      "nom": "Baata",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "923",
+      "code_postal": "26025",
+      "nom": "Boghar",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "924",
+      "code_postal": "26026",
+      "nom": "Sidi Naamane",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "925",
+      "code_postal": "26027",
+      "nom": "Ouled Bouachra",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "926",
+      "code_postal": "26028",
+      "nom": "Sidi Zahar",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "927",
+      "code_postal": "26029",
+      "nom": "Oued Harbil",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "928",
+      "code_postal": "26030",
+      "nom": "Benchicao",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "929",
+      "code_postal": "26031",
+      "nom": "Sidi Damed",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "930",
+      "code_postal": "26032",
+      "nom": "Aziz",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "931",
+      "code_postal": "26033",
+      "nom": "Souagui",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "932",
+      "code_postal": "26034",
+      "nom": "Zoubiria",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "933",
+      "code_postal": "26035",
+      "nom": "Ksar El Boukhari",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "934",
+      "code_postal": "26036",
+      "nom": "El Azizia",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "935",
+      "code_postal": "26037",
+      "nom": "Djouab",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "936",
+      "code_postal": "26038",
+      "nom": "Chahbounia",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "937",
+      "code_postal": "26039",
+      "nom": "Meghraoua",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "938",
+      "code_postal": "26040",
+      "nom": "Cheniguel",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "939",
+      "code_postal": "26041",
+      "nom": "Ain Ouksir",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "940",
+      "code_postal": "26042",
+      "nom": "Oum El Djalil",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "941",
+      "code_postal": "26043",
+      "nom": "Ouamri",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "942",
+      "code_postal": "26044",
+      "nom": "Si Mahdjoub",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "943",
+      "code_postal": "26045",
+      "nom": "Tlatet Eddoair",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "944",
+      "code_postal": "26046",
+      "nom": "Beni Slimane",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "945",
+      "code_postal": "26047",
+      "nom": "Berrouaghia",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "946",
+      "code_postal": "26048",
+      "nom": "Seghouane",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "947",
+      "code_postal": "26049",
+      "nom": "Meftaha",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "948",
+      "code_postal": "26050",
+      "nom": "Mihoub",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "949",
+      "code_postal": "26051",
+      "nom": "Boughezoul",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "950",
+      "code_postal": "26052",
+      "nom": "Tablat",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "951",
+      "code_postal": "26053",
+      "nom": "Deux Bassins",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "952",
+      "code_postal": "26054",
+      "nom": "Draa Essamar",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "953",
+      "code_postal": "26055",
+      "nom": "Sidi Errabia",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "954",
+      "code_postal": "26056",
+      "nom": "Bir Ben Laabed",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "955",
+      "code_postal": "26057",
+      "nom": "El Ouinet",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "956",
+      "code_postal": "26058",
+      "nom": "Ouled Antar",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "957",
+      "code_postal": "26059",
+      "nom": "Bouaichoune",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "958",
+      "code_postal": "26060",
+      "nom": "Hannacha",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "959",
+      "code_postal": "26061",
+      "nom": "Sedraia",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "960",
+      "code_postal": "26062",
+      "nom": "Medjebar",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "961",
+      "code_postal": "26063",
+      "nom": "Khams Djouamaa",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "962",
+      "code_postal": "26064",
+      "nom": "Saneg",
+      "wilaya_id": "26"
+    },
+    {
+      "id": "963",
+      "code_postal": "27001",
+      "nom": "Mostaganem",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "964",
+      "code_postal": "27002",
+      "nom": "Sayada",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "965",
+      "code_postal": "27003",
+      "nom": "Fornaka",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "966",
+      "code_postal": "27004",
+      "nom": "Stidia",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "967",
+      "code_postal": "27005",
+      "nom": "Ain Nouissy",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "968",
+      "code_postal": "27006",
+      "nom": "Hassi Maameche",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "969",
+      "code_postal": "27007",
+      "nom": "Ain Tadles",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "970",
+      "code_postal": "27008",
+      "nom": "Sour",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "971",
+      "code_postal": "27009",
+      "nom": "Oued El Kheir",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "972",
+      "code_postal": "27010",
+      "nom": "Sidi Bellater",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "973",
+      "code_postal": "27011",
+      "nom": "Kheiredine ",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "974",
+      "code_postal": "27012",
+      "nom": "Sidi Ali",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "975",
+      "code_postal": "27013",
+      "nom": "Abdelmalek Ramdane",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "976",
+      "code_postal": "27014",
+      "nom": "Hadjadj",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "977",
+      "code_postal": "27015",
+      "nom": "Nekmaria",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "978",
+      "code_postal": "27016",
+      "nom": "Sidi Lakhdar",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "979",
+      "code_postal": "27017",
+      "nom": "Achaacha",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "980",
+      "code_postal": "27018",
+      "nom": "Khadra",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "981",
+      "code_postal": "27019",
+      "nom": "Bouguirat",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "982",
+      "code_postal": "27020",
+      "nom": "Sirat",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "983",
+      "code_postal": "27021",
+      "nom": "Ain Sidi Cherif",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "984",
+      "code_postal": "27022",
+      "nom": "Mesra",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "985",
+      "code_postal": "27023",
+      "nom": "Mansourah",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "986",
+      "code_postal": "27024",
+      "nom": "Souaflia",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "987",
+      "code_postal": "27025",
+      "nom": "Ouled Boughalem",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "988",
+      "code_postal": "27026",
+      "nom": "Ouled Maallah",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "989",
+      "code_postal": "27027",
+      "nom": "Mezghrane",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "990",
+      "code_postal": "27028",
+      "nom": "Ain Boudinar",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "991",
+      "code_postal": "27029",
+      "nom": "Tazgait",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "992",
+      "code_postal": "27030",
+      "nom": "Safsaf",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "993",
+      "code_postal": "27031",
+      "nom": "Touahria",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "994",
+      "code_postal": "27032",
+      "nom": "El Hassiane",
+      "wilaya_id": "27"
+    },
+    {
+      "id": "995",
+      "code_postal": "28001",
+      "nom": "Msila",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "996",
+      "code_postal": "28002",
+      "nom": "Maadid",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "997",
+      "code_postal": "28003",
+      "nom": "Hammam Dhalaa",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "998",
+      "code_postal": "28004",
+      "nom": "Ouled Derradj",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "999",
+      "code_postal": "28005",
+      "nom": "Tarmount",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1000",
+      "code_postal": "28006",
+      "nom": "Mtarfa",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1001",
+      "code_postal": "28007",
+      "nom": "Khoubana",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1002",
+      "code_postal": "28008",
+      "nom": "Mcif",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1003",
+      "code_postal": "28009",
+      "nom": "Chellal",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1004",
+      "code_postal": "28010",
+      "nom": "Ouled Madhi",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1005",
+      "code_postal": "28011",
+      "nom": "Magra",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1006",
+      "code_postal": "28012",
+      "nom": "Berhoum",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1007",
+      "code_postal": "28013",
+      "nom": "Ain Khadra",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1008",
+      "code_postal": "28014",
+      "nom": "Ouled Addi Guebala",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1009",
+      "code_postal": "28015",
+      "nom": "Belaiba",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1010",
+      "code_postal": "28016",
+      "nom": "Sidi Aissa",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1011",
+      "code_postal": "28017",
+      "nom": "Ain El Hadjel",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1012",
+      "code_postal": "28018",
+      "nom": "Sidi Hadjeres",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1013",
+      "code_postal": "28019",
+      "nom": "Ouanougha",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1014",
+      "code_postal": "28020",
+      "nom": "Bou Saada",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1015",
+      "code_postal": "28021",
+      "nom": "Ouled Sidi Brahim",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1016",
+      "code_postal": "28022",
+      "nom": "Sidi Ameur",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1017",
+      "code_postal": "28023",
+      "nom": "Tamsa",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1018",
+      "code_postal": "28024",
+      "nom": "Ben Srour",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1019",
+      "code_postal": "28025",
+      "nom": "Ouled Slimane",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1020",
+      "code_postal": "28026",
+      "nom": "El Houamed",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1021",
+      "code_postal": "28027",
+      "nom": "El Hamel",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1022",
+      "code_postal": "28028",
+      "nom": "Ouled Mansour",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1023",
+      "code_postal": "28029",
+      "nom": "Maarif",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1024",
+      "code_postal": "28030",
+      "nom": "Dehahna",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1025",
+      "code_postal": "28031",
+      "nom": "Bouti Sayah",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1026",
+      "code_postal": "28032",
+      "nom": "Khettouti Sed Djir",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1027",
+      "code_postal": "28033",
+      "nom": "Zarzour",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1028",
+      "code_postal": "28034",
+      "nom": "Oued Chair",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1029",
+      "code_postal": "28035",
+      "nom": "Benzouh",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1030",
+      "code_postal": "28036",
+      "nom": "Bir Foda",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1031",
+      "code_postal": "28037",
+      "nom": "Ain Fares",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1032",
+      "code_postal": "28038",
+      "nom": "Sidi Mhamed",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1033",
+      "code_postal": "28039",
+      "nom": "Ouled Atia",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1034",
+      "code_postal": "28040",
+      "nom": "Souamaa",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1035",
+      "code_postal": "28041",
+      "nom": "Ain El Melh",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1036",
+      "code_postal": "28042",
+      "nom": "Medjedel",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1037",
+      "code_postal": "28043",
+      "nom": "Slim",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1038",
+      "code_postal": "28044",
+      "nom": "Ain Errich",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1039",
+      "code_postal": "28045",
+      "nom": "Beni Ilmane",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1040",
+      "code_postal": "28046",
+      "nom": "Oultene",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1041",
+      "code_postal": "28047",
+      "nom": "Djebel Messaad",
+      "wilaya_id": "28"
+    },
+    {
+      "id": "1042",
+      "code_postal": "29001",
+      "nom": "Mascara",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1043",
+      "code_postal": "29002",
+      "nom": "Bou Hanifia",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1044",
+      "code_postal": "29003",
+      "nom": "Tizi",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1045",
+      "code_postal": "29004",
+      "nom": "Hacine",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1046",
+      "code_postal": "29005",
+      "nom": "Maoussa",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1047",
+      "code_postal": "29006",
+      "nom": "Teghennif",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1048",
+      "code_postal": "29007",
+      "nom": "El Hachem",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1049",
+      "code_postal": "29008",
+      "nom": "Sidi Kada",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1050",
+      "code_postal": "29009",
+      "nom": "Zelmata",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1051",
+      "code_postal": "29010",
+      "nom": "Oued El Abtal",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1052",
+      "code_postal": "29011",
+      "nom": "Ain Ferah",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1053",
+      "code_postal": "29012",
+      "nom": "Ghriss",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1054",
+      "code_postal": "29013",
+      "nom": "Froha",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1055",
+      "code_postal": "29014",
+      "nom": "Matemore",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1056",
+      "code_postal": "29015",
+      "nom": "Makdha",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1057",
+      "code_postal": "29016",
+      "nom": "Sidi Boussaid",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1058",
+      "code_postal": "29017",
+      "nom": "El Bordj",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1059",
+      "code_postal": "29018",
+      "nom": "Ain Fekan",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1060",
+      "code_postal": "29019",
+      "nom": "Benian",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1061",
+      "code_postal": "29020",
+      "nom": "Khalouia",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1062",
+      "code_postal": "29021",
+      "nom": "El Menaouer",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1063",
+      "code_postal": "29022",
+      "nom": "Oued Taria",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1064",
+      "code_postal": "29023",
+      "nom": "Aouf",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1065",
+      "code_postal": "29024",
+      "nom": "Ain Fares",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1066",
+      "code_postal": "29025",
+      "nom": "Ain Frass",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1067",
+      "code_postal": "29026",
+      "nom": "Sig",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1068",
+      "code_postal": "29027",
+      "nom": "Oggaz",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1069",
+      "code_postal": "29028",
+      "nom": "Alaimia",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1070",
+      "code_postal": "29029",
+      "nom": "El Gaada",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1071",
+      "code_postal": "29030",
+      "nom": "Zahana",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1072",
+      "code_postal": "29031",
+      "nom": "Mohammadia",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1073",
+      "code_postal": "29032",
+      "nom": "Sidi Abdelmoumene",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1074",
+      "code_postal": "29033",
+      "nom": "Ferraguig",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1075",
+      "code_postal": "29034",
+      "nom": "El Ghomri",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1076",
+      "code_postal": "29035",
+      "nom": "Sedjerara",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1077",
+      "code_postal": "29036",
+      "nom": "Moctadouz",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1078",
+      "code_postal": "29037",
+      "nom": "Bou Henni",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1079",
+      "code_postal": "29038",
+      "nom": "Guettena",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1080",
+      "code_postal": "29039",
+      "nom": "El Mamounia",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1081",
+      "code_postal": "29040",
+      "nom": "El Keurt",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1082",
+      "code_postal": "29041",
+      "nom": "Gharrous",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1083",
+      "code_postal": "29042",
+      "nom": "Gherdjoum",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1084",
+      "code_postal": "29043",
+      "nom": "Chorfa",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1085",
+      "code_postal": "29044",
+      "nom": "Ras Ain Amirouche",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1086",
+      "code_postal": "29045",
+      "nom": "Nesmot",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1087",
+      "code_postal": "29046",
+      "nom": "Sidi Abdeldjebar",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1088",
+      "code_postal": "29047",
+      "nom": "Sehailia",
+      "wilaya_id": "29"
+    },
+    {
+      "id": "1089",
+      "code_postal": "30001",
+      "nom": "Ouargla",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1090",
+      "code_postal": "30002",
+      "nom": "Ain Beida",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1091",
+      "code_postal": "30003",
+      "nom": "Ngoussa",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1092",
+      "code_postal": "30004",
+      "nom": "Hassi Messaoud",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1093",
+      "code_postal": "30005",
+      "nom": "Rouissat",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1094",
+      "code_postal": "30006",
+      "nom": "Balidat Ameur",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1095",
+      "code_postal": "30007",
+      "nom": "Tebesbest",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1096",
+      "code_postal": "30008",
+      "nom": "Nezla",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1097",
+      "code_postal": "30009",
+      "nom": "Zaouia El Abidia",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1098",
+      "code_postal": "30010",
+      "nom": "Sidi Slimane",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1099",
+      "code_postal": "30011",
+      "nom": "Sidi Khouiled",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1100",
+      "code_postal": "30012",
+      "nom": "Hassi Ben Abdellah",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1101",
+      "code_postal": "30013",
+      "nom": "Touggourt",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1102",
+      "code_postal": "30014",
+      "nom": "El Hadjira",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1103",
+      "code_postal": "30015",
+      "nom": "Taibet",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1104",
+      "code_postal": "30016",
+      "nom": "Tamacine",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1105",
+      "code_postal": "30017",
+      "nom": "Benaceur",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1106",
+      "code_postal": "30018",
+      "nom": "Mnaguer",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1107",
+      "code_postal": "30019",
+      "nom": "Megarine",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1108",
+      "code_postal": "30020",
+      "nom": "El Allia",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1109",
+      "code_postal": "30021",
+      "nom": "El Borma",
+      "wilaya_id": "30"
+    },
+    {
+      "id": "1110",
+      "code_postal": "31001",
+      "nom": "Oran",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1111",
+      "code_postal": "31002",
+      "nom": "Gdyel",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1112",
+      "code_postal": "31003",
+      "nom": "Bir El Djir",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1113",
+      "code_postal": "31004",
+      "nom": "Hassi Bounif",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1114",
+      "code_postal": "31005",
+      "nom": "Es Senia",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1115",
+      "code_postal": "31006",
+      "nom": "Arzew",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1116",
+      "code_postal": "31007",
+      "nom": "Bethioua",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1117",
+      "code_postal": "31008",
+      "nom": "Marsat El Hadjadj",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1118",
+      "code_postal": "31009",
+      "nom": "Ain Turk",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1119",
+      "code_postal": "31010",
+      "nom": "El Ancar",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1120",
+      "code_postal": "31011",
+      "nom": "Oued Tlelat",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1121",
+      "code_postal": "31012",
+      "nom": "Tafraoui",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1122",
+      "code_postal": "31013",
+      "nom": "Sidi Chami",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1123",
+      "code_postal": "31014",
+      "nom": "Boufatis",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1124",
+      "code_postal": "31015",
+      "nom": "Mers El Kebir",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1125",
+      "code_postal": "31016",
+      "nom": "Bousfer",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1126",
+      "code_postal": "31017",
+      "nom": "El Karma",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1127",
+      "code_postal": "31018",
+      "nom": "El Braya",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1128",
+      "code_postal": "31019",
+      "nom": "Hassi Ben Okba",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1129",
+      "code_postal": "31020",
+      "nom": "Ben Freha",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1130",
+      "code_postal": "31021",
+      "nom": "Hassi Mefsoukh",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1131",
+      "code_postal": "31022",
+      "nom": "Sidi Ben Yabka",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1132",
+      "code_postal": "31023",
+      "nom": "Messerghin",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1133",
+      "code_postal": "31024",
+      "nom": "Boutlelis",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1134",
+      "code_postal": "31025",
+      "nom": "Ain Kerma",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1135",
+      "code_postal": "31026",
+      "nom": "Ain Biya",
+      "wilaya_id": "31"
+    },
+    {
+      "id": "1136",
+      "code_postal": "32001",
+      "nom": "El Bayadh",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1137",
+      "code_postal": "32002",
+      "nom": "Rogassa",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1138",
+      "code_postal": "32003",
+      "nom": "Stitten",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1139",
+      "code_postal": "32004",
+      "nom": "Brezina",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1140",
+      "code_postal": "32005",
+      "nom": "Ghassoul",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1141",
+      "code_postal": "32006",
+      "nom": "Boualem",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1142",
+      "code_postal": "32007",
+      "nom": "El Abiodh Sidi Cheikh",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1143",
+      "code_postal": "32008",
+      "nom": "Ain El Orak",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1144",
+      "code_postal": "32009",
+      "nom": "Arbaouat",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1145",
+      "code_postal": "32010",
+      "nom": "Bougtoub",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1146",
+      "code_postal": "32011",
+      "nom": "El Kheither",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1147",
+      "code_postal": "32012",
+      "nom": "Kef El Ahmar",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1148",
+      "code_postal": "32013",
+      "nom": "Boussemghoun",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1149",
+      "code_postal": "32014",
+      "nom": "Chellala",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1150",
+      "code_postal": "32015",
+      "nom": "Krakda",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1151",
+      "code_postal": "32016",
+      "nom": "El Bnoud",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1152",
+      "code_postal": "32017",
+      "nom": "Cheguig",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1153",
+      "code_postal": "32018",
+      "nom": "Sidi Ameur",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1154",
+      "code_postal": "32019",
+      "nom": "El Mehara",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1155",
+      "code_postal": "32020",
+      "nom": "Tousmouline",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1156",
+      "code_postal": "32021",
+      "nom": "Sidi Slimane",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1157",
+      "code_postal": "32022",
+      "nom": "Sidi Tifour",
+      "wilaya_id": "32"
+    },
+    {
+      "id": "1158",
+      "code_postal": "33001",
+      "nom": "Illizi",
+      "wilaya_id": "33"
+    },
+    {
+      "id": "1159",
+      "code_postal": "33002",
+      "nom": "Djanet",
+      "wilaya_id": "33"
+    },
+    {
+      "id": "1160",
+      "code_postal": "33003",
+      "nom": "Debdeb",
+      "wilaya_id": "33"
+    },
+    {
+      "id": "1161",
+      "code_postal": "33004",
+      "nom": "Bordj Omar Driss",
+      "wilaya_id": "33"
+    },
+    {
+      "id": "1162",
+      "code_postal": "33005",
+      "nom": "Bordj El Haouasse",
+      "wilaya_id": "33"
+    },
+    {
+      "id": "1163",
+      "code_postal": "33006",
+      "nom": "In Amenas",
+      "wilaya_id": "33"
+    },
+    {
+      "id": "1164",
+      "code_postal": "34001",
+      "nom": "Bordj Bou Arreridj",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1165",
+      "code_postal": "34002",
+      "nom": "Ras El Oued",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1166",
+      "code_postal": "34003",
+      "nom": "Bordj Zemoura",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1167",
+      "code_postal": "34004",
+      "nom": "Mansoura",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1168",
+      "code_postal": "34005",
+      "nom": "El Mhir",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1169",
+      "code_postal": "34006",
+      "nom": "Ben Daoud",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1170",
+      "code_postal": "34007",
+      "nom": "El Achir",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1171",
+      "code_postal": "34008",
+      "nom": "Ain Taghrout",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1172",
+      "code_postal": "34009",
+      "nom": "Bordj Ghdir",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1173",
+      "code_postal": "34010",
+      "nom": "Sidi Embarek",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1174",
+      "code_postal": "34011",
+      "nom": "El Hamadia",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1175",
+      "code_postal": "34012",
+      "nom": "Belimour",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1176",
+      "code_postal": "34013",
+      "nom": "Medjana",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1177",
+      "code_postal": "34014",
+      "nom": "Teniet En Nasr",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1178",
+      "code_postal": "34015",
+      "nom": "Djaafra",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1179",
+      "code_postal": "34016",
+      "nom": "El Main",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1180",
+      "code_postal": "34017",
+      "nom": "Ouled Brahem",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1181",
+      "code_postal": "34018",
+      "nom": "Ouled Dahmane",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1182",
+      "code_postal": "34019",
+      "nom": "Hasnaoua",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1183",
+      "code_postal": "34020",
+      "nom": "Khelil",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1184",
+      "code_postal": "34021",
+      "nom": "Taglait",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1185",
+      "code_postal": "34022",
+      "nom": "Ksour",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1186",
+      "code_postal": "34023",
+      "nom": "Ouled Sidi Brahim",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1187",
+      "code_postal": "34024",
+      "nom": "Tafreg",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1188",
+      "code_postal": "34025",
+      "nom": "Colla",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1189",
+      "code_postal": "34026",
+      "nom": "Tixter",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1190",
+      "code_postal": "34027",
+      "nom": "El Ach",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1191",
+      "code_postal": "34028",
+      "nom": "El Anseur",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1192",
+      "code_postal": "34029",
+      "nom": "Tesmart",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1193",
+      "code_postal": "34030",
+      "nom": "Ain Tesra",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1194",
+      "code_postal": "34031",
+      "nom": "Bir Kasdali",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1195",
+      "code_postal": "34032",
+      "nom": "Ghilassa",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1196",
+      "code_postal": "34033",
+      "nom": "Rabta",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1197",
+      "code_postal": "34034",
+      "nom": "Haraza",
+      "wilaya_id": "34"
+    },
+    {
+      "id": "1198",
+      "code_postal": "35001",
+      "nom": "Boumerdes",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1199",
+      "code_postal": "35002",
+      "nom": "Boudouaou",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1200",
+      "code_postal": "35004",
+      "nom": "Afir",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1201",
+      "code_postal": "35005",
+      "nom": "Bordj Menaiel",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1202",
+      "code_postal": "35006",
+      "nom": "Baghlia",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1203",
+      "code_postal": "35007",
+      "nom": "Sidi Daoud",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1204",
+      "code_postal": "35008",
+      "nom": "Naciria",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1205",
+      "code_postal": "35009",
+      "nom": "Djinet",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1206",
+      "code_postal": "35010",
+      "nom": "Isser",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1207",
+      "code_postal": "35011",
+      "nom": "Zemmouri",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1208",
+      "code_postal": "35012",
+      "nom": "Si Mustapha",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1209",
+      "code_postal": "35013",
+      "nom": "Tidjelabine",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1210",
+      "code_postal": "35014",
+      "nom": "Chabet El Ameur",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1211",
+      "code_postal": "35015",
+      "nom": "Thenia",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1212",
+      "code_postal": "35018",
+      "nom": "Timezrit",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1213",
+      "code_postal": "35019",
+      "nom": "Corso",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1214",
+      "code_postal": "35020",
+      "nom": "Ouled Moussa",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1215",
+      "code_postal": "35021",
+      "nom": "Larbatache",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1216",
+      "code_postal": "35022",
+      "nom": "Bouzegza Keddara",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1217",
+      "code_postal": "35025",
+      "nom": "Taourga",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1218",
+      "code_postal": "35026",
+      "nom": "Ouled Aissa",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1219",
+      "code_postal": "35027",
+      "nom": "Ben Choud",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1220",
+      "code_postal": "35028",
+      "nom": "Dellys",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1221",
+      "code_postal": "35029",
+      "nom": "Ammal",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1222",
+      "code_postal": "35030",
+      "nom": "Beni Amrane",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1223",
+      "code_postal": "35031",
+      "nom": "Souk El Had",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1224",
+      "code_postal": "35032",
+      "nom": "Boudouaou El Bahri",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1225",
+      "code_postal": "35033",
+      "nom": "Ouled Hedadj",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1226",
+      "code_postal": "35035",
+      "nom": "Laghata",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1227",
+      "code_postal": "35036",
+      "nom": "Hammedi",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1228",
+      "code_postal": "35037",
+      "nom": "Khemis El Khechna",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1229",
+      "code_postal": "35038",
+      "nom": "El Kharrouba",
+      "wilaya_id": "35"
+    },
+    {
+      "id": "1230",
+      "code_postal": "36001",
+      "nom": "El Tarf",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1231",
+      "code_postal": "36002",
+      "nom": "Bouhadjar",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1232",
+      "code_postal": "36003",
+      "nom": "Ben Mhidi",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1233",
+      "code_postal": "36004",
+      "nom": "Bougous",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1234",
+      "code_postal": "36005",
+      "nom": "El Kala",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1235",
+      "code_postal": "36006",
+      "nom": "Ain El Assel",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1236",
+      "code_postal": "36007",
+      "nom": "El Aioun",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1237",
+      "code_postal": "36008",
+      "nom": "Bouteldja",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1238",
+      "code_postal": "36009",
+      "nom": "Souarekh",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1239",
+      "code_postal": "36010",
+      "nom": "Berrihane",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1240",
+      "code_postal": "36011",
+      "nom": "Lac Des Oiseaux",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1241",
+      "code_postal": "36012",
+      "nom": "Chefia",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1242",
+      "code_postal": "36013",
+      "nom": "Drean",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1243",
+      "code_postal": "36014",
+      "nom": "Chihani",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1244",
+      "code_postal": "36015",
+      "nom": "Chebaita Mokhtar",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1245",
+      "code_postal": "36016",
+      "nom": "Besbes",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1246",
+      "code_postal": "36017",
+      "nom": "Asfour",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1247",
+      "code_postal": "36018",
+      "nom": "Echatt",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1248",
+      "code_postal": "36019",
+      "nom": "Zerizer",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1249",
+      "code_postal": "36020",
+      "nom": "Zitouna",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1250",
+      "code_postal": "36021",
+      "nom": "Ain Kerma",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1251",
+      "code_postal": "36022",
+      "nom": "Oued Zitoun",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1252",
+      "code_postal": "36023",
+      "nom": "Hammam Beni Salah",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1253",
+      "code_postal": "36024",
+      "nom": "Raml Souk",
+      "wilaya_id": "36"
+    },
+    {
+      "id": "1254",
+      "code_postal": "37001",
+      "nom": "Tindouf",
+      "wilaya_id": "37"
+    },
+    {
+      "id": "1255",
+      "code_postal": "37002",
+      "nom": "Oum El Assel",
+      "wilaya_id": "37"
+    },
+    {
+      "id": "1256",
+      "code_postal": "38001",
+      "nom": "Tissemsilt",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1257",
+      "code_postal": "38002",
+      "nom": "Bordj Bou Naama",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1258",
+      "code_postal": "38003",
+      "nom": "Theniet El Had",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1259",
+      "code_postal": "38004",
+      "nom": "Lazharia",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1260",
+      "code_postal": "38005",
+      "nom": "Beni Chaib",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1261",
+      "code_postal": "38006",
+      "nom": "Lardjem",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1262",
+      "code_postal": "38007",
+      "nom": "Melaab",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1263",
+      "code_postal": "38008",
+      "nom": "Sidi Lantri",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1264",
+      "code_postal": "38009",
+      "nom": "Bordj El Emir Abdelkader",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1265",
+      "code_postal": "38010",
+      "nom": "Layoune",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1266",
+      "code_postal": "38011",
+      "nom": "Khemisti",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1267",
+      "code_postal": "38012",
+      "nom": "Ouled Bessem",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1268",
+      "code_postal": "38013",
+      "nom": "Ammari",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1269",
+      "code_postal": "38014",
+      "nom": "Youssoufia",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1270",
+      "code_postal": "38015",
+      "nom": "Sidi Boutouchent",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1271",
+      "code_postal": "38016",
+      "nom": "Larbaa",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1272",
+      "code_postal": "38017",
+      "nom": "Maasem",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1273",
+      "code_postal": "38018",
+      "nom": "Sidi Abed",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1274",
+      "code_postal": "38019",
+      "nom": "Tamalaht",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1275",
+      "code_postal": "38020",
+      "nom": "Sidi Slimane",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1276",
+      "code_postal": "38021",
+      "nom": "Boucaid",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1277",
+      "code_postal": "38022",
+      "nom": "Beni Lahcene",
+      "wilaya_id": "38"
+    },
+    {
+      "id": "1278",
+      "code_postal": "39001",
+      "nom": "El Oued",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1279",
+      "code_postal": "39002",
+      "nom": "Robbah",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1280",
+      "code_postal": "39003",
+      "nom": "Oued El Alenda",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1281",
+      "code_postal": "39004",
+      "nom": "Bayadha",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1282",
+      "code_postal": "39005",
+      "nom": "Nakhla",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1283",
+      "code_postal": "39006",
+      "nom": "Guemar",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1284",
+      "code_postal": "39007",
+      "nom": "Kouinine",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1285",
+      "code_postal": "39008",
+      "nom": "Reguiba",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1286",
+      "code_postal": "39009",
+      "nom": "Hamraia",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1287",
+      "code_postal": "39010",
+      "nom": "Taghzout",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1288",
+      "code_postal": "39011",
+      "nom": "Debila",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1289",
+      "code_postal": "39012",
+      "nom": "Hassani Abdelkrim",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1290",
+      "code_postal": "39013",
+      "nom": "Hassi Khelifa",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1291",
+      "code_postal": "39014",
+      "nom": "Taleb Larbi",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1292",
+      "code_postal": "39015",
+      "nom": "Douar El Ma",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1293",
+      "code_postal": "39016",
+      "nom": "Sidi Aoun",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1294",
+      "code_postal": "39017",
+      "nom": "Trifaoui",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1295",
+      "code_postal": "39018",
+      "nom": "Magrane",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1296",
+      "code_postal": "39019",
+      "nom": "Beni Guecha",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1297",
+      "code_postal": "39020",
+      "nom": "Ourmas",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1298",
+      "code_postal": "39021",
+      "nom": "Still",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1299",
+      "code_postal": "39022",
+      "nom": "Mrara",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1300",
+      "code_postal": "39023",
+      "nom": "Sidi Khellil",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1301",
+      "code_postal": "39024",
+      "nom": "Tendla",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1302",
+      "code_postal": "39025",
+      "nom": "El Ogla",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1303",
+      "code_postal": "39026",
+      "nom": "Mih Ouansa",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1304",
+      "code_postal": "39027",
+      "nom": "El Mghair",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1305",
+      "code_postal": "39028",
+      "nom": "Djamaa",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1306",
+      "code_postal": "39029",
+      "nom": "Oum Touyour",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1307",
+      "code_postal": "39030",
+      "nom": "Sidi Amrane",
+      "wilaya_id": "39"
+    },
+    {
+      "id": "1308",
+      "code_postal": "40001",
+      "nom": "Khenchela",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1309",
+      "code_postal": "40002",
+      "nom": "Mtoussa",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1310",
+      "code_postal": "40003",
+      "nom": "Kais",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1311",
+      "code_postal": "40004",
+      "nom": "Baghai",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1312",
+      "code_postal": "40005",
+      "nom": "El Hamma",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1313",
+      "code_postal": "40006",
+      "nom": "Ain Touila",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1314",
+      "code_postal": "40007",
+      "nom": "Taouzianat",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1315",
+      "code_postal": "40008",
+      "nom": "Bouhmama",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1316",
+      "code_postal": "40009",
+      "nom": "El Oueldja",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1317",
+      "code_postal": "40010",
+      "nom": "Remila",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1318",
+      "code_postal": "40011",
+      "nom": "Cherchar",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1319",
+      "code_postal": "40012",
+      "nom": "Djellal",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1320",
+      "code_postal": "40013",
+      "nom": "Babar",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1321",
+      "code_postal": "40014",
+      "nom": "Tamza",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1322",
+      "code_postal": "40015",
+      "nom": "Ensigha",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1323",
+      "code_postal": "40016",
+      "nom": "Ouled Rechache",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1324",
+      "code_postal": "40017",
+      "nom": "El Mahmal",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1325",
+      "code_postal": "40018",
+      "nom": "Msara",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1326",
+      "code_postal": "40019",
+      "nom": "Yabous",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1327",
+      "code_postal": "40020",
+      "nom": "Khirane",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1328",
+      "code_postal": "40021",
+      "nom": "Chelia",
+      "wilaya_id": "40"
+    },
+    {
+      "id": "1329",
+      "code_postal": "41001",
+      "nom": "Souk Ahras",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1330",
+      "code_postal": "41002",
+      "nom": "Sedrata",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1331",
+      "code_postal": "41003",
+      "nom": "Hanancha",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1332",
+      "code_postal": "41004",
+      "nom": "Mechroha",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1333",
+      "code_postal": "41005",
+      "nom": "Ouled Driss",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1334",
+      "code_postal": "41006",
+      "nom": "Tiffech",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1335",
+      "code_postal": "41007",
+      "nom": "Zaarouria",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1336",
+      "code_postal": "41008",
+      "nom": "Taoura",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1337",
+      "code_postal": "41009",
+      "nom": "Drea",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1338",
+      "code_postal": "41010",
+      "nom": "Haddada",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1339",
+      "code_postal": "41011",
+      "nom": "Khedara",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1340",
+      "code_postal": "41012",
+      "nom": "Merahna",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1341",
+      "code_postal": "41013",
+      "nom": "Ouled Moumen",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1342",
+      "code_postal": "41014",
+      "nom": "Bir Bouhouche",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1343",
+      "code_postal": "41015",
+      "nom": "Mdaourouche",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1344",
+      "code_postal": "41016",
+      "nom": "Oum El Adhaim",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1345",
+      "code_postal": "41017",
+      "nom": "Ain Zana",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1346",
+      "code_postal": "41018",
+      "nom": "Ain Soltane",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1347",
+      "code_postal": "41019",
+      "nom": "Quillen",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1348",
+      "code_postal": "41020",
+      "nom": "Sidi Fredj",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1349",
+      "code_postal": "41021",
+      "nom": "Safel El Ouiden",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1350",
+      "code_postal": "41022",
+      "nom": "Ragouba",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1351",
+      "code_postal": "41023",
+      "nom": "Khemissa",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1352",
+      "code_postal": "41024",
+      "nom": "Oued Keberit",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1353",
+      "code_postal": "41025",
+      "nom": "Terraguelt",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1354",
+      "code_postal": "41026",
+      "nom": "Zouabi",
+      "wilaya_id": "41"
+    },
+    {
+      "id": "1355",
+      "code_postal": "42001",
+      "nom": "Tipaza",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1356",
+      "code_postal": "42002",
+      "nom": "Menaceur",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1357",
+      "code_postal": "42003",
+      "nom": "Larhat",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1358",
+      "code_postal": "42004",
+      "nom": "Douaouda",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1359",
+      "code_postal": "42005",
+      "nom": "Bourkika",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1360",
+      "code_postal": "42006",
+      "nom": "Khemisti",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1361",
+      "code_postal": "42010",
+      "nom": "Aghabal",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1362",
+      "code_postal": "42012",
+      "nom": "Hadjout",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1363",
+      "code_postal": "42013",
+      "nom": "Sidi Amar",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1364",
+      "code_postal": "42014",
+      "nom": "Gouraya",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1365",
+      "code_postal": "42015",
+      "nom": "Nodor",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1366",
+      "code_postal": "42016",
+      "nom": "Chaiba",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1367",
+      "code_postal": "42017",
+      "nom": "Ain Tagourait",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1368",
+      "code_postal": "42022",
+      "nom": "Cherchel",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1369",
+      "code_postal": "42023",
+      "nom": "Damous",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1370",
+      "code_postal": "42024",
+      "nom": "Meurad",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1371",
+      "code_postal": "42025",
+      "nom": "Fouka",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1372",
+      "code_postal": "42026",
+      "nom": "Bou Ismail",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1373",
+      "code_postal": "42027",
+      "nom": "Ahmer El Ain",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1374",
+      "code_postal": "42030",
+      "nom": "Bou Haroun",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1375",
+      "code_postal": "42032",
+      "nom": "Sidi Ghiles",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1376",
+      "code_postal": "42033",
+      "nom": "Messelmoun",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1377",
+      "code_postal": "42034",
+      "nom": "Sidi Rached",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1378",
+      "code_postal": "42035",
+      "nom": "Kolea",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1379",
+      "code_postal": "42036",
+      "nom": "Attatba",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1380",
+      "code_postal": "42040",
+      "nom": "Sidi Semiane",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1381",
+      "code_postal": "42041",
+      "nom": "Beni Milleuk",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1382",
+      "code_postal": "42042",
+      "nom": "Hadjerat Ennous",
+      "wilaya_id": "42"
+    },
+    {
+      "id": "1383",
+      "code_postal": "43001",
+      "nom": "Mila",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1384",
+      "code_postal": "43002",
+      "nom": "Ferdjioua",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1385",
+      "code_postal": "43003",
+      "nom": "Chelghoum Laid",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1386",
+      "code_postal": "43004",
+      "nom": "Oued Athmenia",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1387",
+      "code_postal": "43005",
+      "nom": "Ain Mellouk",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1388",
+      "code_postal": "43006",
+      "nom": "Telerghma",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1389",
+      "code_postal": "43007",
+      "nom": "Oued Seguen",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1390",
+      "code_postal": "43008",
+      "nom": "Tadjenanet",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1391",
+      "code_postal": "43009",
+      "nom": "Benyahia Abderrahmane",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1392",
+      "code_postal": "43010",
+      "nom": "Oued Endja",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1393",
+      "code_postal": "43011",
+      "nom": "Ahmed Rachedi",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1394",
+      "code_postal": "43012",
+      "nom": "Ouled Khalouf",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1395",
+      "code_postal": "43013",
+      "nom": "Tiberguent",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1396",
+      "code_postal": "43014",
+      "nom": "Bouhatem",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1397",
+      "code_postal": "43015",
+      "nom": "Rouached",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1398",
+      "code_postal": "43016",
+      "nom": "Tessala Lamatai",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1399",
+      "code_postal": "43017",
+      "nom": "Grarem Gouga",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1400",
+      "code_postal": "43018",
+      "nom": "Sidi Merouane",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1401",
+      "code_postal": "43019",
+      "nom": "Tassadane Haddada",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1402",
+      "code_postal": "43020",
+      "nom": "Derradji Bousselah",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1403",
+      "code_postal": "43021",
+      "nom": "Minar Zarza",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1404",
+      "code_postal": "43022",
+      "nom": "Amira Arras",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1405",
+      "code_postal": "43023",
+      "nom": "Terrai Bainen",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1406",
+      "code_postal": "43024",
+      "nom": "Hamala",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1407",
+      "code_postal": "43025",
+      "nom": "Ain Tine",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1408",
+      "code_postal": "43026",
+      "nom": "El Mechira",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1409",
+      "code_postal": "43027",
+      "nom": "Sidi Khelifa",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1410",
+      "code_postal": "43028",
+      "nom": "Zeghaia",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1411",
+      "code_postal": "43029",
+      "nom": "Elayadi Barbes",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1412",
+      "code_postal": "43030",
+      "nom": "Ain Beida Harriche",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1413",
+      "code_postal": "43031",
+      "nom": "Yahia Beniguecha",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1414",
+      "code_postal": "43032",
+      "nom": "Chigara",
+      "wilaya_id": "43"
+    },
+    {
+      "id": "1415",
+      "code_postal": "44001",
+      "nom": "Ain Defla",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1416",
+      "code_postal": "44002",
+      "nom": "Miliana",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1417",
+      "code_postal": "44003",
+      "nom": "Boumedfaa",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1418",
+      "code_postal": "44004",
+      "nom": "Khemis Miliana",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1419",
+      "code_postal": "44005",
+      "nom": "Hammam Righa",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1420",
+      "code_postal": "44006",
+      "nom": "Arib",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1421",
+      "code_postal": "44007",
+      "nom": "Djelida",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1422",
+      "code_postal": "44008",
+      "nom": "El Amra",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1423",
+      "code_postal": "44009",
+      "nom": "Bourached",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1424",
+      "code_postal": "44010",
+      "nom": "El Attaf",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1425",
+      "code_postal": "44011",
+      "nom": "El Abadia",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1426",
+      "code_postal": "44012",
+      "nom": "Djendel",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1427",
+      "code_postal": "44013",
+      "nom": "Oued Chorfa",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1428",
+      "code_postal": "44014",
+      "nom": "Ain Lechiakh",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1429",
+      "code_postal": "44015",
+      "nom": "Oued Djemaa",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1430",
+      "code_postal": "44016",
+      "nom": "Rouina",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1431",
+      "code_postal": "44017",
+      "nom": "Zeddine",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1432",
+      "code_postal": "44018",
+      "nom": "El Hassania",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1433",
+      "code_postal": "44019",
+      "nom": "Bir Ouled Khelifa",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1434",
+      "code_postal": "44020",
+      "nom": "Ain Soltane",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1435",
+      "code_postal": "44021",
+      "nom": "Tarik Ibn Ziad",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1436",
+      "code_postal": "44022",
+      "nom": "Bordj Emir Khaled",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1437",
+      "code_postal": "44023",
+      "nom": "Ain Torki",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1438",
+      "code_postal": "44024",
+      "nom": "Sidi Lakhdar",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1439",
+      "code_postal": "44025",
+      "nom": "Ben Allal",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1440",
+      "code_postal": "44026",
+      "nom": "Ain Benian",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1441",
+      "code_postal": "44027",
+      "nom": "Hoceinia",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1442",
+      "code_postal": "44028",
+      "nom": "Barbouche",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1443",
+      "code_postal": "44029",
+      "nom": "Djemaa Ouled Chikh",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1444",
+      "code_postal": "44030",
+      "nom": "Mekhatria",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1445",
+      "code_postal": "44031",
+      "nom": "Bathia",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1446",
+      "code_postal": "44032",
+      "nom": "Tachta Zegagha",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1447",
+      "code_postal": "44033",
+      "nom": "Ain Bouyahia",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1448",
+      "code_postal": "44034",
+      "nom": "El Maine",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1449",
+      "code_postal": "44035",
+      "nom": "Tiberkanine",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1450",
+      "code_postal": "44036",
+      "nom": "Belaas",
+      "wilaya_id": "44"
+    },
+    {
+      "id": "1451",
+      "code_postal": "45001",
+      "nom": "Naama",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1452",
+      "code_postal": "45002",
+      "nom": "Mechria",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1453",
+      "code_postal": "45003",
+      "nom": "Ain Sefra",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1454",
+      "code_postal": "45004",
+      "nom": "Tiout",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1455",
+      "code_postal": "45005",
+      "nom": "Sfissifa",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1456",
+      "code_postal": "45006",
+      "nom": "Moghrar",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1457",
+      "code_postal": "45007",
+      "nom": "Assela",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1458",
+      "code_postal": "45008",
+      "nom": "Djeniane Bourzeg",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1459",
+      "code_postal": "45009",
+      "nom": "Ain Ben Khelil",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1460",
+      "code_postal": "45010",
+      "nom": "Makman Ben Amer",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1461",
+      "code_postal": "45011",
+      "nom": "Kasdir",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1462",
+      "code_postal": "45012",
+      "nom": "El Biod",
+      "wilaya_id": "45"
+    },
+    {
+      "id": "1463",
+      "code_postal": "46001",
+      "nom": "Ain Temouchent",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1464",
+      "code_postal": "46002",
+      "nom": "Chaabet El Ham",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1465",
+      "code_postal": "46003",
+      "nom": "Ain Kihal",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1466",
+      "code_postal": "46004",
+      "nom": "Hammam Bouhadjar",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1467",
+      "code_postal": "46005",
+      "nom": "Bou Zedjar",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1468",
+      "code_postal": "46006",
+      "nom": "Oued Berkeche",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1469",
+      "code_postal": "46007",
+      "nom": "Aghlal",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1470",
+      "code_postal": "46008",
+      "nom": "Terga",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1471",
+      "code_postal": "46009",
+      "nom": "Ain El Arbaa",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1472",
+      "code_postal": "46010",
+      "nom": "Tamzoura",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1473",
+      "code_postal": "46011",
+      "nom": "Chentouf",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1474",
+      "code_postal": "46012",
+      "nom": "Sidi Ben Adda",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1475",
+      "code_postal": "46013",
+      "nom": "Aoubellil",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1476",
+      "code_postal": "46014",
+      "nom": "El Malah",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1477",
+      "code_postal": "46015",
+      "nom": "Sidi Boumediene",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1478",
+      "code_postal": "46016",
+      "nom": "Oued Sabah",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1479",
+      "code_postal": "46017",
+      "nom": "Ouled Boudjemaa",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1480",
+      "code_postal": "46018",
+      "nom": "Ain Tolba",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1481",
+      "code_postal": "46019",
+      "nom": "El Amria",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1482",
+      "code_postal": "46020",
+      "nom": "Hassi El Ghella",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1483",
+      "code_postal": "46021",
+      "nom": "Hassasna",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1484",
+      "code_postal": "46022",
+      "nom": "Ouled Kihal",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1485",
+      "code_postal": "46023",
+      "nom": "Beni Saf",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1486",
+      "code_postal": "46024",
+      "nom": "Sidi Safi",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1487",
+      "code_postal": "46025",
+      "nom": "Oulhaca El Gheraba",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1488",
+      "code_postal": "46026",
+      "nom": "Tadmaya",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1489",
+      "code_postal": "46027",
+      "nom": "El Emir Abdelkader",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1490",
+      "code_postal": "46028",
+      "nom": "El Messaid",
+      "wilaya_id": "46"
+    },
+    {
+      "id": "1491",
+      "code_postal": "47001",
+      "nom": "Ghardaia",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1492",
+      "code_postal": "47002",
+      "nom": "El Meniaa",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1493",
+      "code_postal": "47003",
+      "nom": "Dhayet Bendhahoua",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1494",
+      "code_postal": "47004",
+      "nom": "Berriane",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1495",
+      "code_postal": "47005",
+      "nom": "Metlili",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1496",
+      "code_postal": "47006",
+      "nom": "El Guerrara",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1497",
+      "code_postal": "47007",
+      "nom": "El Atteuf",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1498",
+      "code_postal": "47008",
+      "nom": "Zelfana",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1499",
+      "code_postal": "47009",
+      "nom": "Sebseb",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1500",
+      "code_postal": "47010",
+      "nom": "Bounoura",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1501",
+      "code_postal": "47011",
+      "nom": "Hassi Fehal",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1502",
+      "code_postal": "47012",
+      "nom": "Hassi Gara",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1503",
+      "code_postal": "47013",
+      "nom": "Mansoura",
+      "wilaya_id": "47"
+    },
+    {
+      "id": "1504",
+      "code_postal": "48001",
+      "nom": "Relizane",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1505",
+      "code_postal": "48002",
+      "nom": "Oued Rhiou",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1506",
+      "code_postal": "48003",
+      "nom": "Belaassel Bouzegza",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1507",
+      "code_postal": "48004",
+      "nom": "Sidi Saada",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1508",
+      "code_postal": "48005",
+      "nom": "Ouled Aiche",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1509",
+      "code_postal": "48006",
+      "nom": "Sidi Lazreg",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1510",
+      "code_postal": "48007",
+      "nom": "El Hamadna",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1511",
+      "code_postal": "48008",
+      "nom": "Sidi Mhamed Ben Ali",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1512",
+      "code_postal": "48009",
+      "nom": "Mediouna",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1513",
+      "code_postal": "48010",
+      "nom": "Sidi Khettab",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1514",
+      "code_postal": "48011",
+      "nom": "Ammi Moussa",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1515",
+      "code_postal": "48012",
+      "nom": "Zemmoura",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1516",
+      "code_postal": "48013",
+      "nom": "Beni Dergoun",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1517",
+      "code_postal": "48014",
+      "nom": "Djidiouia",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1518",
+      "code_postal": "48015",
+      "nom": "El Guettar",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1519",
+      "code_postal": "48016",
+      "nom": "Hamri",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1520",
+      "code_postal": "48017",
+      "nom": "El Matmar",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1521",
+      "code_postal": "48018",
+      "nom": "Sidi Mhamed Ben Aouda",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1522",
+      "code_postal": "48019",
+      "nom": "Ain Tarek",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1523",
+      "code_postal": "48020",
+      "nom": "Oued Essalem",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1524",
+      "code_postal": "48021",
+      "nom": "Ouarizane",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1525",
+      "code_postal": "48022",
+      "nom": "Mazouna",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1526",
+      "code_postal": "48023",
+      "nom": "Kalaa",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1527",
+      "code_postal": "48024",
+      "nom": "Ain Rahma",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1528",
+      "code_postal": "48025",
+      "nom": "Yellel",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1529",
+      "code_postal": "48026",
+      "nom": "Oued El Djemaa",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1530",
+      "code_postal": "48027",
+      "nom": "Ramka",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1531",
+      "code_postal": "48028",
+      "nom": "Mendes",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1532",
+      "code_postal": "48029",
+      "nom": "Lahlef",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1533",
+      "code_postal": "48030",
+      "nom": "Beni Zentis",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1534",
+      "code_postal": "48031",
+      "nom": "Souk El Haad",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1535",
+      "code_postal": "48032",
+      "nom": "Dar Ben Abdellah",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1536",
+      "code_postal": "48033",
+      "nom": "El Hassi",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1537",
+      "code_postal": "48034",
+      "nom": "Had Echkalla",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1538",
+      "code_postal": "48035",
+      "nom": "Bendaoud",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1539",
+      "code_postal": "48036",
+      "nom": "El Ouldja",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1540",
+      "code_postal": "48037",
+      "nom": "Merdja Sidi Abed",
+      "wilaya_id": "48"
+    },
+    {
+      "id": "1541",
+      "code_postal": "48038",
+      "nom": "Ouled Sidi Mihoub",
+      "wilaya_id": "48"
+    }
+  ]

--- a/json/communesAvecLatLong.json
+++ b/json/communesAvecLatLong.json
@@ -1,7 +1,11618 @@
-/**
-@author Metourni Noureddine
-@description commune avec latitude & longitude
-@remarque LatLng = (0,0) => Position GPS inconnue par Google
-*/
-
-[{"longitude":-0.1869644,"latitude":27.9716342,"nom":"Adrar","id":"1","wilaya_id":"1","code_postal":"01001"},{"longitude":-0.2457477,"latitude":27.4257241,"nom":"Tamest","id":"2","wilaya_id":"1","code_postal":"01002"},{"longitude":-0.259657,"latitude":29.0195565,"nom":"Charouine","id":"3","wilaya_id":"1","code_postal":"01003"},{"longitude":-1.5208624,"latitude":25.2759633,"nom":"Reggane","id":"4","wilaya_id":"1","code_postal":"01004"},{"longitude":1.4869856,"latitude":26.936237,"nom":"Tit","id":"6","wilaya_id":"1","code_postal":"01006"},{"longitude":0.3724815,"latitude":29.5827395,"nom":"Ksar Kaddour","id":"7","wilaya_id":"1","code_postal":"01007"},{"longitude":-0.2186041,"latitude":28.3504036,"nom":"Tsabit","id":"8","wilaya_id":"1","code_postal":"01008"},{"longitude":0.2385387,"latitude":29.2609217,"nom":"Timimoun","id":"9","wilaya_id":"1","code_postal":"01009"},{"longitude":0.2455769,"latitude":29.4206093,"nom":"Ouled Said","id":"10","wilaya_id":"1","code_postal":"01010"},{"longitude":-0.2010233,"latitude":27.2263135,"nom":"Zaouiet Kounta","id":"11","wilaya_id":"1","code_postal":"01011"},{"longitude":1.0729818,"latitude":26.9752935,"nom":"Aoulef","id":"12","wilaya_id":"1","code_postal":"01012"},{"longitude":1.0442502,"latitude":27.0225931,"nom":"Timokten","id":"13","wilaya_id":"1","code_postal":"01013"},{"longitude":-0.266699,"latitude":27.7664008,"nom":"Tamentit","id":"14","wilaya_id":"1","code_postal":"01014"},{"longitude":-0.3042778,"latitude":27.6490194,"nom":"Fenoughil","id":"15","wilaya_id":"1","code_postal":"01015"},{"longitude":0.7105267,"latitude":29.711749,"nom":"Tinerkouk","id":"16","wilaya_id":"1","code_postal":"01016"},{"longitude":-0.0877444,"latitude":27.0363493,"nom":"Sali","id":"18","wilaya_id":"1","code_postal":"01018"},{"longitude":1.3613923,"latitude":26.7018955,"nom":"Akabli","id":"19","wilaya_id":"1","code_postal":"01019"},{"longitude":-0.1448182,"latitude":28.5972281,"nom":"Metarfa","id":"20","wilaya_id":"1","code_postal":"01020"},{"longitude":-0.2807577,"latitude":27.8515174,"nom":"O Ahmed Timmi","id":"21","wilaya_id":"1","code_postal":"01021"},{"longitude":-0.4246315,"latitude":27.9554196,"nom":"Bouda","id":"22","wilaya_id":"1","code_postal":"01022"},{"longitude":0.25,"latitude":28.75,"nom":"Aougrout","id":"23","wilaya_id":"1","code_postal":"01023"},{"longitude":-0.9056623,"latitude":23.760643,"nom":"B Badji Mokhtar","id":"25","wilaya_id":"1","code_postal":"01025"},{"longitude":-0.1729106,"latitude":28.211617,"nom":"Sbaa","id":"26","wilaya_id":"1","code_postal":"01026"},{"longitude":-0.08869479999999999,"latitude":29.4237071,"nom":"Ouled Aissa","id":"27","wilaya_id":"1","code_postal":"01027"},{"longitude":1.6760691,"latitude":20.8948062,"nom":"Timiaouine","id":"28","wilaya_id":"1","code_postal":"01028"},{"longitude":1.3083685,"latitude":36.147424,"nom":"Chlef","id":"29","wilaya_id":"2","code_postal":"02001"},{"longitude":1.3180042,"latitude":36.5049038,"nom":"Tenes","id":"30","wilaya_id":"2","code_postal":"02002"},{"longitude":1.374987,"latitude":36.3540039,"nom":"Benairia","id":"31","wilaya_id":"2","code_postal":"02003"},{"longitude":1.5693045,"latitude":36.08997910000001,"nom":"El Karimia","id":"32","wilaya_id":"2","code_postal":"02004"},{"longitude":1.1377008,"latitude":36.3254557,"nom":"Tadjna","id":"33","wilaya_id":"2","code_postal":"02005"},{"longitude":0.9223635999999998,"latitude":36.2459846,"nom":"Taougrite","id":"34","wilaya_id":"2","code_postal":"02006"},{"longitude":1.5402327,"latitude":36.4914417,"nom":"Beni Haoua","id":"35","wilaya_id":"2","code_postal":"02007"},{"longitude":1.110123,"latitude":36.1100346,"nom":"Sobha","id":"36","wilaya_id":"2","code_postal":"02008"},{"longitude":1.4918235,"latitude":36.1126987,"nom":"Harchoun","id":"37","wilaya_id":"2","code_postal":"02009"},{"longitude":1.236999,"latitude":36.2316052,"nom":"Ouled Fares","id":"38","wilaya_id":"2","code_postal":"02010"},{"longitude":1.3469247,"latitude":36.4505105,"nom":"Sidi Akacha","id":"39","wilaya_id":"2","code_postal":"02011"},{"longitude":1.1209121,"latitude":36.0569401,"nom":"Boukadir","id":"40","wilaya_id":"2","code_postal":"02012"},{"longitude":1.5015009,"latitude":36.2753891,"nom":"Beni Rached","id":"41","wilaya_id":"2","code_postal":"02013"},{"longitude":1.0849592,"latitude":36.4288223,"nom":"Talassa","id":"42","wilaya_id":"2","code_postal":"02014"},{"longitude":1.0514312,"latitude":36.2449244,"nom":"Herenfa","id":"43","wilaya_id":"2","code_postal":"02015"},{"longitude":1.4531355,"latitude":36.5033408,"nom":"Oued Goussine","id":"44","wilaya_id":"2","code_postal":"02016"},{"longitude":0.8508345,"latitude":36.25736,"nom":"Dahra","id":"45","wilaya_id":"2","code_postal":"02017"},{"longitude":1.4918235,"latitude":36.2212775,"nom":"Ouled Abbes","id":"46","wilaya_id":"2","code_postal":"02018"},{"longitude":1.4241426,"latitude":36.0591718,"nom":"Sendjas","id":"47","wilaya_id":"2","code_postal":"02019"},{"longitude":1.4628042,"latitude":36.4058679,"nom":"Zeboudja","id":"48","wilaya_id":"2","code_postal":"02020"},{"longitude":1.2313618,"latitude":36.1047797,"nom":"Oued Sly","id":"49","wilaya_id":"2","code_postal":"02021"},{"longitude":1.1929114,"latitude":36.4088563,"nom":"Abou El Hassen","id":"50","wilaya_id":"2","code_postal":"02022"},{"longitude":0.9175911,"latitude":36.4031597,"nom":"El Marsa","id":"51","wilaya_id":"2","code_postal":"02023"},{"longitude":1.2409799,"latitude":36.1589988,"nom":"Chettia","id":"52","wilaya_id":"2","code_postal":"02024"},{"longitude":1.0957418,"latitude":36.4922766,"nom":"Sidi Abderrahmane","id":"53","wilaya_id":"2","code_postal":"02025"},{"longitude":1.0083637,"latitude":36.3536988,"nom":"Moussadek","id":"54","wilaya_id":"2","code_postal":"02026"},{"longitude":1.3469247,"latitude":36.0165552,"nom":"El Hadjadj","id":"55","wilaya_id":"2","code_postal":"02027"},{"longitude":1.3855161,"latitude":36.2767832,"nom":"Labiod Medjadja","id":"56","wilaya_id":"2","code_postal":"02028"},{"longitude":1.5499211,"latitude":36.1988388,"nom":"Oued Fodda","id":"57","wilaya_id":"2","code_postal":"02029"},{"longitude":1.2698475,"latitude":36.0173924,"nom":"Ouled Ben Abdelkader","id":"58","wilaya_id":"2","code_postal":"02030"},{"longitude":1.2417743,"latitude":36.3397492,"nom":"Bouzghaia","id":"59","wilaya_id":"2","code_postal":"02031"},{"longitude":0.9778686,"latitude":36.1608508,"nom":"Ain Merane","id":"60","wilaya_id":"2","code_postal":"02032"},{"longitude":1.4144827,"latitude":36.200509,"nom":"Oum Drou","id":"61","wilaya_id":"2","code_postal":"02033"},{"longitude":1.5789994,"latitude":36.447678,"nom":"Breira","id":"62","wilaya_id":"2","code_postal":"02034"},{"longitude":2.8694065,"latitude":33.7972551,"nom":"Laghouat","id":"64","wilaya_id":"3","code_postal":"03001"},{"longitude":3.1328011,"latitude":33.7847662,"nom":"Ksar El Hirane","id":"65","wilaya_id":"3","code_postal":"03002"},{"longitude":3.0050628,"latitude":33.7516533,"nom":"Benacer Ben Chohra","id":"66","wilaya_id":"3","code_postal":"03003"},{"longitude":3.014781,"latitude":34.127625,"nom":"Sidi Makhlouf","id":"67","wilaya_id":"3","code_postal":"03004"},{"longitude":3.5483781,"latitude":33.4186197,"nom":"Hassi Delaa","id":"68","wilaya_id":"3","code_postal":"03005"},{"longitude":3.2684215,"latitude":32.9349916,"nom":"Hassi R Mel","id":"69","wilaya_id":"3","code_postal":"03006"},{"longitude":2.2999821,"latitude":33.7946585,"nom":"Ain Mahdi","id":"70","wilaya_id":"3","code_postal":"03007"},{"longitude":2.5272209,"latitude":33.8794929,"nom":"Tadjmout","id":"71","wilaya_id":"3","code_postal":"03008"},{"longitude":2.7954106,"latitude":33.7453939,"nom":"Kheneg","id":"72","wilaya_id":"3","code_postal":"03009"},{"longitude":1.9416877,"latitude":34.2962822,"nom":"Gueltat Sidi Saad","id":"73","wilaya_id":"3","code_postal":"03010"},{"longitude":1.55,"latitude":34.1666669,"nom":"Ain Sidi Ali","id":"74","wilaya_id":"3","code_postal":"03011"},{"longitude":1.7502311,"latitude":33.9500722,"nom":"Brida","id":"76","wilaya_id":"3","code_postal":"03013"},{"longitude":2.1437968,"latitude":33.9299401,"nom":"El Ghicha","id":"77","wilaya_id":"3","code_postal":"03014"},{"longitude":1.5992068,"latitude":33.9571296,"nom":"Hadj Mechri","id":"78","wilaya_id":"3","code_postal":"03015"},{"longitude":1.8635409,"latitude":33.8689577,"nom":"Taouiala","id":"80","wilaya_id":"3","code_postal":"03017"},{"longitude":2.101217,"latitude":33.503632,"nom":"Tadjrouna","id":"81","wilaya_id":"3","code_postal":"03018"},{"longitude":2.1008486,"latitude":34.10748640000001,"nom":"Aflou","id":"82","wilaya_id":"3","code_postal":"03019"},{"longitude":2.990057,"latitude":33.824559,"nom":"El Assafia","id":"83","wilaya_id":"3","code_postal":"03020"},{"longitude":2.3166669,"latitude":34.1666669,"nom":"Oued Morra","id":"84","wilaya_id":"3","code_postal":"03021"},{"longitude":2.8694065,"latitude":33.7972551,"nom":"Oued M Zi","id":"85","wilaya_id":"3","code_postal":"03022"},{"longitude":2.263468,"latitude":34.342998,"nom":"Sidi Bouzid","id":"87","wilaya_id":"3","code_postal":"03024"},{"longitude":7.1197867,"latitude":35.873056,"nom":"Oum El Bouaghi","id":"88","wilaya_id":"4","code_postal":"04001"},{"longitude":7.392173400000001,"latitude":35.7981327,"nom":"Ain Beida","id":"89","wilaya_id":"4","code_postal":"04002"},{"longitude":6.556988199999999,"latitude":36.0189518,"nom":"Ainmlila","id":"90","wilaya_id":"4","code_postal":"04003"},{"longitude":7.7185878,"latitude":35.7940171,"nom":"Behir Chergui","id":"91","wilaya_id":"4","code_postal":"04004"},{"longitude":6.904832099999999,"latitude":36.1101777,"nom":"El Amiria","id":"92","wilaya_id":"4","code_postal":"04005"},{"longitude":6.770813800000001,"latitude":36.09368440000001,"nom":"Sigus","id":"93","wilaya_id":"4","code_postal":"04006"},{"longitude":7.788537400000001,"latitude":35.6653463,"nom":"El Belala","id":"94","wilaya_id":"4","code_postal":"04007"},{"longitude":7.181719999999999,"latitude":35.9425396,"nom":"Ain Babouche","id":"95","wilaya_id":"4","code_postal":"04008"},{"longitude":7.3759671,"latitude":35.9144973,"nom":"Berriche","id":"96","wilaya_id":"4","code_postal":"04009"},{"longitude":6.471658,"latitude":36.0669135,"nom":"Ouled Hamla","id":"97","wilaya_id":"4","code_postal":"04010"},{"longitude":7.549096999999999,"latitude":35.4582557,"nom":"Dhala","id":"98","wilaya_id":"4","code_postal":"04011"},{"longitude":6.6905458,"latitude":35.9302835,"nom":"Ain Kercha","id":"99","wilaya_id":"4","code_postal":"04012"},{"longitude":6.7413706,"latitude":35.9355726,"nom":"Hanchir Toumghani","id":"100","wilaya_id":"4","code_postal":"04013"},{"longitude":7.507127099999999,"latitude":35.6635514,"nom":"El Djazia","id":"101","wilaya_id":"4","code_postal":"04014"},{"longitude":7.300360400000001,"latitude":35.6640497,"nom":"Fkirina","id":"103","wilaya_id":"4","code_postal":"04016"},{"longitude":6.386442799999999,"latitude":35.9414231,"nom":"Souk Naamane","id":"104","wilaya_id":"4","code_postal":"04017"},{"longitude":6.5143087,"latitude":35.8477341,"nom":"Ouled Zouai","id":"107","wilaya_id":"4","code_postal":"04020"},{"longitude":6.2925058,"latitude":35.8966254,"nom":"Bir Chouhada","id":"108","wilaya_id":"4","code_postal":"04021"},{"longitude":7.2571943,"latitude":36.0841308,"nom":"Ksar Sbahi","id":"109","wilaya_id":"4","code_postal":"04022"},{"longitude":7.347604800000001,"latitude":35.5700761,"nom":"Oued Nini","id":"110","wilaya_id":"4","code_postal":"04023"},{"longitude":7.6710889,"latitude":35.6328262,"nom":"Meskiana","id":"111","wilaya_id":"4","code_postal":"04024"},{"longitude":6.8708486,"latitude":35.9736892,"nom":"Ain Fekroune","id":"112","wilaya_id":"4","code_postal":"04025"},{"longitude":7.666667,"latitude":35.716667,"nom":"Rahia","id":"113","wilaya_id":"4","code_postal":"04026"},{"longitude":6.935674,"latitude":35.6842651,"nom":"Ain Zitoun","id":"114","wilaya_id":"4","code_postal":"04027"},{"longitude":6.6223966,"latitude":35.9245726,"nom":"El Harmilia","id":"116","wilaya_id":"4","code_postal":"04029"},{"longitude":6.173911599999999,"latitude":35.5610218,"nom":"Batna","id":"117","wilaya_id":"5","code_postal":"05001"},{"longitude":6.2163597,"latitude":35.0777543,"nom":"Ghassira","id":"118","wilaya_id":"5","code_postal":"05002"},{"longitude":5.8775964,"latitude":35.269936,"nom":"Maafa","id":"119","wilaya_id":"5","code_postal":"05003"},{"longitude":5.909275399999999,"latitude":35.6287744,"nom":"Merouana","id":"120","wilaya_id":"5","code_postal":"05004"},{"longitude":6.173911599999999,"latitude":35.6917406,"nom":"Seriana","id":"121","wilaya_id":"5","code_postal":"05005"},{"longitude":6.089103199999999,"latitude":35.1280608,"nom":"Menaa","id":"122","wilaya_id":"5","code_postal":"05006"},{"longitude":6.386442799999999,"latitude":35.6371149,"nom":"El Madher","id":"123","wilaya_id":"5","code_postal":"05007"},{"longitude":6.258836899999999,"latitude":35.5130278,"nom":"Tazoult","id":"124","wilaya_id":"5","code_postal":"05008"},{"longitude":5.593239,"latitude":35.5566128,"nom":"Ngaous","id":"125","wilaya_id":"5","code_postal":"05009"},{"longitude":5.572229699999999,"latitude":35.73196009999999,"nom":"Guigba","id":"126","wilaya_id":"5","code_postal":"05010"},{"longitude":6.5463156,"latitude":35.2684424,"nom":"Inoughissen","id":"127","wilaya_id":"5","code_postal":"05011"},{"longitude":6.3438785,"latitude":35.552203,"nom":"Ouyoun El Assafir","id":"128","wilaya_id":"5","code_postal":"05012"},{"longitude":6.3013432,"latitude":35.6851412,"nom":"Djerma","id":"129","wilaya_id":"5","code_postal":"05013"},{"longitude":5.3520876,"latitude":35.1408805,"nom":"Bitam","id":"130","wilaya_id":"5","code_postal":"05014"},{"longitude":5.183641,"latitude":35.3687479,"nom":"Metkaouak","id":"131","wilaya_id":"5","code_postal":"05015"},{"longitude":6.354516900000001,"latitude":35.3005374,"nom":"Arris","id":"132","wilaya_id":"5","code_postal":"05016"},{"longitude":6.471658,"latitude":34.9766508,"nom":"Kimmel","id":"133","wilaya_id":"5","code_postal":"05017"},{"longitude":5.624766999999999,"latitude":35.28194149999999,"nom":"Tilatou","id":"134","wilaya_id":"5","code_postal":"05018"},{"longitude":6.0044121,"latitude":35.8308281,"nom":"Ain Djasser","id":"135","wilaya_id":"5","code_postal":"05019"},{"longitude":5.7932008,"latitude":35.8411857,"nom":"Ouled Selam","id":"136","wilaya_id":"5","code_postal":"05020"},{"longitude":5.9621106,"latitude":35.0905115,"nom":"Tigherghar","id":"137","wilaya_id":"5","code_postal":"05021"},{"longitude":6.429036,"latitude":35.8088781,"nom":"Ain Yagout","id":"138","wilaya_id":"5","code_postal":"05022"},{"longitude":6.2269763,"latitude":35.6127845,"nom":"Fesdis","id":"139","wilaya_id":"5","code_postal":"05023"},{"longitude":5.593239,"latitude":35.4255853,"nom":"Sefiane","id":"140","wilaya_id":"5","code_postal":"05024"},{"longitude":5.6563119,"latitude":35.7280419,"nom":"Rahbat","id":"141","wilaya_id":"5","code_postal":"05025"},{"longitude":6.2694608,"latitude":35.1955527,"nom":"Tighanimine","id":"142","wilaya_id":"5","code_postal":"05026"},{"longitude":5.7826597,"latitude":35.6349128,"nom":"Lemsane","id":"143","wilaya_id":"5","code_postal":"05027"},{"longitude":5.8775964,"latitude":35.706563,"nom":"Ksar Belezma","id":"144","wilaya_id":"5","code_postal":"05028"},{"longitude":5.5407299,"latitude":35.3295911,"nom":"Seggana","id":"145","wilaya_id":"5","code_postal":"05029"},{"longitude":6.429036,"latitude":35.285666,"nom":"Ichmoul","id":"146","wilaya_id":"5","code_postal":"05030"},{"longitude":6.5143087,"latitude":35.368536,"nom":"Foum Toub","id":"147","wilaya_id":"5","code_postal":"05031"},{"longitude":6.0467429,"latitude":35.3928288,"nom":"Beni Foudhala El Hakania","id":"148","wilaya_id":"5","code_postal":"05032"},{"longitude":6.0044121,"latitude":35.6567552,"nom":"Oued El Ma","id":"149","wilaya_id":"5","code_postal":"05033"},{"longitude":5.751047499999999,"latitude":35.71267030000001,"nom":"Talkhamt","id":"150","wilaya_id":"5","code_postal":"05034"},{"longitude":6.0996978,"latitude":35.26989530000001,"nom":"Bouzina","id":"151","wilaya_id":"5","code_postal":"05035"},{"longitude":6.5996963,"latitude":35.6256226,"nom":"Chemora","id":"152","wilaya_id":"5","code_postal":"05036"},{"longitude":6.0467429,"latitude":35.5238393,"nom":"Oued Chaaba","id":"153","wilaya_id":"5","code_postal":"05037"},{"longitude":5.7932008,"latitude":35.5799027,"nom":"Taxlent","id":"154","wilaya_id":"5","code_postal":"05038"},{"longitude":5.456813299999999,"latitude":35.6391967,"nom":"Gosbat","id":"155","wilaya_id":"5","code_postal":"05039"},{"longitude":5.751047499999999,"latitude":35.450956,"nom":"Ouled Aouf","id":"156","wilaya_id":"5","code_postal":"05040"},{"longitude":5.551228,"latitude":35.4930629,"nom":"Boumagueur","id":"157","wilaya_id":"5","code_postal":"05041"},{"longitude":5.2893433,"latitude":35.3845934,"nom":"Barika","id":"158","wilaya_id":"5","code_postal":"05042"},{"longitude":5.3311652,"latitude":35.51389229999999,"nom":"Djezzar","id":"159","wilaya_id":"5","code_postal":"05043"},{"longitude":6.3438785,"latitude":35.1588259,"nom":"Tkout","id":"160","wilaya_id":"5","code_postal":"05044"},{"longitude":5.9198387,"latitude":35.3991089,"nom":"Ain Touta","id":"161","wilaya_id":"5","code_postal":"05045"},{"longitude":5.9198387,"latitude":35.5301294,"nom":"Hidoussa","id":"162","wilaya_id":"5","code_postal":"05046"},{"longitude":6.183332999999999,"latitude":35.25,"nom":"Teniet El Abed","id":"163","wilaya_id":"5","code_postal":"05047"},{"longitude":6.3438785,"latitude":35.4212867,"nom":"Oued Taga","id":"164","wilaya_id":"5","code_postal":"05048"},{"longitude":6.685198199999999,"latitude":35.5337671,"nom":"Ouled Fadel","id":"165","wilaya_id":"5","code_postal":"05049"},{"longitude":6.5143087,"latitude":35.4995081,"nom":"Timgad","id":"166","wilaya_id":"5","code_postal":"05050"},{"longitude":5.5827334,"latitude":35.6770224,"nom":"Ras El Aioun","id":"167","wilaya_id":"5","code_postal":"05051"},{"longitude":6.131492799999999,"latitude":35.2135627,"nom":"Chir","id":"168","wilaya_id":"5","code_postal":"05052"},{"longitude":5.6668306,"latitude":35.5859034,"nom":"Ouled Si Slimane","id":"169","wilaya_id":"5","code_postal":"05053"},{"longitude":6.1102943,"latitude":35.8037586,"nom":"Zanat El Beida","id":"170","wilaya_id":"5","code_postal":"05054"},{"longitude":5.1640605,"latitude":35.1270837,"nom":"Amdoukal","id":"171","wilaya_id":"5","code_postal":"05055"},{"longitude":5.1640605,"latitude":35.4774579,"nom":"Ouled Ammar","id":"172","wilaya_id":"5","code_postal":"05056"},{"longitude":5.951539899999999,"latitude":35.7790971,"nom":"El Hassi","id":"173","wilaya_id":"5","code_postal":"05057"},{"longitude":6.3013432,"latitude":35.7721622,"nom":"Lazrou","id":"174","wilaya_id":"5","code_postal":"05058"},{"longitude":6.5143087,"latitude":35.7173264,"nom":"Boumia","id":"175","wilaya_id":"5","code_postal":"05059"},{"longitude":6.642433,"latitude":35.7538128,"nom":"Boulhilat","id":"176","wilaya_id":"5","code_postal":"05060"},{"longitude":6.120892599999999,"latitude":35.3344502,"nom":"Larbaa","id":"177","wilaya_id":"5","code_postal":"05061"},{"longitude":5.056733299999999,"latitude":36.7508896,"nom":"Bejaia","id":"178","wilaya_id":"6","code_postal":"06001"},{"longitude":4.903334,"latitude":36.6421159,"nom":"Amizour","id":"179","wilaya_id":"6","code_postal":"06002"},{"longitude":4.8647019,"latitude":36.55740470000001,"nom":"Ferraoun","id":"180","wilaya_id":"6","code_postal":"06003"},{"longitude":4.738101299999999,"latitude":36.72021549999999,"nom":"Taourirt Ighil","id":"181","wilaya_id":"6","code_postal":"06004"},{"longitude":4.5108862,"latitude":36.5135502,"nom":"Chelata","id":"182","wilaya_id":"6","code_postal":"06005"},{"longitude":4.667343199999999,"latitude":36.3983738,"nom":"Tamokra","id":"183","wilaya_id":"6","code_postal":"06006"},{"longitude":4.7749158,"latitude":36.6151583,"nom":"Timzrit","id":"184","wilaya_id":"6","code_postal":"06007"},{"longitude":5.3360215,"latitude":36.6256524,"nom":"Souk El Thenine","id":"185","wilaya_id":"6","code_postal":"06008"},{"longitude":4.710368,"latitude":36.56340700000001,"nom":"Mcisna","id":"186","wilaya_id":"6","code_postal":"06009"},{"longitude":4.70189,"latitude":36.6301547,"nom":"Thinabdher","id":"187","wilaya_id":"6","code_postal":"06010"},{"longitude":5.1550882,"latitude":36.6682721,"nom":"Tichi","id":"188","wilaya_id":"6","code_postal":"06011"},{"longitude":4.823662,"latitude":36.61496100000001,"nom":"Semaoun","id":"189","wilaya_id":"6","code_postal":"06012"},{"longitude":5.0268199,"latitude":36.5404083,"nom":"Kendira","id":"190","wilaya_id":"6","code_postal":"06013"},{"longitude":4.6963496,"latitude":36.6667365,"nom":"Tifra","id":"191","wilaya_id":"6","code_postal":"06014"},{"longitude":4.5048939,"latitude":36.4624661,"nom":"Ighram","id":"192","wilaya_id":"6","code_postal":"06015"},{"longitude":4.632585300000001,"latitude":36.4774626,"nom":"Amalou","id":"193","wilaya_id":"6","code_postal":"06016"},{"longitude":4.4702131,"latitude":36.3379865,"nom":"Ighil Ali","id":"194","wilaya_id":"6","code_postal":"06017"},{"longitude":4.8899903,"latitude":36.7490754,"nom":"Toudja","id":"196","wilaya_id":"6","code_postal":"06019"},{"longitude":5.305989600000001,"latitude":36.5646323,"nom":"Darguina","id":"197","wilaya_id":"6","code_postal":"06020"},{"longitude":4.7159414,"latitude":36.6122273,"nom":"Sidi Ayad","id":"198","wilaya_id":"6","code_postal":"06021"},{"longitude":5.2440622,"latitude":36.6369535,"nom":"Aokas","id":"199","wilaya_id":"6","code_postal":"06022"},{"longitude":4.810767999999999,"latitude":36.5729271,"nom":"Beni Djellil","id":"200","wilaya_id":"6","code_postal":"06023"},{"longitude":4.669073,"latitude":36.6942103,"nom":"Adekar","id":"201","wilaya_id":"6","code_postal":"06024"},{"longitude":4.5334783,"latitude":36.45901610000001,"nom":"Akbou","id":"202","wilaya_id":"6","code_postal":"06025"},{"longitude":4.6868666,"latitude":36.5446668,"nom":"Seddouk","id":"203","wilaya_id":"6","code_postal":"06026"},{"longitude":4.4079213,"latitude":36.3878041,"nom":"Tazmalt","id":"204","wilaya_id":"6","code_postal":"06027"},{"longitude":4.5315029,"latitude":36.3831907,"nom":"Ait Rizine","id":"205","wilaya_id":"6","code_postal":"06028"},{"longitude":4.6152308,"latitude":36.5956868,"nom":"Chemini","id":"206","wilaya_id":"6","code_postal":"06029"},{"longitude":4.6295394,"latitude":36.6114371,"nom":"Souk Oufella","id":"207","wilaya_id":"6","code_postal":"06030"},{"longitude":5.284117699999999,"latitude":36.5519437,"nom":"Taskriout","id":"208","wilaya_id":"6","code_postal":"06031"},{"longitude":4.6513509,"latitude":36.6127223,"nom":"Tibane","id":"209","wilaya_id":"6","code_postal":"06032"},{"longitude":5.0078451,"latitude":36.68767950000001,"nom":"Tala Hamza","id":"210","wilaya_id":"6","code_postal":"06033"},{"longitude":4.971239,"latitude":36.5729398,"nom":"Barbacha","id":"211","wilaya_id":"6","code_postal":"06034"},{"longitude":4.707061599999999,"latitude":36.839681,"nom":"Beni Ksila","id":"212","wilaya_id":"6","code_postal":"06035"},{"longitude":4.5334783,"latitude":36.45901610000001,"nom":"Ouzallaguen","id":"213","wilaya_id":"6","code_postal":"06036"},{"longitude":4.6853713,"latitude":36.4452822,"nom":"Bouhamza","id":"214","wilaya_id":"6","code_postal":"06037"},{"longitude":4.414018899999999,"latitude":36.4463751,"nom":"Beni Melikeche","id":"215","wilaya_id":"6","code_postal":"06038"},{"longitude":4.691548399999999,"latitude":36.6090172,"nom":"Sidi Aich","id":"216","wilaya_id":"6","code_postal":"06039"},{"longitude":4.854562899999999,"latitude":36.6803265,"nom":"El Kseur","id":"217","wilaya_id":"6","code_postal":"06040"},{"longitude":5.3834854,"latitude":36.6282747,"nom":"Melbou","id":"218","wilaya_id":"6","code_postal":"06041"},{"longitude":4.6243989,"latitude":36.6307165,"nom":"Akfadou","id":"219","wilaya_id":"6","code_postal":"06042"},{"longitude":4.6714261,"latitude":36.6090298,"nom":"Leflaye","id":"220","wilaya_id":"6","code_postal":"06043"},{"longitude":5.278127599999999,"latitude":36.4931377,"nom":"Kherrata","id":"221","wilaya_id":"6","code_postal":"06044"},{"longitude":5.2475518,"latitude":36.4295337,"nom":"Draa Kaid","id":"222","wilaya_id":"6","code_postal":"06045"},{"longitude":5.4253757,"latitude":36.5833119,"nom":"Tamridjet","id":"223","wilaya_id":"6","code_postal":"06046"},{"longitude":5.2302325,"latitude":36.5463433,"nom":"Ait Smail","id":"224","wilaya_id":"6","code_postal":"06047"},{"longitude":5.0880839,"latitude":36.6698411,"nom":"Boukhelifa","id":"225","wilaya_id":"6","code_postal":"06048"},{"longitude":5.2176317,"latitude":36.6134619,"nom":"Tizi Nberber","id":"226","wilaya_id":"6","code_postal":"06049"},{"longitude":4.7578312,"latitude":36.5070785,"nom":"Beni Maouch","id":"227","wilaya_id":"6","code_postal":"06050"},{"longitude":4.9795489,"latitude":36.7093915,"nom":"Oued Ghir","id":"228","wilaya_id":"6","code_postal":"06051"},{"longitude":4.4111706,"latitude":36.3506738,"nom":"Boudjellil","id":"229","wilaya_id":"6","code_postal":"06052"},{"longitude":5.751047499999999,"latitude":34.8370347,"nom":"Biskra","id":"230","wilaya_id":"7","code_postal":"07001"},{"longitude":5.772120399999999,"latitude":34.5936352,"nom":"Oumache","id":"231","wilaya_id":"7","code_postal":"07002"},{"longitude":5.7932008,"latitude":34.9669667,"nom":"Branis","id":"232","wilaya_id":"7","code_postal":"07003"},{"longitude":5.8775964,"latitude":34.87499,"nom":"Chetma","id":"233","wilaya_id":"7","code_postal":"07004"},{"longitude":5.1015225,"latitude":34.4466834,"nom":"Ouled Djellal","id":"234","wilaya_id":"7","code_postal":"07005"},{"longitude":4.645035,"latitude":33.9767317,"nom":"Ras El Miaad","id":"235","wilaya_id":"7","code_postal":"07006"},{"longitude":4.976654,"latitude":34.1415665,"nom":"Besbes","id":"236","wilaya_id":"7","code_postal":"07007"},{"longitude":4.9558696,"latitude":34.3862694,"nom":"Sidi Khaled","id":"237","wilaya_id":"7","code_postal":"07008"},{"longitude":5.1015225,"latitude":34.6234715,"nom":"Doucen","id":"238","wilaya_id":"7","code_postal":"07009"},{"longitude":4.8105955,"latitude":34.679416,"nom":"Ech Chaiba","id":"239","wilaya_id":"7","code_postal":"07010"},{"longitude":5.9198387,"latitude":34.7849283,"nom":"Sidi Okba","id":"240","wilaya_id":"7","code_postal":"07011"},{"longitude":6.0255738,"latitude":34.9337006,"nom":"Mchouneche","id":"241","wilaya_id":"7","code_postal":"07012"},{"longitude":6.0255738,"latitude":34.5813972,"nom":"El Haouch","id":"242","wilaya_id":"7","code_postal":"07013"},{"longitude":6.195132,"latitude":34.6611164,"nom":"Ain Naga","id":"243","wilaya_id":"7","code_postal":"07014"},{"longitude":6.5038787,"latitude":34.6878171,"nom":"Zeribet El Oued","id":"244","wilaya_id":"7","code_postal":"07015"},{"longitude":6.5356449,"latitude":34.4668996,"nom":"El Feidh","id":"245","wilaya_id":"7","code_postal":"07016"},{"longitude":5.6668306,"latitude":35.192365,"nom":"El Kantara","id":"246","wilaya_id":"7","code_postal":"07017"},{"longitude":5.8353837,"latitude":35.1843701,"nom":"Ain Zaatout","id":"247","wilaya_id":"7","code_postal":"07018"},{"longitude":5.5827334,"latitude":34.9768124,"nom":"El Outaya","id":"248","wilaya_id":"7","code_postal":"07019"},{"longitude":5.7089241,"latitude":35.1026843,"nom":"Djemorah","id":"249","wilaya_id":"7","code_postal":"07020"},{"longitude":5.3802134,"latitude":34.7291803,"nom":"Tolga","id":"250","wilaya_id":"7","code_postal":"07021"},{"longitude":5.3961323,"latitude":34.636809,"nom":"Lioua","id":"251","wilaya_id":"7","code_postal":"07022"},{"longitude":5.4253757,"latitude":34.7528735,"nom":"Lichana","id":"252","wilaya_id":"7","code_postal":"07023"},{"longitude":5.5407299,"latitude":34.5381104,"nom":"Ourlal","id":"253","wilaya_id":"7","code_postal":"07024"},{"longitude":5.624766999999999,"latitude":34.5784354,"nom":"Mlili","id":"254","wilaya_id":"7","code_postal":"07025"},{"longitude":5.299795899999999,"latitude":34.7583947,"nom":"Foughala","id":"255","wilaya_id":"7","code_postal":"07026"},{"longitude":5.3573194,"latitude":34.7062854,"nom":"Bordj Ben Azzouz","id":"256","wilaya_id":"7","code_postal":"07027"},{"longitude":6.2800864,"latitude":34.8328954,"nom":"Meziraa","id":"257","wilaya_id":"7","code_postal":"07028"},{"longitude":5.4665823,"latitude":34.7208281,"nom":"Bouchagroun","id":"258","wilaya_id":"7","code_postal":"07029"},{"longitude":5.4463322,"latitude":34.5533941,"nom":"Mekhadma","id":"259","wilaya_id":"7","code_postal":"07030"},{"longitude":5.284393,"latitude":34.705819,"nom":"El Ghrous","id":"260","wilaya_id":"7","code_postal":"07031"},{"longitude":5.624766999999999,"latitude":34.7989056,"nom":"El Hadjab","id":"261","wilaya_id":"7","code_postal":"07032"},{"longitude":-2.2143231,"latitude":31.6182492,"nom":"Bechar","id":"263","wilaya_id":"8","code_postal":"08001"},{"longitude":-1.0598107,"latitude":29.2555013,"nom":"Ouled Khoudir","id":"265","wilaya_id":"8","code_postal":"08003"},{"longitude":-2.945068,"latitude":31.5517416,"nom":"Meridja","id":"266","wilaya_id":"8","code_postal":"08004"},{"longitude":-1.1269073,"latitude":29.3188506,"nom":"Timoudi","id":"267","wilaya_id":"8","code_postal":"08005"},{"longitude":-2.2581158,"latitude":31.9330162,"nom":"Lahmar","id":"268","wilaya_id":"8","code_postal":"08006"},{"longitude":-2.1671288,"latitude":30.1324686,"nom":"Beni Abbes","id":"269","wilaya_id":"8","code_postal":"08007"},{"longitude":-1.604054,"latitude":29.580219,"nom":"Beni Ikhlef","id":"270","wilaya_id":"8","code_postal":"08008"},{"longitude":-2.7375454,"latitude":30.9322468,"nom":"Mechraa Houari B","id":"271","wilaya_id":"8","code_postal":"08009"},{"longitude":-2.4233417,"latitude":31.5569451,"nom":"Kenedsa","id":"272","wilaya_id":"8","code_postal":"08010"},{"longitude":-2.2907524,"latitude":30.452471,"nom":"Igli","id":"273","wilaya_id":"8","code_postal":"08011"},{"longitude":-3.2557384,"latitude":29.4055402,"nom":"Tabalbala","id":"274","wilaya_id":"8","code_postal":"08012"},{"longitude":-2.0322172,"latitude":30.9201058,"nom":"Taghit","id":"275","wilaya_id":"8","code_postal":"08013"},{"longitude":-1.8269573,"latitude":29.8515849,"nom":"El Ouata","id":"276","wilaya_id":"8","code_postal":"08014"},{"longitude":-2.462651,"latitude":31.923019,"nom":"Boukais","id":"277","wilaya_id":"8","code_postal":"08015"},{"longitude":-2.2175179,"latitude":32.023248,"nom":"Mogheul","id":"278","wilaya_id":"8","code_postal":"08016"},{"longitude":-2.7431421,"latitude":31.0102291,"nom":"Abadla","id":"279","wilaya_id":"8","code_postal":"08017"},{"longitude":-1.4386366,"latitude":29.4624252,"nom":"Kerzaz","id":"280","wilaya_id":"8","code_postal":"08018"},{"longitude":-0.9725085,"latitude":29.1006615,"nom":"Ksabi","id":"281","wilaya_id":"8","code_postal":"08019"},{"longitude":-1.9,"latitude":29.916667,"nom":"Tamtert","id":"282","wilaya_id":"8","code_postal":"08020"},{"longitude":-1.2457898,"latitude":32.0492426,"nom":"Beni Ounif","id":"283","wilaya_id":"8","code_postal":"08021"},{"longitude":2.8005677,"latitude":36.4798683,"nom":"Blida","id":"284","wilaya_id":"9","code_postal":"09001"},{"longitude":3.0085182,"latitude":36.5782346,"nom":"Chebli","id":"285","wilaya_id":"9","code_postal":"09002"},{"longitude":2.9875565,"latitude":36.5181119,"nom":"Bouinan","id":"286","wilaya_id":"9","code_postal":"09003"},{"longitude":2.7680247,"latitude":36.5665832,"nom":"Oued El Alleug","id":"287","wilaya_id":"9","code_postal":"09004"},{"longitude":2.8726747,"latitude":36.5047206,"nom":"Ouled Yaich","id":"288","wilaya_id":"9","code_postal":"09007"},{"longitude":2.9076094,"latitude":36.4336226,"nom":"Chrea","id":"289","wilaya_id":"9","code_postal":"09008"},{"longitude":2.6090043,"latitude":36.4404969,"nom":"El Affroun","id":"290","wilaya_id":"9","code_postal":"09010"},{"longitude":2.728219,"latitude":36.4594664,"nom":"Chiffa","id":"291","wilaya_id":"9","code_postal":"09011"},{"longitude":2.9975593,"latitude":36.4205919,"nom":"Hammam Melouane","id":"292","wilaya_id":"9","code_postal":"09012"},{"longitude":2.847737,"latitude":36.6078803,"nom":"Ben Khlil","id":"293","wilaya_id":"9","code_postal":"09013"},{"longitude":2.9076094,"latitude":36.4984753,"nom":"Soumaa","id":"294","wilaya_id":"9","code_postal":"09014"},{"longitude":2.6785092,"latitude":36.4713985,"nom":"Mouzaia","id":"295","wilaya_id":"9","code_postal":"09016"},{"longitude":3.2483058,"latitude":36.5329164,"nom":"Souhane","id":"296","wilaya_id":"9","code_postal":"09017"},{"longitude":3.2281983,"latitude":36.6197872,"nom":"Meftah","id":"297","wilaya_id":"9","code_postal":"09018"},{"longitude":3.1277854,"latitude":36.5145296,"nom":"Ouled Selama","id":"298","wilaya_id":"9","code_postal":"09019"},{"longitude":2.9076094,"latitude":36.5848591,"nom":"Boufarik","id":"299","wilaya_id":"9","code_postal":"09020"},{"longitude":3.1578875,"latitude":36.5893036,"nom":"Larbaa","id":"300","wilaya_id":"9","code_postal":"09021"},{"longitude":2.5495112,"latitude":36.4201457,"nom":"Oued Djer","id":"301","wilaya_id":"9","code_postal":"09022"},{"longitude":2.8277963,"latitude":36.5435922,"nom":"Beni Tamou","id":"302","wilaya_id":"9","code_postal":"09023"},{"longitude":2.797901,"latitude":36.4254203,"nom":"Bouarfa","id":"303","wilaya_id":"9","code_postal":"09024"},{"longitude":2.8527235,"latitude":36.5268016,"nom":"Beni Mered","id":"304","wilaya_id":"9","code_postal":"09025"},{"longitude":3.1077277,"latitude":36.47183770000001,"nom":"Bougara","id":"305","wilaya_id":"9","code_postal":"09026"},{"longitude":2.8826534,"latitude":36.4828707,"nom":"Guerrouaou","id":"306","wilaya_id":"9","code_postal":"09027"},{"longitude":2.6487087,"latitude":36.3963569,"nom":"Ain Romana","id":"307","wilaya_id":"9","code_postal":"09028"},{"longitude":3.2633918,"latitude":36.5810764,"nom":"Djebabra","id":"308","wilaya_id":"9","code_postal":"09029"},{"longitude":3.8962348,"latitude":36.37763,"nom":"Bouira","id":"309","wilaya_id":"10","code_postal":"10001"},{"longitude":4.0388918,"latitude":36.357569,"nom":"El Asnam","id":"310","wilaya_id":"10","code_postal":"10002"},{"longitude":3.4296446,"latitude":36.4630499,"nom":"Guerrouma","id":"311","wilaya_id":"10","code_postal":"10003"},{"longitude":3.637535,"latitude":36.3882249,"nom":"Souk El Khemis","id":"312","wilaya_id":"10","code_postal":"10004"},{"longitude":3.6927531,"latitude":36.5200245,"nom":"Kadiria","id":"313","wilaya_id":"10","code_postal":"10005"},{"longitude":4.2128337,"latitude":36.2541817,"nom":"Hanif","id":"314","wilaya_id":"10","code_postal":"10006"},{"longitude":3.7545828,"latitude":35.9997826,"nom":"Dirah","id":"315","wilaya_id":"10","code_postal":"10007"},{"longitude":3.8757119,"latitude":36.4494403,"nom":"Ait Laaziz","id":"316","wilaya_id":"10","code_postal":"10008"},{"longitude":3.9572374,"latitude":36.4251625,"nom":"Taghzout","id":"317","wilaya_id":"10","code_postal":"10009"},{"longitude":3.6319131,"latitude":36.2190042,"nom":"Raouraoua","id":"318","wilaya_id":"10","code_postal":"10010"},{"longitude":4.0491077,"latitude":36.0863547,"nom":"Mezdour","id":"319","wilaya_id":"10","code_postal":"10011"},{"longitude":4.0491077,"latitude":36.4328965,"nom":"Haizer","id":"320","wilaya_id":"10","code_postal":"10012"},{"longitude":3.5913939,"latitude":36.5662811,"nom":"Lakhdaria","id":"321","wilaya_id":"10","code_postal":"10013"},{"longitude":3.8693481,"latitude":36.4428933,"nom":"Maala","id":"322","wilaya_id":"10","code_postal":"10014"},{"longitude":3.8153696,"latitude":36.2199413,"nom":"El Hachimia","id":"323","wilaya_id":"10","code_postal":"10015"},{"longitude":3.7739869,"latitude":36.495896,"nom":"Aomar","id":"324","wilaya_id":"10","code_postal":"10016"},{"longitude":4.3256918,"latitude":36.3691831,"nom":"Chorfa","id":"325","wilaya_id":"10","code_postal":"10017"},{"longitude":3.9736961,"latitude":36.0817064,"nom":"Bordj Oukhriss","id":"326","wilaya_id":"10","code_postal":"10018"},{"longitude":4.1616143,"latitude":36.3749965,"nom":"El Adjiba","id":"327","wilaya_id":"10","code_postal":"10019"},{"longitude":3.7801961,"latitude":36.0914921,"nom":"El Hakimia","id":"328","wilaya_id":"10","code_postal":"10020"},{"longitude":3.6015207,"latitude":36.3174072,"nom":"El Khebouzia","id":"329","wilaya_id":"10","code_postal":"10021"},{"longitude":4.0491077,"latitude":36.259821,"nom":"Ahl El Ksar","id":"330","wilaya_id":"10","code_postal":"10022"},{"longitude":3.4902391,"latitude":36.5692761,"nom":"Bouderbala","id":"331","wilaya_id":"10","code_postal":"10023"},{"longitude":3.5306765,"latitude":36.4817207,"nom":"Zbarbar","id":"332","wilaya_id":"10","code_postal":"10024"},{"longitude":3.7943157,"latitude":36.3655637,"nom":"Ain El Hadjar","id":"333","wilaya_id":"10","code_postal":"10025"},{"longitude":3.7130493,"latitude":36.454596,"nom":"Djebahia","id":"334","wilaya_id":"10","code_postal":"10026"},{"longitude":4.346237299999999,"latitude":36.4332801,"nom":"Aghbalou","id":"335","wilaya_id":"10","code_postal":"10027"},{"longitude":3.9470396,"latitude":35.9811329,"nom":"Taguedit","id":"336","wilaya_id":"10","code_postal":"10028"},{"longitude":3.8146526,"latitude":36.4081721,"nom":"Ain Turk","id":"337","wilaya_id":"10","code_postal":"10029"},{"longitude":4.2538452,"latitude":36.4257962,"nom":"Saharidj","id":"338","wilaya_id":"10","code_postal":"10030"},{"longitude":3.5765977,"latitude":36.1305919,"nom":"Dechmia","id":"339","wilaya_id":"10","code_postal":"10031"},{"longitude":3.4619838,"latitude":36.0738504,"nom":"Ridane","id":"340","wilaya_id":"10","code_postal":"10032"},{"longitude":4.0899911,"latitude":36.3450193,"nom":"Bechloul","id":"341","wilaya_id":"10","code_postal":"10033"},{"longitude":3.3691241,"latitude":36.5295755,"nom":"Boukram","id":"342","wilaya_id":"10","code_postal":"10034"},{"longitude":3.7232005,"latitude":36.4002383,"nom":"Ain Bessam","id":"343","wilaya_id":"10","code_postal":"10035"},{"longitude":3.5711466,"latitude":36.2641708,"nom":"Bir Ghbalou","id":"344","wilaya_id":"10","code_postal":"10036"},{"longitude":4.264103,"latitude":36.3713916,"nom":"Mchedallah","id":"345","wilaya_id":"10","code_postal":"10037"},{"longitude":3.6901552,"latitude":36.1492231,"nom":"Sour El Ghozlane","id":"346","wilaya_id":"10","code_postal":"10038"},{"longitude":3.551855,"latitude":36.0335667,"nom":"Maamora","id":"347","wilaya_id":"10","code_postal":"10039"},{"longitude":4.0899911,"latitude":36.1717506,"nom":"Ouled Rached","id":"348","wilaya_id":"10","code_postal":"10040"},{"longitude":3.753666299999999,"latitude":36.3019154,"nom":"Ain Laloui","id":"349","wilaya_id":"10","code_postal":"10041"},{"longitude":3.8451731,"latitude":35.9191859,"nom":"Hadjera Zerga","id":"350","wilaya_id":"10","code_postal":"10042"},{"longitude":4.2948884,"latitude":36.2945728,"nom":"Ath Mansour","id":"351","wilaya_id":"10","code_postal":"10043"},{"longitude":3.6116494,"latitude":36.4360848,"nom":"El Mokrani","id":"352","wilaya_id":"10","code_postal":"10044"},{"longitude":3.9266502,"latitude":36.2638925,"nom":"Oued El Berdi","id":"353","wilaya_id":"10","code_postal":"10045"},{"longitude":5.5258107,"latitude":22.7888209,"nom":"Tamanrasset","id":"354","wilaya_id":"11","code_postal":"11001"},{"longitude":4.0695454,"latitude":22.1877766,"nom":"Abalessa","id":"355","wilaya_id":"11","code_postal":"11002"},{"longitude":1.9050391,"latitude":27.1077421,"nom":"In Ghar","id":"356","wilaya_id":"11","code_postal":"11003"},{"longitude":5.7693847,"latitude":19.5708544,"nom":"In Guezzam","id":"357","wilaya_id":"11","code_postal":"11004"},{"longitude":5.9343664,"latitude":23.8173973,"nom":"Idles","id":"358","wilaya_id":"11","code_postal":"11005"},{"longitude":3.4195527,"latitude":20.6784913,"nom":"Tinzaouatine","id":"360","wilaya_id":"11","code_postal":"11007"},{"longitude":2.4851463,"latitude":27.1927769,"nom":"In Salah","id":"361","wilaya_id":"11","code_postal":"11008"},{"longitude":3.4195527,"latitude":24.4857286,"nom":"In Amguel","id":"362","wilaya_id":"11","code_postal":"11009"},{"longitude":2.8452439,"latitude":27.3592301,"nom":"Foggaret Ezzaouia","id":"363","wilaya_id":"11","code_postal":"11010"},{"longitude":8.101092000000001,"latitude":35.4142494,"nom":"Tebessa","id":"364","wilaya_id":"12","code_postal":"12001"},{"longitude":8.057429899999999,"latitude":34.7610886,"nom":"Bir El Ater","id":"365","wilaya_id":"12","code_postal":"12002"},{"longitude":7.7471025,"latitude":35.2684831,"nom":"Cheria","id":"366","wilaya_id":"12","code_postal":"12003"},{"longitude":7.885766500000001,"latitude":35.8658056,"nom":"El Aouinet","id":"368","wilaya_id":"12","code_postal":"12005"},{"longitude":8.2801065,"latitude":35.2917478,"nom":"Lahouidjbet","id":"369","wilaya_id":"12","code_postal":"12006"},{"longitude":8.2076282,"latitude":34.9565856,"nom":"Safsaf El Ouesra","id":"370","wilaya_id":"12","code_postal":"12007"},{"longitude":7.953837799999999,"latitude":35.4512851,"nom":"Hammamet","id":"371","wilaya_id":"12","code_postal":"12008"},{"longitude":7.5193093,"latitude":34.4820138,"nom":"Negrine","id":"372","wilaya_id":"12","code_postal":"12009"},{"longitude":7.8096037,"latitude":35.3708248,"nom":"Bir El Mokadem","id":"373","wilaya_id":"12","code_postal":"12010"},{"longitude":8.3225325,"latitude":35.4998244,"nom":"El Kouif","id":"374","wilaya_id":"12","code_postal":"12011"},{"longitude":8.0110677,"latitude":35.6676901,"nom":"Morsott","id":"375","wilaya_id":"12","code_postal":"12012"},{"longitude":7.466666999999999,"latitude":35.183333,"nom":"El Ogla","id":"376","wilaya_id":"12","code_postal":"12013"},{"longitude":8.25,"latitude":35.366667,"nom":"Bekkaria","id":"380","wilaya_id":"12","code_postal":"12017"},{"longitude":8.0328815,"latitude":35.7476345,"nom":"Boukhadra","id":"381","wilaya_id":"12","code_postal":"12018"},{"longitude":8.1393179,"latitude":35.9489963,"nom":"Ouenza","id":"382","wilaya_id":"12","code_postal":"12019"},{"longitude":8.1693666,"latitude":35.2051832,"nom":"El Ma El Biodh","id":"383","wilaya_id":"12","code_postal":"12020"},{"longitude":8.300632199999999,"latitude":35.0104461,"nom":"Oum Ali","id":"384","wilaya_id":"12","code_postal":"12021"},{"longitude":7.766118799999998,"latitude":35.1170207,"nom":"Thlidjene","id":"385","wilaya_id":"12","code_postal":"12022"},{"longitude":8.266667,"latitude":35.633333,"nom":"Ain Zerga","id":"386","wilaya_id":"12","code_postal":"12023"},{"longitude":8.2295009,"latitude":35.7939476,"nom":"El Meridj","id":"387","wilaya_id":"12","code_postal":"12024"},{"longitude":7.4746519,"latitude":35.3497731,"nom":"Bedjene","id":"389","wilaya_id":"12","code_postal":"12026"},{"longitude":7.408395799999999,"latitude":34.5576609,"nom":"Ferkane","id":"391","wilaya_id":"12","code_postal":"12028"},{"longitude":-1.3180042,"latitude":34.88840620000001,"nom":"Tlemcen","id":"392","wilaya_id":"13","code_postal":"13001"},{"longitude":-1.4338047,"latitude":34.8650364,"nom":"Beni Mester","id":"393","wilaya_id":"13","code_postal":"13002"},{"longitude":-0.9557867,"latitude":34.92211040000001,"nom":"Ain Tallout","id":"394","wilaya_id":"13","code_postal":"13003"},{"longitude":-1.4289734,"latitude":35.0579657,"nom":"Remchi","id":"395","wilaya_id":"13","code_postal":"13004"},{"longitude":-1.2927151,"latitude":35.1158895,"nom":"El Fehoul","id":"396","wilaya_id":"13","code_postal":"13005"},{"longitude":-1.5281253,"latitude":34.8280257,"nom":"Sabra","id":"397","wilaya_id":"13","code_postal":"13006"},{"longitude":-1.8562218,"latitude":35.0962252,"nom":"Ghazaouet","id":"398","wilaya_id":"13","code_postal":"13007"},{"longitude":-1.9172519,"latitude":34.9218192,"nom":"Souani","id":"399","wilaya_id":"13","code_postal":"13008"},{"longitude":-1.8123324,"latitude":34.9592459,"nom":"Djebala","id":"400","wilaya_id":"13","code_postal":"13009"},{"longitude":-1.1520965,"latitude":34.6332195,"nom":"El Gor","id":"401","wilaya_id":"13","code_postal":"13010"},{"longitude":-1.1714782,"latitude":34.8290775,"nom":"Oued Chouly","id":"402","wilaya_id":"13","code_postal":"13011"},{"longitude":-1.2349683,"latitude":34.8768632,"nom":"Ain Fezza","id":"403","wilaya_id":"13","code_postal":"13012"},{"longitude":-1.0322845,"latitude":34.9049444,"nom":"Ouled Mimoun","id":"404","wilaya_id":"13","code_postal":"13013"},{"longitude":-1.375051,"latitude":35.0477582,"nom":"Ain Youcef","id":"406","wilaya_id":"13","code_postal":"13015"},{"longitude":-1.4479374,"latitude":35.0123044,"nom":"Zenata","id":"407","wilaya_id":"13","code_postal":"13016"},{"longitude":-1.5450766,"latitude":34.6593136,"nom":"Beni Snous","id":"408","wilaya_id":"13","code_postal":"13017"},{"longitude":-2.029768,"latitude":34.9640856,"nom":"Bab El Assa","id":"409","wilaya_id":"13","code_postal":"13018"},{"longitude":-1.5693045,"latitude":35.0177005,"nom":"Fellaoucene","id":"411","wilaya_id":"13","code_postal":"13020"},{"longitude":-1.4746046,"latitude":34.6794874,"nom":"Azails","id":"412","wilaya_id":"13","code_postal":"13021"},{"longitude":-1.3601865,"latitude":35.1563994,"nom":"Sebbaa Chioukh","id":"413","wilaya_id":"13","code_postal":"13022"},{"longitude":-1.2289576,"latitude":35.0739077,"nom":"Bensekrane","id":"415","wilaya_id":"13","code_postal":"13024"},{"longitude":-0.9313136,"latitude":35.0276866,"nom":"Ain Nehala","id":"416","wilaya_id":"13","code_postal":"13025"},{"longitude":-1.3710402,"latitude":34.9484714,"nom":"Hennaya","id":"417","wilaya_id":"13","code_postal":"13026"},{"longitude":-1.7349661,"latitude":34.8534497,"nom":"Maghnia","id":"418","wilaya_id":"13","code_postal":"13027"},{"longitude":-1.6444975,"latitude":34.8927177,"nom":"Hammam Boughrara","id":"419","wilaya_id":"13","code_postal":"13028"},{"longitude":-1.8952713,"latitude":35.0405953,"nom":"Souahlia","id":"420","wilaya_id":"13","code_postal":"13029"},{"longitude":-2.0518154,"latitude":35.0160389,"nom":"Msirda Fouaga","id":"421","wilaya_id":"13","code_postal":"13030"},{"longitude":-1.2554112,"latitude":34.2190891,"nom":"El Aricha","id":"423","wilaya_id":"13","code_postal":"13032"},{"longitude":-2.002836,"latitude":35.0168536,"nom":"Souk Thlata","id":"424","wilaya_id":"13","code_postal":"13033"},{"longitude":-1.1329034,"latitude":35.0638308,"nom":"Sidi Abdelli","id":"425","wilaya_id":"13","code_postal":"13034"},{"longitude":-1.332462,"latitude":34.6396882,"nom":"Sebdou","id":"426","wilaya_id":"13","code_postal":"13035"},{"longitude":-1.5559775,"latitude":35.082551,"nom":"Beni Ouarsous","id":"427","wilaya_id":"13","code_postal":"13036"},{"longitude":-1.6384287,"latitude":34.7755299,"nom":"Sidi Medjahed","id":"428","wilaya_id":"13","code_postal":"13037"},{"longitude":-1.7526648,"latitude":34.6496059,"nom":"Beni Boussaid","id":"429","wilaya_id":"13","code_postal":"13038"},{"longitude":-2.1352039,"latitude":35.0531381,"nom":"Marsa Ben Mhidi","id":"430","wilaya_id":"13","code_postal":"13039"},{"longitude":-1.7490143,"latitude":35.0097474,"nom":"Nedroma","id":"431","wilaya_id":"13","code_postal":"13040"},{"longitude":-1.5668811,"latitude":34.4458733,"nom":"Sidi Djillali","id":"432","wilaya_id":"13","code_postal":"13041"},{"longitude":-1.5123907,"latitude":34.7108589,"nom":"Beni Bahdel","id":"433","wilaya_id":"13","code_postal":"13042"},{"longitude":-1.6493532,"latitude":35.1789336,"nom":"Honaine","id":"435","wilaya_id":"13","code_postal":"13044"},{"longitude":-1.8391485,"latitude":35.049712,"nom":"Tianet","id":"436","wilaya_id":"13","code_postal":"13045"},{"longitude":-1.4978716,"latitude":34.9621354,"nom":"Ouled Riyah","id":"437","wilaya_id":"13","code_postal":"13046"},{"longitude":-1.571728,"latitude":34.7777862,"nom":"Bouhlou","id":"438","wilaya_id":"13","code_postal":"13047"},{"longitude":-1.5565831,"latitude":35.1725987,"nom":"Souk El Khemis","id":"439","wilaya_id":"13","code_postal":"13048"},{"longitude":-1.3879292,"latitude":34.7081886,"nom":"Ain Ghoraba","id":"440","wilaya_id":"13","code_postal":"13049"},{"longitude":-1.2975309,"latitude":34.92033420000001,"nom":"Chetouane","id":"441","wilaya_id":"13","code_postal":"13050"},{"longitude":-1.3565692,"latitude":34.8659187,"nom":"Mansourah","id":"442","wilaya_id":"13","code_postal":"13051"},{"longitude":-1.6784986,"latitude":35.0300112,"nom":"Ain Kebira","id":"444","wilaya_id":"13","code_postal":"13053"},{"longitude":1.3220322,"latitude":35.3673553,"nom":"Tiaret","id":"445","wilaya_id":"14","code_postal":"14001"},{"longitude":1.2049233,"latitude":35.1731543,"nom":"Medroussa","id":"446","wilaya_id":"14","code_postal":"14002"},{"longitude":1.5136009,"latitude":35.3563885,"nom":"Ain Bouchekif","id":"447","wilaya_id":"14","code_postal":"14003"},{"longitude":1.2253693,"latitude":35.56373689999999,"nom":"Sidi Ali Mellal","id":"448","wilaya_id":"14","code_postal":"14004"},{"longitude":1.6651379,"latitude":35.3530331,"nom":"Ain Zarit","id":"449","wilaya_id":"14","code_postal":"14005"},{"longitude":1.5450766,"latitude":34.8471273,"nom":"Ain Deheb","id":"450","wilaya_id":"14","code_postal":"14006"},{"longitude":0.9777269000000001,"latitude":35.2393277,"nom":"Sidi Bakhti","id":"451","wilaya_id":"14","code_postal":"14007"},{"longitude":1.2433848,"latitude":34.8919466,"nom":"Medrissa","id":"452","wilaya_id":"14","code_postal":"14008"},{"longitude":2.3172324,"latitude":34.9121227,"nom":"Zmalet El Emir Aek","id":"453","wilaya_id":"14","code_postal":"14009"},{"longitude":1.2337661,"latitude":35.2497888,"nom":"Mellakou","id":"456","wilaya_id":"14","code_postal":"14012"},{"longitude":1.4759356,"latitude":35.4157148,"nom":"Dahmouni","id":"457","wilaya_id":"14","code_postal":"14013"},{"longitude":1.0227145,"latitude":35.5313694,"nom":"Rahouia","id":"458","wilaya_id":"14","code_postal":"14014"},{"longitude":1.7587496,"latitude":35.4270876,"nom":"Mahdia","id":"459","wilaya_id":"14","code_postal":"14015"},{"longitude":1.4966619,"latitude":35.1781601,"nom":"Sougueur","id":"460","wilaya_id":"14","code_postal":"14016"},{"longitude":0.8794310999999999,"latitude":35.0604194,"nom":"Ain El Hadid","id":"462","wilaya_id":"14","code_postal":"14018"},{"longitude":1.4785205,"latitude":35.0917694,"nom":"Naima","id":"464","wilaya_id":"14","code_postal":"14020"},{"longitude":1.3270326,"latitude":35.3632425,"nom":"Meghila","id":"465","wilaya_id":"14","code_postal":"14021"},{"longitude":1.2578169,"latitude":35.39221,"nom":"Guertoufa","id":"466","wilaya_id":"14","code_postal":"14022"},{"longitude":1.5184418,"latitude":35.4714207,"nom":"Sidi Hosni","id":"467","wilaya_id":"14","code_postal":"14023"},{"longitude":0.8514301,"latitude":35.4443866,"nom":"Djillali Ben Amar","id":"468","wilaya_id":"14","code_postal":"14024"},{"longitude":1.6020337,"latitude":35.4580212,"nom":"Sebaine","id":"469","wilaya_id":"14","code_postal":"14025"},{"longitude":1.2758641,"latitude":35.1133168,"nom":"Tousnina","id":"470","wilaya_id":"14","code_postal":"14026"},{"longitude":1.0538252,"latitude":35.0617882,"nom":"Frenda","id":"471","wilaya_id":"14","code_postal":"14027"},{"longitude":1.0777723,"latitude":34.9238511,"nom":"Ain Kermes","id":"472","wilaya_id":"14","code_postal":"14028"},{"longitude":2.3172324,"latitude":35.2202319,"nom":"Ksar Chellala","id":"473","wilaya_id":"14","code_postal":"14029"},{"longitude":1.9710284,"latitude":35.4101241,"nom":"Rechaiga","id":"474","wilaya_id":"14","code_postal":"14030"},{"longitude":1.2283566,"latitude":35.3356113,"nom":"Tagdemt","id":"476","wilaya_id":"14","code_postal":"14032"},{"longitude":1.26705,"latitude":35.51192899999999,"nom":"Oued Lilli","id":"477","wilaya_id":"14","code_postal":"14033"},{"longitude":1.8733017,"latitude":35.460979,"nom":"Hamadia","id":"479","wilaya_id":"14","code_postal":"14035"},{"longitude":1.3047556,"latitude":34.8982002,"nom":"Chehaima","id":"480","wilaya_id":"14","code_postal":"14036"},{"longitude":0.6844213,"latitude":35.1056992,"nom":"Takhemaret","id":"481","wilaya_id":"14","code_postal":"14037"},{"longitude":1.1329034,"latitude":34.7992061,"nom":"Sidi Abderrahmane","id":"482","wilaya_id":"14","code_postal":"14038"},{"longitude":2.4826726,"latitude":35.2581419,"nom":"Serghine","id":"483","wilaya_id":"14","code_postal":"14039"},{"longitude":1.961246,"latitude":35.5581085,"nom":"Bougara","id":"484","wilaya_id":"14","code_postal":"14040"},{"longitude":1.266238,"latitude":35.5824151,"nom":"Tidda","id":"486","wilaya_id":"14","code_postal":"14042"},{"longitude":4.0593255,"latitude":36.7021906,"nom":"Tizi Ouzou","id":"487","wilaya_id":"15","code_postal":"15001"},{"longitude":4.2846246,"latitude":36.5650202,"nom":"Ain El Hammam","id":"488","wilaya_id":"15","code_postal":"15002"},{"longitude":4.3051542,"latitude":36.4995515,"nom":"Akbil","id":"489","wilaya_id":"15","code_postal":"15003"},{"longitude":4.3177067,"latitude":36.7584263,"nom":"Freha","id":"490","wilaya_id":"15","code_postal":"15004"},{"longitude":4.346237299999999,"latitude":36.6705552,"nom":"Souamaa","id":"491","wilaya_id":"15","code_postal":"15005"},{"longitude":4.0049301,"latitude":36.5447993,"nom":"Mechtrass","id":"492","wilaya_id":"15","code_postal":"15006"},{"longitude":4.1496093,"latitude":36.6613077,"nom":"Irdjen","id":"493","wilaya_id":"15","code_postal":"15007"},{"longitude":4.2653984,"latitude":36.8024218,"nom":"Timizart","id":"494","wilaya_id":"15","code_postal":"15008"},{"longitude":4.0624151,"latitude":36.7920474,"nom":"Makouda","id":"495","wilaya_id":"15","code_postal":"15009"},{"longitude":3.8146526,"latitude":36.5593675,"nom":"Draa El Mizan","id":"496","wilaya_id":"15","code_postal":"15010"},{"longitude":3.7760446,"latitude":36.5888512,"nom":"Tizi Ghenif","id":"497","wilaya_id":"15","code_postal":"15011"},{"longitude":3.9364126,"latitude":36.4995751,"nom":"Bounouh","id":"498","wilaya_id":"15","code_postal":"15012"},{"longitude":4.5255955,"latitude":36.8221623,"nom":"Ait Chaffaa","id":"499","wilaya_id":"15","code_postal":"15013"},{"longitude":3.8757119,"latitude":36.49264429999999,"nom":"Frikat","id":"500","wilaya_id":"15","code_postal":"15014"},{"longitude":4.0848789,"latitude":36.6636279,"nom":"Beni Aissi","id":"501","wilaya_id":"15","code_postal":"15015"},{"longitude":4.039156,"latitude":36.636975,"nom":"Beni Zmenzer","id":"502","wilaya_id":"15","code_postal":"15016"},{"longitude":4.3667907,"latitude":36.5404761,"nom":"Iferhounene","id":"503","wilaya_id":"15","code_postal":"15017"},{"longitude":4.3667907,"latitude":36.7343859,"nom":"Azazga","id":"504","wilaya_id":"15","code_postal":"15018"},{"longitude":4.442432,"latitude":36.5805668,"nom":"Iloula Oumalou","id":"505","wilaya_id":"15","code_postal":"15019"},{"longitude":4.4386329,"latitude":36.7339217,"nom":"Yakouren","id":"506","wilaya_id":"15","code_postal":"15020"},{"longitude":4.204093299999999,"latitude":36.63729319999999,"nom":"Larba Nait Irathen","id":"507","wilaya_id":"15","code_postal":"15021"},{"longitude":4.2087286,"latitude":36.6799518,"nom":"Tizi Rached","id":"508","wilaya_id":"15","code_postal":"15022"},{"longitude":4.583078899999999,"latitude":36.8015396,"nom":"Zekri","id":"509","wilaya_id":"15","code_postal":"15023"},{"longitude":4.175088,"latitude":36.7700939,"nom":"Ouaguenoun","id":"510","wilaya_id":"15","code_postal":"15024"},{"longitude":3.894797499999999,"latitude":36.5504491,"nom":"Ain Zaouia","id":"511","wilaya_id":"15","code_postal":"15025"},{"longitude":3.7790684,"latitude":36.6305931,"nom":"Mkira","id":"512","wilaya_id":"15","code_postal":"15026"},{"longitude":4.3256918,"latitude":36.6066637,"nom":"Ait Yahia","id":"513","wilaya_id":"15","code_postal":"15027"},{"longitude":4.1121615,"latitude":36.6077811,"nom":"Ait Mahmoud","id":"514","wilaya_id":"15","code_postal":"15028"},{"longitude":3.9572374,"latitude":36.6194358,"nom":"Maatka","id":"515","wilaya_id":"15","code_postal":"15029"},{"longitude":4.1820961,"latitude":36.4823272,"nom":"Ait Boumehdi","id":"516","wilaya_id":"15","code_postal":"15030"},{"longitude":4.3423883,"latitude":36.5389695,"nom":"Abi Youcef","id":"517","wilaya_id":"15","code_postal":"15031"},{"longitude":4.0815246,"latitude":36.62054,"nom":"Beni Douala","id":"518","wilaya_id":"15","code_postal":"15032"},{"longitude":4.3946198,"latitude":36.5161852,"nom":"Illilten","id":"519","wilaya_id":"15","code_postal":"15033"},{"longitude":4.4725912,"latitude":36.6141303,"nom":"Bouzguen","id":"520","wilaya_id":"15","code_postal":"15034"},{"longitude":4.2435893,"latitude":36.6096083,"nom":"Ait Aggouacha","id":"521","wilaya_id":"15","code_postal":"15035"},{"longitude":4.0886525,"latitude":36.5559718,"nom":"Ouadhia","id":"522","wilaya_id":"15","code_postal":"15036"},{"longitude":4.4240151,"latitude":36.8895311,"nom":"Azzefoun","id":"523","wilaya_id":"15","code_postal":"15037"},{"longitude":4.1267837,"latitude":36.8905856,"nom":"Tigzirt","id":"524","wilaya_id":"15","code_postal":"15038"},{"longitude":4.1155596,"latitude":36.7486964,"nom":"Ait Aissa Mimoun","id":"525","wilaya_id":"15","code_postal":"15039"},{"longitude":3.9558753,"latitude":36.5410545,"nom":"Boghni","id":"526","wilaya_id":"15","code_postal":"15040"},{"longitude":4.413693299999999,"latitude":36.6717744,"nom":"Ifigha","id":"527","wilaya_id":"15","code_postal":"15041"},{"longitude":4.2282093,"latitude":36.6586389,"nom":"Ait Oumalou","id":"528","wilaya_id":"15","code_postal":"15042"},{"longitude":3.9572785,"latitude":36.6756079,"nom":"Tirmitine","id":"529","wilaya_id":"15","code_postal":"15043"},{"longitude":4.4490836,"latitude":36.817363,"nom":"Akerrou","id":"530","wilaya_id":"15","code_postal":"15044"},{"longitude":4.2794935,"latitude":36.5274507,"nom":"Yatafen","id":"531","wilaya_id":"15","code_postal":"15045"},{"longitude":4.5025157,"latitude":36.56280599999999,"nom":"Beni Ziki","id":"532","wilaya_id":"15","code_postal":"15046"},{"longitude":3.9652509,"latitude":36.7309604,"nom":"Draa Ben Khedda","id":"533","wilaya_id":"15","code_postal":"15047"},{"longitude":4.2179584,"latitude":36.5188468,"nom":"Ouacif","id":"534","wilaya_id":"15","code_postal":"15048"},{"longitude":4.5418141,"latitude":36.6740411,"nom":"Idjeur","id":"535","wilaya_id":"15","code_postal":"15049"},{"longitude":4.264103,"latitude":36.6735171,"nom":"Mekla","id":"536","wilaya_id":"15","code_postal":"15050"},{"longitude":4.0388918,"latitude":36.5735762,"nom":"Tizi Nthlata","id":"537","wilaya_id":"15","code_postal":"15051"},{"longitude":4.1820961,"latitude":36.5686516,"nom":"Beni Yenni","id":"538","wilaya_id":"15","code_postal":"15052"},{"longitude":4.346237299999999,"latitude":36.8211575,"nom":"Aghrib","id":"539","wilaya_id":"15","code_postal":"15053"},{"longitude":4.2230836,"latitude":36.86855930000001,"nom":"Iflissen","id":"540","wilaya_id":"15","code_postal":"15054"},{"longitude":4.1411406,"latitude":36.8069616,"nom":"Boudjima","id":"541","wilaya_id":"15","code_postal":"15055"},{"longitude":3.8757119,"latitude":36.6436636,"nom":"Ait Yahia Moussa","id":"542","wilaya_id":"15","code_postal":"15056"},{"longitude":4.003152099999999,"latitude":36.5909543,"nom":"Souk El Thenine","id":"543","wilaya_id":"15","code_postal":"15057"},{"longitude":4.3102879,"latitude":36.6664742,"nom":"Ait Khelil","id":"544","wilaya_id":"15","code_postal":"15058"},{"longitude":3.9980485,"latitude":36.7688293,"nom":"Sidi Naamane","id":"545","wilaya_id":"15","code_postal":"15059"},{"longitude":4.2435893,"latitude":36.5233354,"nom":"Iboudraren","id":"546","wilaya_id":"15","code_postal":"15060"},{"longitude":4.079767299999999,"latitude":36.852067,"nom":"Mizrana","id":"548","wilaya_id":"15","code_postal":"15062"},{"longitude":4.3924936,"latitude":36.5772781,"nom":"Imsouhal","id":"549","wilaya_id":"15","code_postal":"15063"},{"longitude":3.8960811,"latitude":36.70763000000001,"nom":"Tadmait","id":"550","wilaya_id":"15","code_postal":"15064"},{"longitude":4.0593255,"latitude":36.5081471,"nom":"Ait Bouadou","id":"551","wilaya_id":"15","code_postal":"15065"},{"longitude":4.013361,"latitude":36.5043008,"nom":"Assi Youcef","id":"552","wilaya_id":"15","code_postal":"15066"},{"longitude":4.1616143,"latitude":36.5262163,"nom":"Ait Toudert","id":"553","wilaya_id":"15","code_postal":"15067"},{"longitude":3.0551159,"latitude":36.7724841,"nom":"Alger Centre","id":"554","wilaya_id":"16","code_postal":"16001"},{"longitude":3.0587561,"latitude":36.753768,"nom":"Sidi Mhamed","id":"555","wilaya_id":"16","code_postal":"16002"},{"longitude":3.0688896,"latitude":36.7411788,"nom":"El Madania","id":"556","wilaya_id":"16","code_postal":"16003"},{"longitude":3.0781232,"latitude":36.7509629,"nom":"Hamma Anassers","id":"557","wilaya_id":"16","code_postal":"16004"},{"longitude":3.0513601,"latitude":36.7927594,"nom":"Bab El Oued","id":"558","wilaya_id":"16","code_postal":"16005"},{"longitude":3.0433403,"latitude":36.8037134,"nom":"Bologhine Ibn Ziri","id":"559","wilaya_id":"16","code_postal":"16006"},{"longitude":3.058872,"latitude":36.7844961,"nom":"Casbah","id":"560","wilaya_id":"16","code_postal":"16007"},{"longitude":3.0400945,"latitude":36.7836306,"nom":"Oued Koriche","id":"561","wilaya_id":"16","code_postal":"16008"},{"longitude":3.0503737,"latitude":36.7353493,"nom":"Bir Mourad Rais","id":"562","wilaya_id":"16","code_postal":"16009"},{"longitude":3.0309946,"latitude":36.7690092,"nom":"El Biar","id":"563","wilaya_id":"16","code_postal":"16010"},{"longitude":3.0125674,"latitude":36.7816379,"nom":"Bouzareah","id":"564","wilaya_id":"16","code_postal":"16011"},{"longitude":3.0425977,"latitude":36.7162726,"nom":"Birkhadem","id":"565","wilaya_id":"16","code_postal":"16012"},{"longitude":3.1428341,"latitude":36.7029047,"nom":"El Harrach","id":"566","wilaya_id":"16","code_postal":"16013"},{"longitude":3.0985796,"latitude":36.6672951,"nom":"Baraki","id":"567","wilaya_id":"16","code_postal":"16014"},{"longitude":3.1754557,"latitude":36.6993487,"nom":"Oued Smar","id":"568","wilaya_id":"16","code_postal":"16015"},{"longitude":3.1152484,"latitude":36.7117069,"nom":"Bourouba","id":"569","wilaya_id":"16","code_postal":"16016"},{"longitude":3.1102345,"latitude":36.744147,"nom":"Hussein Dey","id":"570","wilaya_id":"16","code_postal":"16017"},{"longitude":3.0814946,"latitude":36.7266729,"nom":"Kouba","id":"571","wilaya_id":"16","code_postal":"16018"},{"longitude":3.1180085,"latitude":36.7261506,"nom":"Bachedjerah","id":"572","wilaya_id":"16","code_postal":"16019"},{"longitude":3.2281983,"latitude":36.70601449999999,"nom":"Dar El Beida","id":"573","wilaya_id":"16","code_postal":"16020"},{"longitude":3.1854975,"latitude":36.7206251,"nom":"Bab Azzouar","id":"574","wilaya_id":"16","code_postal":"16021"},{"longitude":3.0100658,"latitude":36.7574811,"nom":"Ben Aknoun","id":"575","wilaya_id":"16","code_postal":"16022"},{"longitude":2.9800558,"latitude":36.7528506,"nom":"Dely Ibrahim","id":"576","wilaya_id":"16","code_postal":"16023"},{"longitude":3.0019362,"latitude":36.8162039,"nom":"Bains Romains","id":"577","wilaya_id":"16","code_postal":"16024"},{"longitude":3.0100658,"latitude":36.8112925,"nom":"Rais Hamidou","id":"578","wilaya_id":"16","code_postal":"16025"},{"longitude":3.079263,"latitude":36.6978776,"nom":"Djasr Kasentina","id":"579","wilaya_id":"16","code_postal":"16026"},{"longitude":3.0488564,"latitude":36.7497677,"nom":"El Mouradia","id":"580","wilaya_id":"16","code_postal":"16027"},{"longitude":3.0250778,"latitude":36.7409507,"nom":"Hydra","id":"581","wilaya_id":"16","code_postal":"16028"},{"longitude":3.1528692,"latitude":36.73495279999999,"nom":"Mohammadia","id":"582","wilaya_id":"16","code_postal":"16029"},{"longitude":3.190432,"latitude":36.747187,"nom":"Bordj El Kiffan","id":"583","wilaya_id":"16","code_postal":"16030"},{"longitude":3.1114879,"latitude":36.7319999,"nom":"El Magharia","id":"584","wilaya_id":"16","code_postal":"16031"},{"longitude":2.9725563,"latitude":36.782641,"nom":"Beni Messous","id":"585","wilaya_id":"16","code_postal":"16032"},{"longitude":3.1679257,"latitude":36.6645264,"nom":"Les Eucalyptus","id":"586","wilaya_id":"16","code_postal":"16033"},{"longitude":3.0476046,"latitude":36.6460945,"nom":"Birtouta","id":"587","wilaya_id":"16","code_postal":"16034"},{"longitude":2.9225893,"latitude":36.6222556,"nom":"Tassala El Merdja","id":"588","wilaya_id":"16","code_postal":"16035"},{"longitude":2.9875565,"latitude":36.6044691,"nom":"Ouled Chebel","id":"589","wilaya_id":"16","code_postal":"16036"},{"longitude":3.1077277,"latitude":36.6229795,"nom":"Sidi Moussa","id":"590","wilaya_id":"16","code_postal":"16037"},{"longitude":3.2835137,"latitude":36.7852529,"nom":"Ain Taya","id":"591","wilaya_id":"16","code_postal":"16038"},{"longitude":3.2404681,"latitude":36.7791328,"nom":"Bordj El Bahri","id":"592","wilaya_id":"16","code_postal":"16039"},{"longitude":3.2448731,"latitude":36.8111249,"nom":"Marsa","id":"593","wilaya_id":"16","code_postal":"16040"},{"longitude":3.3086778,"latitude":36.7684157,"nom":"Haraoua","id":"594","wilaya_id":"16","code_postal":"16041"},{"longitude":3.2885455,"latitude":36.7259091,"nom":"Rouiba","id":"595","wilaya_id":"16","code_postal":"16042"},{"longitude":3.3387368,"latitude":36.7431477,"nom":"Reghaia","id":"596","wilaya_id":"16","code_postal":"16043"},{"longitude":2.9337917,"latitude":36.7965083,"nom":"Ain Benian","id":"597","wilaya_id":"16","code_postal":"16044"},{"longitude":2.8881795,"latitude":36.7516507,"nom":"Staoueli","id":"598","wilaya_id":"16","code_postal":"16045"},{"longitude":2.8277963,"latitude":36.6946148,"nom":"Zeralda","id":"599","wilaya_id":"16","code_postal":"16046"},{"longitude":2.8676861,"latitude":36.65054629999999,"nom":"Mahelma","id":"600","wilaya_id":"16","code_postal":"16047"},{"longitude":2.9126022,"latitude":36.6764115,"nom":"Rahmania","id":"601","wilaya_id":"16","code_postal":"16048"},{"longitude":2.9026172,"latitude":36.7089832,"nom":"Souidania","id":"602","wilaya_id":"16","code_postal":"16049"},{"longitude":2.9225893,"latitude":36.7623459,"nom":"Cheraga","id":"603","wilaya_id":"16","code_postal":"16050"},{"longitude":2.9425698,"latitude":36.7295502,"nom":"Ouled Fayet","id":"604","wilaya_id":"16","code_postal":"16051"},{"longitude":2.9825559,"latitude":36.7285583,"nom":"El Achour","id":"605","wilaya_id":"16","code_postal":"16052"},{"longitude":3.0025615,"latitude":36.7172858,"nom":"Draria","id":"606","wilaya_id":"16","code_postal":"16053"},{"longitude":2.9275836,"latitude":36.6490943,"nom":"Douera","id":"607","wilaya_id":"16","code_postal":"16054"},{"longitude":2.9731072,"latitude":36.6943775,"nom":"Baba Hassen","id":"608","wilaya_id":"16","code_postal":"16055"},{"longitude":3.0275802,"latitude":36.6897194,"nom":"Saoula","id":"610","wilaya_id":"16","code_postal":"16057"},{"longitude":3.2684215,"latitude":34.6751691,"nom":"Djelfa","id":"611","wilaya_id":"17","code_postal":"17001"},{"longitude":3.4675075,"latitude":34.5065791,"nom":"Moudjebara","id":"612","wilaya_id":"17","code_postal":"17002"},{"longitude":3.0275802,"latitude":35.07822850000001,"nom":"Hassi Bahbah","id":"614","wilaya_id":"17","code_postal":"17004"},{"longitude":3.1328011,"latitude":34.8056891,"nom":"Ain Maabed","id":"615","wilaya_id":"17","code_postal":"17005"},{"longitude":3.2256855,"latitude":33.9524075,"nom":"Sed Rahal","id":"616","wilaya_id":"17","code_postal":"17006"},{"longitude":3.7816093,"latitude":34.5304864,"nom":"Feidh El Botma","id":"617","wilaya_id":"17","code_postal":"17007"},{"longitude":3.2231727,"latitude":35.6267216,"nom":"Birine","id":"618","wilaya_id":"17","code_postal":"17008"},{"longitude":3.1403256,"latitude":35.2429194,"nom":"Bouira Lahdeb","id":"619","wilaya_id":"17","code_postal":"17009"},{"longitude":3.3250413,"latitude":34.4316233,"nom":"Zaccar","id":"620","wilaya_id":"17","code_postal":"17010"},{"longitude":2.5966036,"latitude":35.2886856,"nom":"El Khemis","id":"621","wilaya_id":"17","code_postal":"17011"},{"longitude":3.4321679,"latitude":35.0592433,"nom":"Sidi Baizid","id":"622","wilaya_id":"17","code_postal":"17012"},{"longitude":3.4813978,"latitude":34.7562504,"nom":"Mliliha","id":"623","wilaya_id":"17","code_postal":"17013"},{"longitude":2.5247449,"latitude":34.4548511,"nom":"El Idrissia","id":"624","wilaya_id":"17","code_postal":"17014"},{"longitude":2.706634,"latitude":34.373924,"nom":"Douis","id":"625","wilaya_id":"17","code_postal":"17015"},{"longitude":3.2533339,"latitude":35.1548428,"nom":"Hassi El Euch","id":"626","wilaya_id":"17","code_postal":"17016"},{"longitude":3.495292,"latitude":34.1536688,"nom":"Messaad","id":"627","wilaya_id":"17","code_postal":"17017"},{"longitude":4.6850858,"latitude":33.1610943,"nom":"Guettara","id":"628","wilaya_id":"17","code_postal":"17018"},{"longitude":2.514842,"latitude":35.435674,"nom":"Sidi Ladjel","id":"629","wilaya_id":"17","code_postal":"17019"},{"longitude":3.3615643,"latitude":35.3521531,"nom":"Had Sahary","id":"630","wilaya_id":"17","code_postal":"17020"},{"longitude":2.6822356,"latitude":35.2003683,"nom":"Guernini","id":"631","wilaya_id":"17","code_postal":"17021"},{"longitude":3.5991846,"latitude":34.1762857,"nom":"Selmana","id":"632","wilaya_id":"17","code_postal":"17022"},{"longitude":2.522269,"latitude":34.2413281,"nom":"Ain Chouhada","id":"633","wilaya_id":"17","code_postal":"17023"},{"longitude":4.530214099999999,"latitude":33.7206099,"nom":"Oum Laadham","id":"634","wilaya_id":"17","code_postal":"17024"},{"longitude":2.8003916,"latitude":34.6176861,"nom":"Charef","id":"636","wilaya_id":"17","code_postal":"17026"},{"longitude":2.783333,"latitude":34.466667,"nom":"Beni Yacoub","id":"637","wilaya_id":"17","code_postal":"17027"},{"longitude":2.8502302,"latitude":34.8539773,"nom":"Zaafrane","id":"638","wilaya_id":"17","code_postal":"17028"},{"longitude":3.2256855,"latitude":34.3525264,"nom":"Ain El Ibel","id":"640","wilaya_id":"17","code_postal":"17030"},{"longitude":2.9076094,"latitude":35.4542653,"nom":"Ain Oussera","id":"641","wilaya_id":"17","code_postal":"17031"},{"longitude":3.0113166,"latitude":35.4859395,"nom":"Benhar","id":"642","wilaya_id":"17","code_postal":"17032"},{"longitude":3.8693481,"latitude":34.3547243,"nom":"Amourah","id":"644","wilaya_id":"17","code_postal":"17034"},{"longitude":3.5407909,"latitude":35.4702472,"nom":"Ain Fekka","id":"645","wilaya_id":"17","code_postal":"17035"},{"longitude":2.983333,"latitude":34.283333,"nom":"Tadmit","id":"646","wilaya_id":"17","code_postal":"17036"},{"longitude":5.749093299999999,"latitude":36.81673869999999,"nom":"Jijel","id":"647","wilaya_id":"18","code_postal":"18001"},{"longitude":5.569604099999999,"latitude":36.584745,"nom":"Erraguene","id":"648","wilaya_id":"18","code_postal":"18002"},{"longitude":5.6352801,"latitude":36.7456809,"nom":"El Aouana","id":"649","wilaya_id":"18","code_postal":"18003"},{"longitude":5.4987565,"latitude":36.6337798,"nom":"Ziamma Mansouriah","id":"650","wilaya_id":"18","code_postal":"18004"},{"longitude":5.909275399999999,"latitude":36.7753597,"nom":"Taher","id":"651","wilaya_id":"18","code_postal":"18005"},{"longitude":5.8459341,"latitude":36.77848669999999,"nom":"Emir Abdelkader","id":"652","wilaya_id":"18","code_postal":"18006"},{"longitude":5.9581464,"latitude":36.771582,"nom":"Chekfa","id":"653","wilaya_id":"18","code_postal":"18007"},{"longitude":5.9548431,"latitude":36.6770779,"nom":"Chahna","id":"654","wilaya_id":"18","code_postal":"18008"},{"longitude":6.2853999,"latitude":36.7507275,"nom":"El Milia","id":"655","wilaya_id":"18","code_postal":"18009"},{"longitude":6.273445199999999,"latitude":36.6425914,"nom":"Sidi Maarouf","id":"656","wilaya_id":"18","code_postal":"18010"},{"longitude":6.3359009,"latitude":36.71852519999999,"nom":"Settara","id":"657","wilaya_id":"18","code_postal":"18011"},{"longitude":6.1593269,"latitude":36.798905,"nom":"El Ancer","id":"658","wilaya_id":"18","code_postal":"18012"},{"longitude":6.0526981,"latitude":36.8546552,"nom":"Sidi Abdelaziz","id":"659","wilaya_id":"18","code_postal":"18013"},{"longitude":5.7405139,"latitude":36.7406564,"nom":"Kaous","id":"660","wilaya_id":"18","code_postal":"18014"},{"longitude":6.387773399999999,"latitude":36.6284551,"nom":"Ghebala","id":"661","wilaya_id":"18","code_postal":"18015"},{"longitude":6.104333599999999,"latitude":36.6977238,"nom":"Bouraoui Belhadef","id":"662","wilaya_id":"18","code_postal":"18016"},{"longitude":5.624766999999999,"latitude":36.6709346,"nom":"Selma Benziada","id":"664","wilaya_id":"18","code_postal":"18018"},{"longitude":6.018960000000001,"latitude":36.6422747,"nom":"Boussif Ouled Askeur","id":"665","wilaya_id":"18","code_postal":"18019"},{"longitude":5.962771399999999,"latitude":36.82568029999999,"nom":"El Kennar Nouchfi","id":"666","wilaya_id":"18","code_postal":"18020"},{"longitude":5.7826597,"latitude":36.5880677,"nom":"Boudria Beni Yadjis","id":"668","wilaya_id":"18","code_postal":"18022"},{"longitude":5.751047499999999,"latitude":36.6649099,"nom":"Texena","id":"670","wilaya_id":"18","code_postal":"18024"},{"longitude":6.1222175,"latitude":36.8088666,"nom":"Djemaa Beni Habibi","id":"671","wilaya_id":"18","code_postal":"18025"},{"longitude":5.968859,"latitude":36.7707314,"nom":"Bordj Taher","id":"672","wilaya_id":"18","code_postal":"18026"},{"longitude":6.169933599999999,"latitude":36.5969116,"nom":"Ouled Rabah","id":"673","wilaya_id":"18","code_postal":"18027"},{"longitude":5.8881542,"latitude":36.6904688,"nom":"Ouadjana","id":"674","wilaya_id":"18","code_postal":"18028"},{"longitude":5.4150871,"latitude":36.1969027,"nom":"Setif","id":"675","wilaya_id":"19","code_postal":"19001"},{"longitude":5.509246999999999,"latitude":36.3637833,"nom":"Ain El Kebira","id":"676","wilaya_id":"19","code_postal":"19002"},{"longitude":5.6563119,"latitude":36.4648323,"nom":"Beni Aziz","id":"677","wilaya_id":"19","code_postal":"19003"},{"longitude":5.166666999999999,"latitude":35.733333,"nom":"Ouled Sidi Ahmed","id":"678","wilaya_id":"19","code_postal":"19004"},{"longitude":5.2475518,"latitude":35.6920766,"nom":"Boutaleb","id":"679","wilaya_id":"19","code_postal":"19005"},{"longitude":5.1953554,"latitude":36.3129898,"nom":"Ain Roua","id":"680","wilaya_id":"19","code_postal":"19006"},{"longitude":4.9973939,"latitude":36.4379461,"nom":"Draa Kebila","id":"681","wilaya_id":"19","code_postal":"19007"},{"longitude":5.7932008,"latitude":36.1016103,"nom":"Bir El Arch","id":"682","wilaya_id":"19","code_postal":"19008"},{"longitude":4.9039424,"latitude":36.4764952,"nom":"Beni Chebana","id":"683","wilaya_id":"19","code_postal":"19009"},{"longitude":5.1223608,"latitude":35.7845851,"nom":"Ouled Tebben","id":"684","wilaya_id":"19","code_postal":"19010"},{"longitude":5.373017600000001,"latitude":35.6865509,"nom":"Hamma","id":"685","wilaya_id":"19","code_postal":"19011"},{"longitude":5.6983979,"latitude":36.398105,"nom":"Maaouia","id":"686","wilaya_id":"19","code_postal":"19012"},{"longitude":4.891024199999999,"latitude":36.4096669,"nom":"Ain Legraj","id":"687","wilaya_id":"19","code_postal":"19013"},{"longitude":5.2893433,"latitude":36.2980641,"nom":"Ain Abessa","id":"688","wilaya_id":"19","code_postal":"19014"},{"longitude":5.624766999999999,"latitude":36.3692058,"nom":"Dehamcha","id":"689","wilaya_id":"19","code_postal":"19015"},{"longitude":5.4987565,"latitude":36.46140159999999,"nom":"Babor","id":"690","wilaya_id":"19","code_postal":"19016"},{"longitude":5.4987565,"latitude":36.0721187,"nom":"Guidjel","id":"691","wilaya_id":"19","code_postal":"19017"},{"longitude":5.541949700000001,"latitude":35.9372791,"nom":"Ain Lahdjar","id":"692","wilaya_id":"19","code_postal":"19018"},{"longitude":5.0078451,"latitude":36.4937653,"nom":"Bousselam","id":"693","wilaya_id":"19","code_postal":"19019"},{"longitude":5.6983979,"latitude":36.1603006,"nom":"El Eulma","id":"694","wilaya_id":"19","code_postal":"19020"},{"longitude":5.7932008,"latitude":36.3179676,"nom":"Djemila","id":"695","wilaya_id":"19","code_postal":"19021"},{"longitude":4.8525282,"latitude":36.44220550000001,"nom":"Beni Ouartilane","id":"696","wilaya_id":"19","code_postal":"19022"},{"longitude":5.2475518,"latitude":35.7791966,"nom":"Rosfa","id":"697","wilaya_id":"19","code_postal":"19023"},{"longitude":5.4672962,"latitude":36.344105,"nom":"Ouled Addouane","id":"698","wilaya_id":"19","code_postal":"19024"},{"longitude":5.8775964,"latitude":36.2273854,"nom":"Belaa","id":"699","wilaya_id":"19","code_postal":"19025"},{"longitude":5.3302913,"latitude":36.1755508,"nom":"Ain Arnat","id":"700","wilaya_id":"19","code_postal":"19026"},{"longitude":5.414900299999999,"latitude":36.3788902,"nom":"Amoucha","id":"701","wilaya_id":"19","code_postal":"19027"},{"longitude":5.2976288,"latitude":35.9147478,"nom":"Ain Oulmane","id":"702","wilaya_id":"19","code_postal":"19028"},{"longitude":5.666313,"latitude":35.8941421,"nom":"Beidha Bordj","id":"703","wilaya_id":"19","code_postal":"19029"},{"longitude":5.1119407,"latitude":36.5109283,"nom":"Bouandas","id":"704","wilaya_id":"19","code_postal":"19030"},{"longitude":5.6668306,"latitude":36.0643003,"nom":"Bazer Sakhra","id":"705","wilaya_id":"19","code_postal":"19031"},{"longitude":5.8353837,"latitude":35.96946399999999,"nom":"Hammam Essokhna","id":"706","wilaya_id":"19","code_postal":"19032"},{"longitude":5.2475518,"latitude":36.08336389999999,"nom":"Mezloug","id":"707","wilaya_id":"19","code_postal":"19033"},{"longitude":5.4987565,"latitude":35.9853448,"nom":"Bir Haddada","id":"708","wilaya_id":"19","code_postal":"19034"},{"longitude":5.593239,"latitude":36.4678015,"nom":"Serdj El Ghoul","id":"709","wilaya_id":"19","code_postal":"19035"},{"longitude":4.9247074,"latitude":36.3460467,"nom":"Harbil","id":"710","wilaya_id":"19","code_postal":"19036"},{"longitude":5.414900299999999,"latitude":36.2924521,"nom":"El Ouricia","id":"711","wilaya_id":"19","code_postal":"19037"},{"longitude":5.3625516,"latitude":36.4352238,"nom":"Tizi Nbechar","id":"712","wilaya_id":"19","code_postal":"19038"},{"longitude":5.373017600000001,"latitude":35.8171868,"nom":"Salah Bey","id":"713","wilaya_id":"19","code_postal":"19039"},{"longitude":5.5133952,"latitude":35.8184752,"nom":"Ain Azal","id":"714","wilaya_id":"19","code_postal":"19040"},{"longitude":4.8209596,"latitude":36.3286473,"nom":"Guenzet","id":"715","wilaya_id":"19","code_postal":"19041"},{"longitude":5.7089241,"latitude":35.9755409,"nom":"Talaifacene","id":"716","wilaya_id":"19","code_postal":"19042"},{"longitude":5.1119407,"latitude":36.3381987,"nom":"Bougaa","id":"717","wilaya_id":"19","code_postal":"19043"},{"longitude":5.5827334,"latitude":36.28474420000001,"nom":"Beni Fouda","id":"718","wilaya_id":"19","code_postal":"19044"},{"longitude":5.7405139,"latitude":36.2664729,"nom":"Tachouda","id":"719","wilaya_id":"19","code_postal":"19045"},{"longitude":4.9096065,"latitude":36.51669589999999,"nom":"Beni Mouhli","id":"720","wilaya_id":"19","code_postal":"19046"},{"longitude":5.5407299,"latitude":36.1568639,"nom":"Ouled Sabor","id":"721","wilaya_id":"19","code_postal":"19047"},{"longitude":5.3311652,"latitude":36.03630090000001,"nom":"Guellal","id":"722","wilaya_id":"19","code_postal":"19048"},{"longitude":5.7194522,"latitude":36.4833899,"nom":"Ain Sebt","id":"723","wilaya_id":"19","code_postal":"19049"},{"longitude":5.0548544,"latitude":36.3222675,"nom":"Hammam Guergour","id":"724","wilaya_id":"19","code_postal":"19050"},{"longitude":5.0754854,"latitude":36.5394362,"nom":"Ait Naoual Mezada","id":"725","wilaya_id":"19","code_postal":"19051"},{"longitude":5.2162283,"latitude":35.9870878,"nom":"Ksar El Abtal","id":"726","wilaya_id":"19","code_postal":"19052"},{"longitude":5.1119407,"latitude":36.251687,"nom":"Beni Hocine","id":"727","wilaya_id":"19","code_postal":"19053"},{"longitude":5.1327829,"latitude":36.5531554,"nom":"Ait Tizi","id":"728","wilaya_id":"19","code_postal":"19054"},{"longitude":5.0769287,"latitude":36.3966491,"nom":"Maouklane","id":"729","wilaya_id":"19","code_postal":"19055"},{"longitude":5.677351199999999,"latitude":36.2045916,"nom":"Guelta Zerka","id":"730","wilaya_id":"19","code_postal":"19056"},{"longitude":5.4253757,"latitude":36.4971074,"nom":"Oued El Barad","id":"731","wilaya_id":"19","code_postal":"19057"},{"longitude":5.9665303,"latitude":35.959337,"nom":"Taya","id":"732","wilaya_id":"19","code_postal":"19058"},{"longitude":5.9198387,"latitude":36.0520855,"nom":"El Ouldja","id":"733","wilaya_id":"19","code_postal":"19059"},{"longitude":5.7089241,"latitude":35.9755409,"nom":"Tella","id":"734","wilaya_id":"19","code_postal":"19060"},{"longitude":0.1484305,"latitude":34.8412014,"nom":"Saida","id":"735","wilaya_id":"20","code_postal":"20001"},{"longitude":-0.0735088,"latitude":34.8941184,"nom":"Doui Thabet","id":"736","wilaya_id":"20","code_postal":"20002"},{"longitude":0.15418,"latitude":34.7574087,"nom":"Ain El Hadjar","id":"737","wilaya_id":"20","code_postal":"20003"},{"longitude":0.1524313,"latitude":34.8765984,"nom":"Ouled Khaled","id":"738","wilaya_id":"20","code_postal":"20004"},{"longitude":0.0116586,"latitude":34.6497005,"nom":"Moulay Larbi","id":"739","wilaya_id":"20","code_postal":"20005"},{"longitude":-0.2080547,"latitude":34.92016100000001,"nom":"Youb","id":"740","wilaya_id":"20","code_postal":"20006"},{"longitude":-0.1148012,"latitude":35.0903759,"nom":"Hounet","id":"741","wilaya_id":"20","code_postal":"20007"},{"longitude":0.1097315,"latitude":35.0249991,"nom":"Sidi Amar","id":"742","wilaya_id":"20","code_postal":"20008"},{"longitude":0.0536592,"latitude":35.0305441,"nom":"Sidi Boubekeur","id":"743","wilaya_id":"20","code_postal":"20009"},{"longitude":0.3301342,"latitude":34.8260947,"nom":"El Hassasna","id":"744","wilaya_id":"20","code_postal":"20010"},{"longitude":0.4997973000000001,"latitude":34.6818661,"nom":"Maamora","id":"745","wilaya_id":"20","code_postal":"20011"},{"longitude":0.259657,"latitude":34.5497948,"nom":"Sidi Ahmed","id":"746","wilaya_id":"20","code_postal":"20012"},{"longitude":0.8441666999999999,"latitude":34.5044444,"nom":"Ain Sekhouna","id":"747","wilaya_id":"20","code_postal":"20013"},{"longitude":0.4718608999999999,"latitude":34.986248,"nom":"Ouled Brahim","id":"748","wilaya_id":"20","code_postal":"20014"},{"longitude":0.5529666,"latitude":34.9011622,"nom":"Tircine","id":"749","wilaya_id":"20","code_postal":"20015"},{"longitude":0.3034289,"latitude":34.9675528,"nom":"Ain Soltane","id":"750","wilaya_id":"20","code_postal":"20016"},{"longitude":6.910180599999999,"latitude":36.8715199,"nom":"Skikda","id":"751","wilaya_id":"21","code_postal":"21001"},{"longitude":6.7888879,"latitude":36.8912294,"nom":"Ain Zouit","id":"752","wilaya_id":"21","code_postal":"21002"},{"longitude":6.8873791,"latitude":36.8259805,"nom":"El Hadaik","id":"753","wilaya_id":"21","code_postal":"21003"},{"longitude":7.1170952,"latitude":36.7441137,"nom":"Azzaba","id":"754","wilaya_id":"21","code_postal":"21004"},{"longitude":7.169598099999999,"latitude":36.7824999,"nom":"Djendel Saadi Mohamed","id":"755","wilaya_id":"21","code_postal":"21005"},{"longitude":7.223489900000001,"latitude":36.7336763,"nom":"Ain Cherchar","id":"756","wilaya_id":"21","code_postal":"21006"},{"longitude":7.305758099999999,"latitude":36.700497,"nom":"Bekkouche Lakhdar","id":"757","wilaya_id":"21","code_postal":"21007"},{"longitude":7.296312400000001,"latitude":36.8658203,"nom":"Benazouz","id":"758","wilaya_id":"21","code_postal":"21008"},{"longitude":7.069999999999999,"latitude":36.6599999,"nom":"Es Sebt","id":"759","wilaya_id":"21","code_postal":"21009"},{"longitude":6.554319899999999,"latitude":37.0013848,"nom":"Collo","id":"760","wilaya_id":"21","code_postal":"21010"},{"longitude":6.4809854,"latitude":36.9318483,"nom":"Beni Zid","id":"761","wilaya_id":"21","code_postal":"21011"},{"longitude":6.5876817,"latitude":36.9313308,"nom":"Kerkera","id":"762","wilaya_id":"21","code_postal":"21012"},{"longitude":6.313303299999999,"latitude":36.9221397,"nom":"Oued Zehour","id":"764","wilaya_id":"21","code_postal":"21014"},{"longitude":6.4556713,"latitude":36.9880728,"nom":"Zitouna","id":"765","wilaya_id":"21","code_postal":"21015"},{"longitude":6.840459999999999,"latitude":36.6557031,"nom":"El Harrouch","id":"766","wilaya_id":"21","code_postal":"21016"},{"longitude":6.972405699999999,"latitude":36.516375,"nom":"Ouled Hebaba","id":"768","wilaya_id":"21","code_postal":"21018"},{"longitude":6.7186283,"latitude":36.6800923,"nom":"Sidi Mezghiche","id":"769","wilaya_id":"21","code_postal":"21019"},{"longitude":6.805627599999999,"latitude":36.7033327,"nom":"Emdjez Edchich","id":"770","wilaya_id":"21","code_postal":"21020"},{"longitude":6.634417699999999,"latitude":36.6270696,"nom":"Beni Oulbane","id":"771","wilaya_id":"21","code_postal":"21021"},{"longitude":6.738694600000001,"latitude":36.6024073,"nom":"Ain Bouziane","id":"772","wilaya_id":"21","code_postal":"21022"},{"longitude":6.894084599999999,"latitude":36.7599329,"nom":"Ramdane Djamel","id":"773","wilaya_id":"21","code_postal":"21023"},{"longitude":6.933332999999999,"latitude":36.783333,"nom":"Beni Bachir","id":"774","wilaya_id":"21","code_postal":"21024"},{"longitude":6.853861999999999,"latitude":36.7005645,"nom":"Salah Bouchaour","id":"775","wilaya_id":"21","code_postal":"21025"},{"longitude":6.645105,"latitude":36.8357539,"nom":"Tamalous","id":"776","wilaya_id":"21","code_postal":"21026"},{"longitude":6.431699000000001,"latitude":36.7455954,"nom":"Ain Kechra","id":"777","wilaya_id":"21","code_postal":"21027"},{"longitude":6.5756695,"latitude":36.6894163,"nom":"Oum Toub","id":"778","wilaya_id":"21","code_postal":"21028"},{"longitude":7.0821162,"latitude":36.8828035,"nom":"Fil Fila","id":"780","wilaya_id":"21","code_postal":"21030"},{"longitude":6.512975399999999,"latitude":37.0023239,"nom":"Cheraia","id":"781","wilaya_id":"21","code_postal":"21031"},{"longitude":6.4037428,"latitude":37.0376737,"nom":"Kanoua","id":"782","wilaya_id":"21","code_postal":"21032"},{"longitude":6.9759468,"latitude":36.6867619,"nom":"El Ghedir","id":"783","wilaya_id":"21","code_postal":"21033"},{"longitude":6.8,"latitude":36.783333,"nom":"Bouchtata","id":"784","wilaya_id":"21","code_postal":"21034"},{"longitude":6.928964199999999,"latitude":36.8463287,"nom":"Hamadi Krouma","id":"787","wilaya_id":"21","code_postal":"21037"},{"longitude":7.286867999999999,"latitude":37.0094161,"nom":"El Marsa","id":"788","wilaya_id":"21","code_postal":"21038"},{"longitude":-0.6298922,"latitude":35.2022249,"nom":"Sidi Bel Abbes","id":"789","wilaya_id":"22","code_postal":"22001"},{"longitude":-0.7818088999999999,"latitude":35.2672655,"nom":"Tessala","id":"790","wilaya_id":"22","code_postal":"22002"},{"longitude":-0.5730713,"latitude":35.268429,"nom":"Sidi Brahim","id":"791","wilaya_id":"22","code_postal":"22003"},{"longitude":-0.359435,"latitude":35.1925642,"nom":"Mostefa Ben Brahim","id":"792","wilaya_id":"22","code_postal":"22004"},{"longitude":-0.5446911999999999,"latitude":34.7949589,"nom":"Telagh","id":"793","wilaya_id":"22","code_postal":"22005"},{"longitude":-0.658333,"latitude":34.8385674,"nom":"Mezaourou","id":"794","wilaya_id":"22","code_postal":"22006"},{"longitude":-0.6962853,"latitude":35.0588511,"nom":"Boukhanafis","id":"795","wilaya_id":"22","code_postal":"22007"},{"longitude":-0.8336504,"latitude":35.1036318,"nom":"Sidi Ali Boussidi","id":"796","wilaya_id":"22","code_postal":"22008"},{"longitude":-0.8496433999999999,"latitude":35.0096949,"nom":"Badredine El Mokrani","id":"797","wilaya_id":"22","code_postal":"22009"},{"longitude":-0.1939932,"latitude":34.4446266,"nom":"Marhoum","id":"798","wilaya_id":"22","code_postal":"22010"},{"longitude":-0.2021951,"latitude":34.6923957,"nom":"Tafissour","id":"799","wilaya_id":"22","code_postal":"22011"},{"longitude":-0.610943,"latitude":35.0923336,"nom":"Amarnas","id":"800","wilaya_id":"22","code_postal":"22012"},{"longitude":-0.5352355999999999,"latitude":35.1806922,"nom":"Tilmouni","id":"801","wilaya_id":"22","code_postal":"22013"},{"longitude":-0.724773,"latitude":35.2016965,"nom":"Sidi Lahcene","id":"802","wilaya_id":"22","code_postal":"22014"},{"longitude":-0.6755257000000001,"latitude":35.2850615,"nom":"Ain Thrid","id":"803","wilaya_id":"22","code_postal":"22015"},{"longitude":-0.4307836,"latitude":35.4411307,"nom":"Makedra","id":"804","wilaya_id":"22","code_postal":"22016"},{"longitude":-0.5068824,"latitude":35.0157329,"nom":"Tenira","id":"805","wilaya_id":"22","code_postal":"22017"},{"longitude":-0.760411,"latitude":34.824175,"nom":"Moulay Slissen","id":"806","wilaya_id":"22","code_postal":"22018"},{"longitude":-0.7615995,"latitude":34.6984869,"nom":"El Hacaiba","id":"807","wilaya_id":"22","code_postal":"22019"},{"longitude":-0.8889678,"latitude":35.0273144,"nom":"Hassi Zehana","id":"808","wilaya_id":"22","code_postal":"22020"},{"longitude":-0.7437760999999999,"latitude":35.0255332,"nom":"Tabia","id":"809","wilaya_id":"22","code_postal":"22021"},{"longitude":-0.4478783000000001,"latitude":34.7815446,"nom":"Merine","id":"810","wilaya_id":"22","code_postal":"22022"},{"longitude":-0.8055975999999999,"latitude":34.5003381,"nom":"Ras El Ma","id":"811","wilaya_id":"22","code_postal":"22023"},{"longitude":-0.7212109999999999,"latitude":34.6876739,"nom":"Ain Tindamine","id":"812","wilaya_id":"22","code_postal":"22024"},{"longitude":-0.8567905,"latitude":35.136239,"nom":"Ain Kada","id":"813","wilaya_id":"22","code_postal":"22025"},{"longitude":-0.2469943999999999,"latitude":35.1386244,"nom":"Mcid","id":"814","wilaya_id":"22","code_postal":"22026"},{"longitude":-0.6678177,"latitude":35.1140441,"nom":"Sidi Khaled","id":"815","wilaya_id":"22","code_postal":"22027"},{"longitude":-0.5068824,"latitude":35.3675096,"nom":"Ain El Berd","id":"816","wilaya_id":"22","code_postal":"22028"},{"longitude":-0.2807868,"latitude":35.2365004,"nom":"Sfissef","id":"817","wilaya_id":"22","code_postal":"22029"},{"longitude":-0.2608306,"latitude":35.3285126,"nom":"Ain Adden","id":"818","wilaya_id":"22","code_postal":"22030"},{"longitude":-0.3266073,"latitude":34.8026387,"nom":"Oued Taourira","id":"819","wilaya_id":"22","code_postal":"22031"},{"longitude":-0.6216008,"latitude":34.6743959,"nom":"Dhaya","id":"820","wilaya_id":"22","code_postal":"22032"},{"longitude":-0.4313729,"latitude":35.23605930000001,"nom":"Zerouala","id":"821","wilaya_id":"22","code_postal":"22033"},{"longitude":-0.7989959999999999,"latitude":35.071492,"nom":"Lamtar","id":"822","wilaya_id":"22","code_postal":"22034"},{"longitude":-0.5470554,"latitude":34.5931437,"nom":"Sidi Chaib","id":"823","wilaya_id":"22","code_postal":"22035"},{"longitude":-0.7084642,"latitude":34.5871725,"nom":"Oued Sbaa","id":"825","wilaya_id":"22","code_postal":"22037"},{"longitude":-0.3236685,"latitude":35.3523658,"nom":"Boudjebaa El Bordj","id":"826","wilaya_id":"22","code_postal":"22038"},{"longitude":-0.8579818,"latitude":35.2228096,"nom":"Sehala Thaoura","id":"827","wilaya_id":"22","code_postal":"22039"},{"longitude":-0.7770528999999999,"latitude":35.1518977,"nom":"Sidi Yacoub","id":"828","wilaya_id":"22","code_postal":"22040"},{"longitude":-0.5163312,"latitude":35.3126031,"nom":"Sidi Hamadouche","id":"829","wilaya_id":"22","code_postal":"22041"},{"longitude":-0.4408037,"latitude":35.1370812,"nom":"Belarbi","id":"830","wilaya_id":"22","code_postal":"22042"},{"longitude":-0.5517843000000001,"latitude":34.8859984,"nom":"Teghalimet","id":"832","wilaya_id":"22","code_postal":"22044"},{"longitude":-0.8961217,"latitude":34.9363466,"nom":"Ben Badis","id":"833","wilaya_id":"22","code_postal":"22045"},{"longitude":-0.7342734,"latitude":34.9264009,"nom":"Sidi Ali Benyoub","id":"834","wilaya_id":"22","code_postal":"22046"},{"longitude":-0.8365437,"latitude":34.950551,"nom":"Chetouane Belaila","id":"835","wilaya_id":"22","code_postal":"22047"},{"longitude":-0.5009781,"latitude":34.4174164,"nom":"Bir El Hammam","id":"836","wilaya_id":"22","code_postal":"22048"},{"longitude":-0.1144079,"latitude":34.5887754,"nom":"Taoudmout","id":"837","wilaya_id":"22","code_postal":"22049"},{"longitude":-0.8091670999999999,"latitude":34.4268654,"nom":"Redjem Demouche","id":"838","wilaya_id":"22","code_postal":"22050"},{"longitude":-0.6130087,"latitude":34.963705,"nom":"Benachiba Chelia","id":"839","wilaya_id":"22","code_postal":"22051"},{"longitude":-0.5446911999999999,"latitude":35.1036532,"nom":"Hassi Dahou","id":"840","wilaya_id":"22","code_postal":"22052"},{"longitude":7.752535200000001,"latitude":36.9264582,"nom":"Annaba","id":"841","wilaya_id":"23","code_postal":"23001"},{"longitude":7.4597725,"latitude":36.8275635,"nom":"Berrahel","id":"842","wilaya_id":"23","code_postal":"23002"},{"longitude":7.665662500000001,"latitude":36.7609066,"nom":"El Hadjar","id":"843","wilaya_id":"23","code_postal":"23003"},{"longitude":7.4597725,"latitude":36.6989793,"nom":"Eulma","id":"844","wilaya_id":"23","code_postal":"23004"},{"longitude":7.7431524,"latitude":36.8535764,"nom":"El Bouni","id":"845","wilaya_id":"23","code_postal":"23005"},{"longitude":7.503066899999999,"latitude":36.9104322,"nom":"Oued El Aneb","id":"846","wilaya_id":"23","code_postal":"23006"},{"longitude":7.5788975,"latitude":36.7236097,"nom":"Cheurfa","id":"847","wilaya_id":"23","code_postal":"23007"},{"longitude":7.633112999999999,"latitude":36.944893,"nom":"Seraidi","id":"848","wilaya_id":"23","code_postal":"23008"},{"longitude":7.590099500000001,"latitude":36.6449172,"nom":"Ain Berda","id":"849","wilaya_id":"23","code_postal":"23009"},{"longitude":7.3732655,"latitude":37.0040741,"nom":"Chetaibi","id":"850","wilaya_id":"23","code_postal":"23010"},{"longitude":7.665662500000001,"latitude":36.8037437,"nom":"Sidi Amer","id":"851","wilaya_id":"23","code_postal":"23011"},{"longitude":7.4165053,"latitude":36.915875,"nom":"Treat","id":"852","wilaya_id":"23","code_postal":"23012"},{"longitude":7.4327273,"latitude":36.458976,"nom":"Guelma","id":"853","wilaya_id":"24","code_postal":"24001"},{"longitude":7.5111876,"latitude":36.61258309999999,"nom":"Nechmaya","id":"854","wilaya_id":"24","code_postal":"24002"},{"longitude":7.3260032,"latitude":36.5905648,"nom":"Bouati Mahmoud","id":"855","wilaya_id":"24","code_postal":"24003"},{"longitude":7.162864700000001,"latitude":36.3139054,"nom":"Oued Zenati","id":"856","wilaya_id":"24","code_postal":"24004"},{"longitude":7.139976,"latitude":36.1573949,"nom":"Tamlouka","id":"857","wilaya_id":"24","code_postal":"24005"},{"longitude":7.7118003,"latitude":36.556799,"nom":"Oued Fragha","id":"858","wilaya_id":"24","code_postal":"24006"},{"longitude":7.513217999999999,"latitude":36.2431716,"nom":"Ain Sandel","id":"859","wilaya_id":"24","code_postal":"24007"},{"longitude":7.222816,"latitude":36.3729492,"nom":"Ras El Agba","id":"860","wilaya_id":"24","code_postal":"24008"},{"longitude":7.734880500000001,"latitude":36.3522993,"nom":"Dahouara","id":"861","wilaya_id":"24","code_postal":"24009"},{"longitude":7.4787104,"latitude":36.4587897,"nom":"Belkhir","id":"862","wilaya_id":"24","code_postal":"24010"},{"longitude":7.369888500000001,"latitude":36.4312641,"nom":"Ben Djarah","id":"863","wilaya_id":"24","code_postal":"24011"},{"longitude":7.1144039,"latitude":36.4622523,"nom":"Bou Hamdane","id":"864","wilaya_id":"24","code_postal":"24012"},{"longitude":7.2518004,"latitude":36.246509,"nom":"Ain Makhlouf","id":"865","wilaya_id":"24","code_postal":"24013"},{"longitude":7.699999999999999,"latitude":36.616667,"nom":"Ain Ben Beida","id":"866","wilaya_id":"24","code_postal":"24014"},{"longitude":7.5342015,"latitude":36.3705271,"nom":"Khezara","id":"867","wilaya_id":"24","code_postal":"24015"},{"longitude":7.604644599999999,"latitude":36.4817434,"nom":"Beni Mezline","id":"868","wilaya_id":"24","code_postal":"24016"},{"longitude":7.507803899999999,"latitude":36.306868,"nom":"Bou Hachana","id":"869","wilaya_id":"24","code_postal":"24017"},{"longitude":7.4787104,"latitude":36.5501826,"nom":"Guelaat Bou Sbaa","id":"870","wilaya_id":"24","code_postal":"24018"},{"longitude":7.27,"latitude":36.46,"nom":"Hammam Maskhoutine","id":"871","wilaya_id":"24","code_postal":"24019"},{"longitude":7.3894772,"latitude":36.5046911,"nom":"El Fedjoudj","id":"872","wilaya_id":"24","code_postal":"24020"},{"longitude":7.048499899999999,"latitude":36.402899,"nom":"Bordj Sabat","id":"873","wilaya_id":"24","code_postal":"24021"},{"longitude":7.6412489,"latitude":36.3246695,"nom":"Hamman Nbail","id":"874","wilaya_id":"24","code_postal":"24022"},{"longitude":7.4325,"latitude":36.459102,"nom":"Ain Larbi","id":"875","wilaya_id":"24","code_postal":"24023"},{"longitude":7.309131799999999,"latitude":36.4457672,"nom":"Medjez Amar","id":"876","wilaya_id":"24","code_postal":"24024"},{"longitude":7.7362384,"latitude":36.47192709999999,"nom":"Bouchegouf","id":"877","wilaya_id":"24","code_postal":"24025"},{"longitude":7.4327273,"latitude":36.502001,"nom":"Heliopolis","id":"878","wilaya_id":"24","code_postal":"24026"},{"longitude":7.2841698,"latitude":36.4170167,"nom":"Ain Hessania","id":"879","wilaya_id":"24","code_postal":"24027"},{"longitude":7.2342735,"latitude":36.5451275,"nom":"Roknia","id":"880","wilaya_id":"24","code_postal":"24028"},{"longitude":7.2518004,"latitude":36.3866785,"nom":"Salaoua Announa","id":"881","wilaya_id":"24","code_postal":"24029"},{"longitude":7.7824225,"latitude":36.4339664,"nom":"Medjez Sfa","id":"882","wilaya_id":"24","code_postal":"24030"},{"longitude":7.512541199999999,"latitude":36.45800699999999,"nom":"Boumahra Ahmed","id":"883","wilaya_id":"24","code_postal":"24031"},{"longitude":7.072702,"latitude":36.2612886,"nom":"Ain Reggada","id":"884","wilaya_id":"24","code_postal":"24032"},{"longitude":7.767477299999999,"latitude":36.38248189999999,"nom":"Oued Cheham","id":"885","wilaya_id":"24","code_postal":"24033"},{"longitude":7.568736800000001,"latitude":36.4645365,"nom":"Djeballah Khemissi","id":"886","wilaya_id":"24","code_postal":"24034"},{"longitude":-85.6686026,"latitude":41.8411603,"nom":"Constantine","id":"887","wilaya_id":"25","code_postal":"25001"},{"longitude":6.5676625,"latitude":36.4181986,"nom":"Hamma Bouziane","id":"888","wilaya_id":"25","code_postal":"25002"},{"longitude":-121.0886537,"latitude":38.6811223,"nom":"El Haria","id":"889","wilaya_id":"25","code_postal":"25003"},{"longitude":6.702890399999999,"latitude":36.5309186,"nom":"Zighoud Youcef","id":"890","wilaya_id":"25","code_postal":"25004"},{"longitude":6.6531216,"latitude":36.4565656,"nom":"Didouche Mourad","id":"891","wilaya_id":"25","code_postal":"25005"},{"longitude":6.685198199999999,"latitude":36.2714408,"nom":"El Khroub","id":"892","wilaya_id":"25","code_postal":"25006"},{"longitude":6.9423844,"latitude":36.2135906,"nom":"Ain Abid","id":"893","wilaya_id":"25","code_postal":"25007"},{"longitude":6.556988199999999,"latitude":36.5372531,"nom":"Beni Hamiden","id":"894","wilaya_id":"25","code_postal":"25008"},{"longitude":6.8136642,"latitude":36.220992,"nom":"Ouled Rahmoune","id":"895","wilaya_id":"25","code_postal":"25009"},{"longitude":6.471658,"latitude":36.2831875,"nom":"Ain Smara","id":"896","wilaya_id":"25","code_postal":"25010"},{"longitude":6.386442799999999,"latitude":36.4603589,"nom":"Mesaoud Boudjeriou","id":"897","wilaya_id":"25","code_postal":"25011"},{"longitude":6.429036,"latitude":36.3718282,"nom":"Ibn Ziad","id":"898","wilaya_id":"25","code_postal":"25012"},{"longitude":2.7680247,"latitude":36.2853847,"nom":"Medea","id":"899","wilaya_id":"26","code_postal":"26001"},{"longitude":2.8463103,"latitude":36.252581,"nom":"Ouzera","id":"900","wilaya_id":"26","code_postal":"26002"},{"longitude":3.0776568,"latitude":35.7669488,"nom":"Ouled Maaref","id":"901","wilaya_id":"26","code_postal":"26003"},{"longitude":3.1578875,"latitude":35.8520702,"nom":"Ain Boucif","id":"902","wilaya_id":"26","code_postal":"26004"},{"longitude":3.2281983,"latitude":36.403785,"nom":"Aissaouia","id":"903","wilaya_id":"26","code_postal":"26005"},{"longitude":3.0375914,"latitude":36.1161743,"nom":"Ouled Deide","id":"904","wilaya_id":"26","code_postal":"26006"},{"longitude":3.0245978,"latitude":36.2672156,"nom":"El Omaria","id":"905","wilaya_id":"26","code_postal":"26007"},{"longitude":2.3881368,"latitude":35.9080275,"nom":"Derrag","id":"906","wilaya_id":"26","code_postal":"26008"},{"longitude":3.4094629,"latitude":36.2472045,"nom":"El Guelbelkebir","id":"907","wilaya_id":"26","code_postal":"26009"},{"longitude":2.341887,"latitude":35.5868879,"nom":"Bouaiche","id":"908","wilaya_id":"26","code_postal":"26010"},{"longitude":2.9675572,"latitude":36.2155805,"nom":"Ouled Brahim","id":"910","wilaya_id":"26","code_postal":"26012"},{"longitude":3.2483058,"latitude":36.034631,"nom":"Sidi Ziane","id":"912","wilaya_id":"26","code_postal":"26014"},{"longitude":2.6685736,"latitude":36.3309673,"nom":"Tamesguida","id":"913","wilaya_id":"26","code_postal":"26015"},{"longitude":2.8776638,"latitude":36.3369617,"nom":"El Hamdania","id":"914","wilaya_id":"26","code_postal":"26016"},{"longitude":3.238251,"latitude":35.9370344,"nom":"Kef Lakhdar","id":"915","wilaya_id":"26","code_postal":"26017"},{"longitude":3.3993751,"latitude":35.9325946,"nom":"Chelalet El Adhaoura","id":"916","wilaya_id":"26","code_postal":"26018"},{"longitude":3.1980527,"latitude":36.1554282,"nom":"Bouskene","id":"917","wilaya_id":"26","code_postal":"26019"},{"longitude":3.1177555,"latitude":36.0272162,"nom":"Rebaia","id":"918","wilaya_id":"26","code_postal":"26020"},{"longitude":3.1578875,"latitude":36.2865922,"nom":"Bouchrahil","id":"919","wilaya_id":"26","code_postal":"26021"},{"longitude":2.4980197,"latitude":35.9370104,"nom":"Ouled Hellal","id":"920","wilaya_id":"26","code_postal":"26022"},{"longitude":3.318747,"latitude":35.978354,"nom":"Tafraout","id":"921","wilaya_id":"26","code_postal":"26023"},{"longitude":3.1177555,"latitude":36.3742549,"nom":"Baata","id":"922","wilaya_id":"26","code_postal":"26024"},{"longitude":2.7182728,"latitude":35.9498907,"nom":"Boghar","id":"923","wilaya_id":"26","code_postal":"26025"},{"longitude":3.0876783,"latitude":36.2559141,"nom":"Sidi Naamane","id":"924","wilaya_id":"26","code_postal":"26026"},{"longitude":2.7083287,"latitude":36.0914607,"nom":"Ouled Bouachra","id":"925","wilaya_id":"26","code_postal":"26027"},{"longitude":3.3317554,"latitude":36.0683421,"nom":"Sidi Zahar","id":"926","wilaya_id":"26","code_postal":"26028"},{"longitude":2.6487087,"latitude":36.2447225,"nom":"Oued Harbil","id":"927","wilaya_id":"26","code_postal":"26029"},{"longitude":2.847737,"latitude":36.1967899,"nom":"Benchicao","id":"928","wilaya_id":"26","code_postal":"26030"},{"longitude":3.318747,"latitude":35.8041669,"nom":"Sidi Damed","id":"929","wilaya_id":"26","code_postal":"26031"},{"longitude":2.4999918,"latitude":35.758478,"nom":"Aziz","id":"930","wilaya_id":"26","code_postal":"26032"},{"longitude":3.2483058,"latitude":36.1215213,"nom":"Souagui","id":"931","wilaya_id":"26","code_postal":"26033"},{"longitude":2.8377656,"latitude":36.077613,"nom":"Zoubiria","id":"932","wilaya_id":"26","code_postal":"26034"},{"longitude":2.7481176,"latitude":35.8729994,"nom":"Ksar El Boukhari","id":"933","wilaya_id":"26","code_postal":"26035"},{"longitude":3.4902391,"latitude":36.3098718,"nom":"El Azizia","id":"934","wilaya_id":"26","code_postal":"26036"},{"longitude":3.4278338,"latitude":36.1381285,"nom":"Djouab","id":"935","wilaya_id":"26","code_postal":"26037"},{"longitude":2.5792482,"latitude":35.582061,"nom":"Chahbounia","id":"936","wilaya_id":"26","code_postal":"26038"},{"longitude":3.5306765,"latitude":36.3736214,"nom":"Meghraoua","id":"937","wilaya_id":"26","code_postal":"26039"},{"longitude":3.5667006,"latitude":35.9225813,"nom":"Cheniguel","id":"938","wilaya_id":"26","code_postal":"26040"},{"longitude":3.4701398,"latitude":35.8528084,"nom":"Ain Ouksir","id":"939","wilaya_id":"26","code_postal":"26041"},{"longitude":2.6685736,"latitude":35.8312012,"nom":"Oum El Djalil","id":"940","wilaya_id":"26","code_postal":"26042"},{"longitude":2.5594214,"latitude":36.2575001,"nom":"Ouamri","id":"941","wilaya_id":"26","code_postal":"26043"},{"longitude":2.7481176,"latitude":36.177412,"nom":"Si Mahdjoub","id":"942","wilaya_id":"26","code_postal":"26044"},{"longitude":3.3086778,"latitude":36.2283487,"nom":"Beni Slimane","id":"944","wilaya_id":"26","code_postal":"26046"},{"longitude":2.9175955,"latitude":36.1625653,"nom":"Berrouaghia","id":"945","wilaya_id":"26","code_postal":"26047"},{"longitude":2.9175955,"latitude":35.9887439,"nom":"Seghouane","id":"946","wilaya_id":"26","code_postal":"26048"},{"longitude":2.9175955,"latitude":35.9016881,"nom":"Meftaha","id":"947","wilaya_id":"26","code_postal":"26049"},{"longitude":3.4397386,"latitude":36.3654474,"nom":"Mihoub","id":"948","wilaya_id":"26","code_postal":"26050"},{"longitude":2.7381672,"latitude":35.7533117,"nom":"Boughezoul","id":"949","wilaya_id":"26","code_postal":"26051"},{"longitude":3.318747,"latitude":36.4121257,"nom":"Tablat","id":"950","wilaya_id":"26","code_postal":"26052"},{"longitude":3.2992135,"latitude":36.469433,"nom":"Deux Bassins","id":"951","wilaya_id":"26","code_postal":"26053"},{"longitude":2.7083287,"latitude":36.2650726,"nom":"Draa Essamar","id":"952","wilaya_id":"26","code_postal":"26054"},{"longitude":3.3071524,"latitude":36.2754347,"nom":"Sidi Errabia","id":"953","wilaya_id":"26","code_postal":"26055"},{"longitude":3.4198797,"latitude":36.1916138,"nom":"Bir Ben Laabed","id":"954","wilaya_id":"26","code_postal":"26056"},{"longitude":3.0676373,"latitude":35.865293,"nom":"El Ouinet","id":"955","wilaya_id":"26","code_postal":"26057"},{"longitude":2.6387795,"latitude":35.9951773,"nom":"Ouled Antar","id":"956","wilaya_id":"26","code_postal":"26058"},{"longitude":2.6487087,"latitude":36.1362286,"nom":"Bouaichoune","id":"957","wilaya_id":"26","code_postal":"26059"},{"longitude":2.5891648,"latitude":36.1809422,"nom":"Hannacha","id":"958","wilaya_id":"26","code_postal":"26060"},{"longitude":3.5288362,"latitude":36.2425076,"nom":"Sedraia","id":"959","wilaya_id":"26","code_postal":"26061"},{"longitude":2.797901,"latitude":35.9480676,"nom":"Medjebar","id":"960","wilaya_id":"26","code_postal":"26062"},{"longitude":3.1277854,"latitude":36.1464261,"nom":"Khams Djouamaa","id":"961","wilaya_id":"26","code_postal":"26063"},{"longitude":2.8277963,"latitude":35.8493684,"nom":"Saneg","id":"962","wilaya_id":"26","code_postal":"26064"},{"longitude":0.1401381,"latitude":36.01312350000001,"nom":"Mostaganem","id":"963","wilaya_id":"27","code_postal":"27001"},{"longitude":0.1401381,"latitude":35.9042298,"nom":"Sayada","id":"964","wilaya_id":"27","code_postal":"27002"},{"longitude":-0.0170737,"latitude":35.7536603,"nom":"Fornaka","id":"965","wilaya_id":"27","code_postal":"27003"},{"longitude":-0.006994800000000001,"latitude":35.8307225,"nom":"Stidia","id":"966","wilaya_id":"27","code_postal":"27004"},{"longitude":0.0489902,"latitude":35.8034403,"nom":"Ain Nouissy","id":"967","wilaya_id":"27","code_postal":"27005"},{"longitude":0.102718,"latitude":35.8606678,"nom":"Hassi Maameche","id":"968","wilaya_id":"27","code_postal":"27006"},{"longitude":0.2948797,"latitude":35.9965198,"nom":"Ain Tadles","id":"969","wilaya_id":"27","code_postal":"27007"},{"longitude":0.3401287,"latitude":35.9998017,"nom":"Sour","id":"970","wilaya_id":"27","code_postal":"27008"},{"longitude":0.3818982,"latitude":35.9500047,"nom":"Oued El Kheir","id":"971","wilaya_id":"27","code_postal":"27009"},{"longitude":0.2737423,"latitude":36.0264951,"nom":"Sidi Bellater","id":"972","wilaya_id":"27","code_postal":"27010"},{"longitude":0.1775946,"latitude":35.9477561,"nom":"Kheiredine ","id":"973","wilaya_id":"27","code_postal":"27011"},{"longitude":0.4148744,"latitude":36.0967786,"nom":"Sidi Ali","id":"974","wilaya_id":"27","code_postal":"27012"},{"longitude":0.2737423,"latitude":36.1026171,"nom":"Abdelmalek Ramdane","id":"975","wilaya_id":"27","code_postal":"27013"},{"longitude":0.3254317,"latitude":36.0970536,"nom":"Hadjadj","id":"976","wilaya_id":"27","code_postal":"27014"},{"longitude":0.6227851999999999,"latitude":36.1882211,"nom":"Nekmaria","id":"977","wilaya_id":"27","code_postal":"27015"},{"longitude":0.4431618,"latitude":36.1618701,"nom":"Sidi Lakhdar","id":"978","wilaya_id":"27","code_postal":"27016"},{"longitude":0.6334462,"latitude":36.2437869,"nom":"Achaacha","id":"979","wilaya_id":"27","code_postal":"27017"},{"longitude":0.5754372999999999,"latitude":36.25357109999999,"nom":"Khadra","id":"980","wilaya_id":"27","code_postal":"27018"},{"longitude":0.2549631,"latitude":35.74860839999999,"nom":"Bouguirat","id":"981","wilaya_id":"27","code_postal":"27019"},{"longitude":0.1881358,"latitude":35.7801148,"nom":"Sirat","id":"982","wilaya_id":"27","code_postal":"27020"},{"longitude":0.1284404,"latitude":35.8361077,"nom":"Ain Sidi Cherif","id":"983","wilaya_id":"27","code_postal":"27021"},{"longitude":0.1658856,"latitude":35.841515,"nom":"Mesra","id":"984","wilaya_id":"27","code_postal":"27022"},{"longitude":0.2315251,"latitude":35.8434386,"nom":"Mansourah","id":"985","wilaya_id":"27","code_postal":"27023"},{"longitude":0.3313514,"latitude":35.8617554,"nom":"Souaflia","id":"986","wilaya_id":"27","code_postal":"27024"},{"longitude":0.6701891999999999,"latitude":36.3181385,"nom":"Ouled Boughalem","id":"987","wilaya_id":"27","code_postal":"27025"},{"longitude":0.5908192,"latitude":36.0076756,"nom":"Ouled Maallah","id":"988","wilaya_id":"27","code_postal":"27026"},{"longitude":0.06066369999999999,"latitude":35.8879489,"nom":"Mezghrane","id":"989","wilaya_id":"27","code_postal":"27027"},{"longitude":0.1881358,"latitude":36.0089774,"nom":"Ain Boudinar","id":"990","wilaya_id":"27","code_postal":"27028"},{"longitude":0.5482376,"latitude":36.0948862,"nom":"Tazgait","id":"991","wilaya_id":"27","code_postal":"27029"},{"longitude":0.3771895,"latitude":35.8464922,"nom":"Safsaf","id":"992","wilaya_id":"27","code_postal":"27030"},{"longitude":0.2092267,"latitude":35.810088,"nom":"Touahria","id":"993","wilaya_id":"27","code_postal":"27031"},{"longitude":0.1202541,"latitude":35.7529118,"nom":"El Hassiane","id":"994","wilaya_id":"27","code_postal":"27032"},{"longitude":4.5418141,"latitude":35.677109,"nom":"M'sila","id":"995","wilaya_id":"28","code_postal":"28001"},{"longitude":4.7484518,"latitude":35.7999025,"nom":"Maadid","id":"996","wilaya_id":"28","code_postal":"28002"},{"longitude":4.3770704,"latitude":35.94451859999999,"nom":"Hammam Dhalaa","id":"997","wilaya_id":"28","code_postal":"28003"},{"longitude":4.789873099999999,"latitude":35.6238892,"nom":"Ouled Derradj","id":"998","wilaya_id":"28","code_postal":"28004"},{"longitude":4.2538452,"latitude":35.8183774,"nom":"Tarmount","id":"999","wilaya_id":"28","code_postal":"28005"},{"longitude":4.624375100000001,"latitude":35.7175823,"nom":"Mtarfa","id":"1000","wilaya_id":"28","code_postal":"28006"},{"longitude":4.5005808,"latitude":35.3289153,"nom":"Khoubana","id":"1001","wilaya_id":"28","code_postal":"28007"},{"longitude":4.7691586,"latitude":35.3405434,"nom":"Mcif","id":"1002","wilaya_id":"28","code_postal":"28008"},{"longitude":4.3770704,"latitude":35.5085058,"nom":"Chellal","id":"1003","wilaya_id":"28","code_postal":"28009"},{"longitude":4.5418141,"latitude":35.5461361,"nom":"Ouled Madhi","id":"1004","wilaya_id":"28","code_postal":"28010"},{"longitude":5.1223608,"latitude":35.6102393,"nom":"Magra","id":"1005","wilaya_id":"28","code_postal":"28011"},{"longitude":5.0078451,"latitude":35.6477648,"nom":"Berhoum","id":"1006","wilaya_id":"28","code_postal":"28012"},{"longitude":4.9558696,"latitude":35.5298671,"nom":"Ain Khadra","id":"1007","wilaya_id":"28","code_postal":"28013"},{"longitude":4.8728093,"latitude":35.7078012,"nom":"Ouled Addi Guebala","id":"1008","wilaya_id":"28","code_postal":"28014"},{"longitude":5.1953554,"latitude":35.5743889,"nom":"Belaiba","id":"1009","wilaya_id":"28","code_postal":"28015"},{"longitude":3.7029002,"latitude":35.8147768,"nom":"Sidi Aissa","id":"1010","wilaya_id":"28","code_postal":"28016"},{"longitude":3.8451731,"latitude":35.613995,"nom":"Ain El Hadjel","id":"1011","wilaya_id":"28","code_postal":"28017"},{"longitude":4.028678,"latitude":35.7171398,"nom":"Sidi Hadjeres","id":"1012","wilaya_id":"28","code_postal":"28018"},{"longitude":4.1718542,"latitude":35.9518081,"nom":"Ouanougha","id":"1013","wilaya_id":"28","code_postal":"28019"},{"longitude":4.1794668,"latitude":35.2102695,"nom":"Bou Saada","id":"1014","wilaya_id":"28","code_postal":"28020"},{"longitude":4.1309067,"latitude":35.3420781,"nom":"Ouled Sidi Brahim","id":"1015","wilaya_id":"28","code_postal":"28021"},{"longitude":3.8248241,"latitude":35.417831,"nom":"Sidi Ameur","id":"1016","wilaya_id":"28","code_postal":"28022"},{"longitude":3.9266502,"latitude":35.17339279999999,"nom":"Tamsa","id":"1017","wilaya_id":"28","code_postal":"28023"},{"longitude":4.6037231,"latitude":34.9958214,"nom":"Ben Srour","id":"1018","wilaya_id":"28","code_postal":"28024"},{"longitude":4.8520636,"latitude":34.8981727,"nom":"Ouled Slimane","id":"1019","wilaya_id":"28","code_postal":"28025"},{"longitude":4.6037231,"latitude":35.1715671,"nom":"El Houamed","id":"1020","wilaya_id":"28","code_postal":"28026"},{"longitude":4.0899911,"latitude":35.12408,"nom":"El Hamel","id":"1021","wilaya_id":"28","code_postal":"28027"},{"longitude":4.3770704,"latitude":35.7268096,"nom":"Ouled Mansour","id":"1022","wilaya_id":"28","code_postal":"28028"},{"longitude":4.2948884,"latitude":35.3801821,"nom":"Maarif","id":"1023","wilaya_id":"28","code_postal":"28029"},{"longitude":5.0286488,"latitude":35.7340886,"nom":"Dehahna","id":"1024","wilaya_id":"28","code_postal":"28030"},{"longitude":3.6217802,"latitude":35.642736,"nom":"Bouti Sayah","id":"1025","wilaya_id":"28","code_postal":"28031"},{"longitude":4.2538452,"latitude":35.687602,"nom":"Khettouti Sed Djir","id":"1026","wilaya_id":"28","code_postal":"28032"},{"longitude":4.8313257,"latitude":35.0529379,"nom":"Zarzour","id":"1027","wilaya_id":"28","code_postal":"28033"},{"longitude":4.4593791,"latitude":34.8911615,"nom":"Oued Chair","id":"1028","wilaya_id":"28","code_postal":"28034"},{"longitude":4.0899911,"latitude":35.474817,"nom":"Benzouh","id":"1029","wilaya_id":"28","code_postal":"28035"},{"longitude":3.9266502,"latitude":34.82133719999999,"nom":"Bir Foda","id":"1030","wilaya_id":"28","code_postal":"28036"},{"longitude":4.5005808,"latitude":34.7132986,"nom":"Ain Fares","id":"1031","wilaya_id":"28","code_postal":"28037"},{"longitude":4.2948884,"latitude":34.7648293,"nom":"Sidi Mhamed","id":"1032","wilaya_id":"28","code_postal":"28038"},{"longitude":3.8044831,"latitude":35.0454248,"nom":"Ouled Atia","id":"1033","wilaya_id":"28","code_postal":"28039"},{"longitude":4.7239002,"latitude":35.5863111,"nom":"Souamaa","id":"1034","wilaya_id":"28","code_postal":"28040"},{"longitude":4.1718542,"latitude":34.8132006,"nom":"Ain El Melh","id":"1035","wilaya_id":"28","code_postal":"28041"},{"longitude":3.642048,"latitude":35.0503943,"nom":"Medjedel","id":"1036","wilaya_id":"28","code_postal":"28042"},{"longitude":3.8451731,"latitude":34.9120859,"nom":"Slim","id":"1037","wilaya_id":"28","code_postal":"28043"},{"longitude":4.028678,"latitude":34.5751386,"nom":"Ain Errich","id":"1038","wilaya_id":"28","code_postal":"28044"},{"longitude":4.0899911,"latitude":35.9546181,"nom":"Beni Ilmane","id":"1039","wilaya_id":"28","code_postal":"28045"},{"longitude":4.2948884,"latitude":35.1170124,"nom":"Oultene","id":"1040","wilaya_id":"28","code_postal":"28046"},{"longitude":4.19234,"latitude":35.010688,"nom":"Djebel Messaad","id":"1041","wilaya_id":"28","code_postal":"28047"},{"longitude":0.1388446,"latitude":35.3974554,"nom":"Mascara","id":"1042","wilaya_id":"29","code_postal":"29001"},{"longitude":-0.0489902,"latitude":35.3164348,"nom":"Bou Hanifia","id":"1043","wilaya_id":"29","code_postal":"29002"},{"longitude":0.0716931,"latitude":35.3157392,"nom":"Tizi","id":"1044","wilaya_id":"29","code_postal":"29003"},{"longitude":-0.004663,"latitude":35.46175820000001,"nom":"Hacine","id":"1045","wilaya_id":"29","code_postal":"29004"},{"longitude":0.2460604,"latitude":35.3798032,"nom":"Maoussa","id":"1046","wilaya_id":"29","code_postal":"29005"},{"longitude":0.3296454,"latitude":35.4154336,"nom":"Teghennif","id":"1047","wilaya_id":"29","code_postal":"29006"},{"longitude":0.3789103,"latitude":35.4106358,"nom":"El Hachem","id":"1048","wilaya_id":"29","code_postal":"29007"},{"longitude":0.3416407,"latitude":35.3317591,"nom":"Sidi Kada","id":"1049","wilaya_id":"29","code_postal":"29008"},{"longitude":0.4752897,"latitude":35.2917125,"nom":"Zelmata","id":"1050","wilaya_id":"29","code_postal":"29009"},{"longitude":0.687574,"latitude":35.4551984,"nom":"Oued El Abtal","id":"1051","wilaya_id":"29","code_postal":"29010"},{"longitude":0.7853762999999999,"latitude":35.3811088,"nom":"Ain Ferah","id":"1052","wilaya_id":"29","code_postal":"29011"},{"longitude":0.1682271,"latitude":35.2367082,"nom":"Ghriss","id":"1053","wilaya_id":"29","code_postal":"29012"},{"longitude":0.1282536,"latitude":35.3026637,"nom":"Froha","id":"1054","wilaya_id":"29","code_postal":"29013"},{"longitude":0.2150873,"latitude":35.31351,"nom":"Matemore","id":"1055","wilaya_id":"29","code_postal":"29014"},{"longitude":0.2807868,"latitude":35.19253940000001,"nom":"Makdha","id":"1056","wilaya_id":"29","code_postal":"29015"},{"longitude":0.2807868,"latitude":35.280438,"nom":"Sidi Boussaid","id":"1057","wilaya_id":"29","code_postal":"29016"},{"longitude":0.3277829,"latitude":35.510608,"nom":"El Bordj","id":"1058","wilaya_id":"29","code_postal":"29017"},{"longitude":-0.0139908,"latitude":35.2203411,"nom":"Ain Fekan","id":"1059","wilaya_id":"29","code_postal":"29018"},{"longitude":0.25,"latitude":35.1,"nom":"Benian","id":"1060","wilaya_id":"29","code_postal":"29019"},{"longitude":0.2948797,"latitude":35.4613997,"nom":"Khalouia","id":"1061","wilaya_id":"29","code_postal":"29020"},{"longitude":0.4219444,"latitude":35.5322149,"nom":"El Menaouer","id":"1062","wilaya_id":"29","code_postal":"29021"},{"longitude":0.09103159999999999,"latitude":35.1130905,"nom":"Oued Taria","id":"1063","wilaya_id":"29","code_postal":"29022"},{"longitude":0.3560076,"latitude":35.104351,"nom":"Aouf","id":"1064","wilaya_id":"29","code_postal":"29023"},{"longitude":0.2432307,"latitude":35.4560355,"nom":"Ain Fares","id":"1065","wilaya_id":"29","code_postal":"29024"},{"longitude":-0.1682271,"latitude":35.5437798,"nom":"Sig","id":"1067","wilaya_id":"29","code_postal":"29026"},{"longitude":-0.2584835,"latitude":35.5614065,"nom":"Oggaz","id":"1068","wilaya_id":"29","code_postal":"29027"},{"longitude":-0.3144193,"latitude":35.4274033,"nom":"El Gaada","id":"1070","wilaya_id":"29","code_postal":"29029"},{"longitude":-0.4078058,"latitude":35.5158402,"nom":"Zahana","id":"1071","wilaya_id":"29","code_postal":"29030"},{"longitude":0.05599390000000001,"latitude":35.5876568,"nom":"Mohammadia","id":"1072","wilaya_id":"29","code_postal":"29031"},{"longitude":0.0128247,"latitude":35.6546506,"nom":"Sidi Abdelmoumene","id":"1073","wilaya_id":"29","code_postal":"29032"},{"longitude":0.2068827,"latitude":35.6872612,"nom":"El Ghomri","id":"1075","wilaya_id":"29","code_postal":"29034"},{"longitude":0.2120588,"latitude":35.6293922,"nom":"Sedjerara","id":"1076","wilaya_id":"29","code_postal":"29035"},{"longitude":-0.0489902,"latitude":35.6068031,"nom":"Moctadouz","id":"1077","wilaya_id":"29","code_postal":"29036"},{"longitude":-0.0863581,"latitude":35.5575475,"nom":"Bou Henni","id":"1078","wilaya_id":"29","code_postal":"29037"},{"longitude":0.1404947,"latitude":35.4256036,"nom":"El Mamounia","id":"1080","wilaya_id":"29","code_postal":"29039"},{"longitude":0.09243169999999999,"latitude":35.3800031,"nom":"El Keurt","id":"1081","wilaya_id":"29","code_postal":"29040"},{"longitude":0.4465984,"latitude":35.1259091,"nom":"Gharrous","id":"1082","wilaya_id":"29","code_postal":"29041"},{"longitude":-0.259657,"latitude":35.39296849999999,"nom":"Chorfa","id":"1084","wilaya_id":"29","code_postal":"29043"},{"longitude":0.5233310999999999,"latitude":35.4425889,"nom":"Sidi Abdeldjebar","id":"1087","wilaya_id":"29","code_postal":"29046"},{"longitude":0.403094,"latitude":35.4446508,"nom":"Sehailia","id":"1088","wilaya_id":"29","code_postal":"29047"},{"longitude":4.976654,"latitude":32.1677808,"nom":"Ouargla","id":"1089","wilaya_id":"30","code_postal":"30001"},{"longitude":5.395264,"latitude":31.945266,"nom":"Ain Beida","id":"1090","wilaya_id":"30","code_postal":"30002"},{"longitude":5.3128644,"latitude":32.1399866,"nom":"Ngoussa","id":"1091","wilaya_id":"30","code_postal":"30003"},{"longitude":5.393955099999999,"latitude":30.416772,"nom":"Hassi Messaoud","id":"1092","wilaya_id":"30","code_postal":"30004"},{"longitude":5.3468563,"latitude":31.9317115,"nom":"Rouissat","id":"1093","wilaya_id":"30","code_postal":"30005"},{"longitude":5.9753267,"latitude":32.9447252,"nom":"Balidat Ameur","id":"1094","wilaya_id":"30","code_postal":"30006"},{"longitude":6.0838065,"latitude":33.1161615,"nom":"Tebesbest","id":"1095","wilaya_id":"30","code_postal":"30007"},{"longitude":6.067641,"latitude":33.094041,"nom":"Nezla","id":"1096","wilaya_id":"30","code_postal":"30008"},{"longitude":6.093076,"latitude":33.2906594,"nom":"Sidi Slimane","id":"1098","wilaya_id":"30","code_postal":"30010"},{"longitude":5.417519,"latitude":31.9769255,"nom":"Sidi Khouiled","id":"1099","wilaya_id":"30","code_postal":"30011"},{"longitude":5.4691361,"latitude":32.025631,"nom":"Hassi Ben Abdellah","id":"1100","wilaya_id":"30","code_postal":"30012"},{"longitude":6.0785104,"latitude":33.0996078,"nom":"Touggourt","id":"1101","wilaya_id":"30","code_postal":"30013"},{"longitude":5.514493000000001,"latitude":32.6142956,"nom":"El Hadjira","id":"1102","wilaya_id":"30","code_postal":"30014"},{"longitude":6.399750099999999,"latitude":33.0863448,"nom":"Taibet","id":"1103","wilaya_id":"30","code_postal":"30015"},{"longitude":6.0212106,"latitude":33.01456710000001,"nom":"Tamacine","id":"1104","wilaya_id":"30","code_postal":"30016"},{"longitude":6.445015799999999,"latitude":33.1092231,"nom":"Benaceur","id":"1105","wilaya_id":"30","code_postal":"30017"},{"longitude":6.094400299999999,"latitude":33.1940606,"nom":"Megarine","id":"1107","wilaya_id":"30","code_postal":"30019"},{"longitude":5.4227567,"latitude":32.6999655,"nom":"El Allia","id":"1108","wilaya_id":"30","code_postal":"30020"},{"longitude":8.1338558,"latitude":31.0062563,"nom":"El Borma","id":"1109","wilaya_id":"30","code_postal":"30021"},{"longitude":-0.6337376,"latitude":35.6976541,"nom":"Oran","id":"1110","wilaya_id":"31","code_postal":"31001"},{"longitude":-0.4691097,"latitude":35.8052667,"nom":"Gdyel","id":"1111","wilaya_id":"31","code_postal":"31002"},{"longitude":-0.554149,"latitude":35.7284976,"nom":"Bir El Djir","id":"1112","wilaya_id":"31","code_postal":"31003"},{"longitude":-0.4785495,"latitude":35.6851254,"nom":"Hassi Bounif","id":"1113","wilaya_id":"31","code_postal":"31004"},{"longitude":-0.6061329999999999,"latitude":35.6202476,"nom":"Es Senia","id":"1114","wilaya_id":"31","code_postal":"31005"},{"longitude":-0.3465971,"latitude":35.8602138,"nom":"Arzew","id":"1115","wilaya_id":"31","code_postal":"31006"},{"longitude":-0.2338473,"latitude":35.7513806,"nom":"Bethioua","id":"1116","wilaya_id":"31","code_postal":"31007"},{"longitude":-0.1682271,"latitude":35.762407,"nom":"Marsat El Hadjadj","id":"1117","wilaya_id":"31","code_postal":"31008"},{"longitude":-0.8008388,"latitude":35.74895300000001,"nom":"Ain Turk","id":"1118","wilaya_id":"31","code_postal":"31009"},{"longitude":-0.4596721,"latitude":35.5539698,"nom":"Oued Tlelat","id":"1120","wilaya_id":"31","code_postal":"31011"},{"longitude":-0.5446911999999999,"latitude":35.4550561,"nom":"Tafraoui","id":"1121","wilaya_id":"31","code_postal":"31012"},{"longitude":-0.5446911999999999,"latitude":35.673918,"nom":"Sidi Chami","id":"1122","wilaya_id":"31","code_postal":"31013"},{"longitude":-0.3936722,"latitude":35.6307787,"nom":"Boufatis","id":"1123","wilaya_id":"31","code_postal":"31014"},{"longitude":-0.7105267,"latitude":35.722219,"nom":"Mers El Kebir","id":"1124","wilaya_id":"31","code_postal":"31015"},{"longitude":-0.7813933,"latitude":35.7184264,"nom":"Bousfer","id":"1125","wilaya_id":"31","code_postal":"31016"},{"longitude":-1.0011902,"latitude":35.627277,"nom":"El Karma","id":"1126","wilaya_id":"31","code_postal":"31017"},{"longitude":-0.4974359,"latitude":35.6194616,"nom":"El Braya","id":"1127","wilaya_id":"31","code_postal":"31018"},{"longitude":-0.4676447,"latitude":35.7289564,"nom":"Hassi Ben Okba","id":"1128","wilaya_id":"31","code_postal":"31019"},{"longitude":-0.3654204,"latitude":35.7292156,"nom":"Ben Freha","id":"1129","wilaya_id":"31","code_postal":"31020"},{"longitude":-0.374617,"latitude":35.8010772,"nom":"Hassi Mefsoukh","id":"1130","wilaya_id":"31","code_postal":"31021"},{"longitude":-0.6526335999999999,"latitude":35.6993064,"nom":"Sidi Ben Yabka","id":"1131","wilaya_id":"31","code_postal":"31022"},{"longitude":-0.7722973999999999,"latitude":35.5852064,"nom":"Messerghin","id":"1132","wilaya_id":"31","code_postal":"31023"},{"longitude":-0.8865833999999999,"latitude":35.5844234,"nom":"Boutlelis","id":"1133","wilaya_id":"31","code_postal":"31024"},{"longitude":-1.0011902,"latitude":35.627277,"nom":"Ain Kerma","id":"1134","wilaya_id":"31","code_postal":"31025"},{"longitude":-0.2816754,"latitude":35.8081628,"nom":"Ain Biya","id":"1135","wilaya_id":"31","code_postal":"31026"},{"longitude":1.0203224,"latitude":33.65813869999999,"nom":"El Bayadh","id":"1136","wilaya_id":"32","code_postal":"32001"},{"longitude":0.9271366999999999,"latitude":34.0188896,"nom":"Rogassa","id":"1137","wilaya_id":"32","code_postal":"32002"},{"longitude":1.2506002,"latitude":33.8348155,"nom":"Stitten","id":"1138","wilaya_id":"32","code_postal":"32003"},{"longitude":1.2586654,"latitude":33.0978041,"nom":"Brezina","id":"1139","wilaya_id":"32","code_postal":"32004"},{"longitude":1.2001181,"latitude":33.3793059,"nom":"Ghassoul","id":"1140","wilaya_id":"32","code_postal":"32005"},{"longitude":1.5329678,"latitude":33.7283305,"nom":"Boualem","id":"1141","wilaya_id":"32","code_postal":"32006"},{"longitude":0.5399631,"latitude":32.9031575,"nom":"El Abiodh Sidi Cheikh","id":"1142","wilaya_id":"32","code_postal":"32007"},{"longitude":0.7390245,"latitude":33.4081281,"nom":"Ain El Orak","id":"1143","wilaya_id":"32","code_postal":"32008"},{"longitude":0.5849023999999999,"latitude":33.0916013,"nom":"Arbaouat","id":"1144","wilaya_id":"32","code_postal":"32009"},{"longitude":0.09103159999999999,"latitude":34.0390465,"nom":"Bougtoub","id":"1145","wilaya_id":"32","code_postal":"32010"},{"longitude":0.0700051,"latitude":34.1364841,"nom":"El Kheither","id":"1146","wilaya_id":"32","code_postal":"32011"},{"longitude":0.0233208,"latitude":32.8704903,"nom":"Boussemghoun","id":"1148","wilaya_id":"32","code_postal":"32013"},{"longitude":0.06066369999999999,"latitude":33.0394912,"nom":"Chellala","id":"1149","wilaya_id":"32","code_postal":"32014"},{"longitude":1.4362206,"latitude":33.7685936,"nom":"Sidi Ameur","id":"1153","wilaya_id":"32","code_postal":"32018"},{"longitude":0.3642437,"latitude":33.3130066,"nom":"El Mehara","id":"1154","wilaya_id":"32","code_postal":"32019"},{"longitude":0.3113278,"latitude":33.6479569,"nom":"Tousmouline","id":"1155","wilaya_id":"32","code_postal":"32020"},{"longitude":1.7271179,"latitude":33.83187789999999,"nom":"Sidi Slimane","id":"1156","wilaya_id":"32","code_postal":"32021"},{"longitude":1.683333,"latitude":33.716667,"nom":"Sidi Tifour","id":"1157","wilaya_id":"32","code_postal":"32022"},{"longitude":8.4732718,"latitude":26.5094346,"nom":"Illizi","id":"1158","wilaya_id":"33","code_postal":"33001"},{"longitude":9.4811604,"latitude":24.5545691,"nom":"Djanet","id":"1159","wilaya_id":"33","code_postal":"33002"},{"longitude":9.422346,"latitude":29.9672147,"nom":"Debdeb","id":"1160","wilaya_id":"33","code_postal":"33003"},{"longitude":6.7547522,"latitude":28.115695,"nom":"Bordj Omar Driss","id":"1161","wilaya_id":"33","code_postal":"33004"},{"longitude":8.434873,"latitude":24.8849934,"nom":"Bordj El Haouasse","id":"1162","wilaya_id":"33","code_postal":"33005"},{"longitude":9.5784754,"latitude":28.0461513,"nom":"In Amenas","id":"1163","wilaya_id":"33","code_postal":"33006"},{"longitude":4.7564046,"latitude":36.0704188,"nom":"Bordj Bou Arreridj","id":"1164","wilaya_id":"34","code_postal":"34001"},{"longitude":5.0356951,"latitude":35.947031,"nom":"Ras El Oued","id":"1165","wilaya_id":"34","code_postal":"34002"},{"longitude":4.883185,"latitude":36.2612267,"nom":"Bordj Zemoura","id":"1166","wilaya_id":"34","code_postal":"34003"},{"longitude":4.43879,"latitude":36.1376769,"nom":"Mansoura","id":"1167","wilaya_id":"34","code_postal":"34004"},{"longitude":4.3895593,"latitude":36.1184335,"nom":"El Mhir","id":"1168","wilaya_id":"34","code_postal":"34005"},{"longitude":4.1419948,"latitude":36.0673882,"nom":"Ben Daoud","id":"1169","wilaya_id":"34","code_postal":"34006"},{"longitude":4.624375100000001,"latitude":36.0655916,"nom":"El Achir","id":"1170","wilaya_id":"34","code_postal":"34007"},{"longitude":5.1223608,"latitude":36.1321301,"nom":"Ain Taghrout","id":"1171","wilaya_id":"34","code_postal":"34008"},{"longitude":4.9247074,"latitude":35.9124803,"nom":"Bordj Ghdir","id":"1172","wilaya_id":"34","code_postal":"34009"},{"longitude":4.914323899999999,"latitude":36.0974673,"nom":"Sidi Embarek","id":"1173","wilaya_id":"34","code_postal":"34010"},{"longitude":4.7795149,"latitude":35.983529,"nom":"El Hamadia","id":"1174","wilaya_id":"34","code_postal":"34011"},{"longitude":4.914323899999999,"latitude":35.9672331,"nom":"Belimour","id":"1175","wilaya_id":"34","code_postal":"34012"},{"longitude":4.6714821,"latitude":36.1340533,"nom":"Medjana","id":"1176","wilaya_id":"34","code_postal":"34013"},{"longitude":4.6001675,"latitude":36.2312193,"nom":"Teniet En Nasr","id":"1177","wilaya_id":"34","code_postal":"34014"},{"longitude":4.6628371,"latitude":36.2922699,"nom":"Djaafra","id":"1178","wilaya_id":"34","code_postal":"34015"},{"longitude":4.738017,"latitude":36.3719865,"nom":"El Main","id":"1179","wilaya_id":"34","code_postal":"34016"},{"longitude":5.080691799999999,"latitude":35.8733817,"nom":"Ouled Brahem","id":"1180","wilaya_id":"34","code_postal":"34017"},{"longitude":4.7701642,"latitude":36.2214873,"nom":"Ouled Dahmane","id":"1181","wilaya_id":"34","code_postal":"34018"},{"longitude":4.7955348,"latitude":36.1520672,"nom":"Hasnaoua","id":"1182","wilaya_id":"34","code_postal":"34019"},{"longitude":4.997446099999999,"latitude":36.2240477,"nom":"Khelil","id":"1183","wilaya_id":"34","code_postal":"34020"},{"longitude":4.9870491,"latitude":35.8011473,"nom":"Taglait","id":"1184","wilaya_id":"34","code_postal":"34021"},{"longitude":4.5956667,"latitude":35.9921303,"nom":"Ksour","id":"1185","wilaya_id":"34","code_postal":"34022"},{"longitude":4.3340554,"latitude":36.2289906,"nom":"Ouled Sidi Brahim","id":"1186","wilaya_id":"34","code_postal":"34023"},{"longitude":4.6657027,"latitude":36.2374167,"nom":"Colla","id":"1188","wilaya_id":"34","code_postal":"34025"},{"longitude":5.1223608,"latitude":36.0453882,"nom":"Tixter","id":"1189","wilaya_id":"34","code_postal":"34026"},{"longitude":4.624375100000001,"latitude":35.8917787,"nom":"El Ach","id":"1190","wilaya_id":"34","code_postal":"34027"},{"longitude":4.8013775,"latitude":36.0470339,"nom":"El Anseur","id":"1191","wilaya_id":"34","code_postal":"34028"},{"longitude":4.800233299999999,"latitude":36.2645778,"nom":"Tesmart","id":"1192","wilaya_id":"34","code_postal":"34029"},{"longitude":5.002327,"latitude":36.0367494,"nom":"Ain Tesra","id":"1193","wilaya_id":"34","code_postal":"34030"},{"longitude":5.027662299999999,"latitude":36.1463398,"nom":"Bir Kasdali","id":"1194","wilaya_id":"34","code_postal":"34031"},{"longitude":4.9039424,"latitude":35.8480848,"nom":"Ghilassa","id":"1195","wilaya_id":"34","code_postal":"34032"},{"longitude":4.7795149,"latitude":35.8965925,"nom":"Rabta","id":"1196","wilaya_id":"34","code_postal":"34033"},{"longitude":4.2538452,"latitude":36.1660564,"nom":"Haraza","id":"1197","wilaya_id":"34","code_postal":"34034"},{"longitude":3.4851867,"latitude":36.7580109,"nom":"Boumerdes","id":"1198","wilaya_id":"35","code_postal":"35001"},{"longitude":3.4296446,"latitude":36.7003998,"nom":"Boudouaou","id":"1199","wilaya_id":"35","code_postal":"35002"},{"longitude":3.9897847,"latitude":36.8433446,"nom":"Afir","id":"1200","wilaya_id":"35","code_postal":"35004"},{"longitude":3.753666299999999,"latitude":36.7552496,"nom":"Bordj Menaiel","id":"1201","wilaya_id":"35","code_postal":"35005"},{"longitude":3.8757119,"latitude":36.7943784,"nom":"Baghlia","id":"1202","wilaya_id":"35","code_postal":"35006"},{"longitude":3.8583028,"latitude":36.85560630000001,"nom":"Sidi Daoud","id":"1203","wilaya_id":"35","code_postal":"35007"},{"longitude":3.8146526,"latitude":36.7317908,"nom":"Naciria","id":"1204","wilaya_id":"35","code_postal":"35008"},{"longitude":3.7333537,"latitude":36.8419263,"nom":"Djinet","id":"1205","wilaya_id":"35","code_postal":"35009"},{"longitude":3.6724649,"latitude":36.6931797,"nom":"Isser","id":"1206","wilaya_id":"35","code_postal":"35010"},{"longitude":3.6010514,"latitude":36.7859638,"nom":"Zemmouri","id":"1207","wilaya_id":"35","code_postal":"35011"},{"longitude":3.6116494,"latitude":36.7381058,"nom":"Si Mustapha","id":"1208","wilaya_id":"35","code_postal":"35012"},{"longitude":3.4902391,"latitude":36.720184,"nom":"Tidjelabine","id":"1209","wilaya_id":"35","code_postal":"35013"},{"longitude":3.682608,"latitude":36.6174343,"nom":"Chabet El Ameur","id":"1210","wilaya_id":"35","code_postal":"35014"},{"longitude":3.5509074,"latitude":36.7399281,"nom":"Thenia","id":"1211","wilaya_id":"35","code_postal":"35015"},{"longitude":3.7993992,"latitude":36.662278,"nom":"Timezrit","id":"1212","wilaya_id":"35","code_postal":"35018"},{"longitude":3.4447863,"latitude":36.73765480000001,"nom":"Corso","id":"1213","wilaya_id":"35","code_postal":"35019"},{"longitude":3.3892894,"latitude":36.6800054,"nom":"Ouled Moussa","id":"1214","wilaya_id":"35","code_postal":"35020"},{"longitude":3.371541,"latitude":36.636145,"nom":"Larbatache","id":"1215","wilaya_id":"35","code_postal":"35021"},{"longitude":3.4789503,"latitude":36.6261517,"nom":"Bouzegza Keddara","id":"1216","wilaya_id":"35","code_postal":"35022"},{"longitude":3.9368439,"latitude":36.7923763,"nom":"Taourga","id":"1217","wilaya_id":"35","code_postal":"35025"},{"longitude":3.8146526,"latitude":36.79634679999999,"nom":"Ouled Aissa","id":"1218","wilaya_id":"35","code_postal":"35026"},{"longitude":3.9011747,"latitude":36.8526735,"nom":"Ben Choud","id":"1219","wilaya_id":"35","code_postal":"35027"},{"longitude":3.9368439,"latitude":36.8783599,"nom":"Dellys","id":"1220","wilaya_id":"35","code_postal":"35028"},{"longitude":3.5913939,"latitude":36.6309911,"nom":"Ammal","id":"1221","wilaya_id":"35","code_postal":"35029"},{"longitude":3.5762077,"latitude":36.65839270000001,"nom":"Beni Amrane","id":"1222","wilaya_id":"35","code_postal":"35030"},{"longitude":3.5863313,"latitude":36.69041170000001,"nom":"Souk El Had","id":"1223","wilaya_id":"35","code_postal":"35031"},{"longitude":3.394332,"latitude":36.7606292,"nom":"Boudouaou El Bahri","id":"1224","wilaya_id":"35","code_postal":"35032"},{"longitude":3.3439291,"latitude":36.7082162,"nom":"Ouled Hedadj","id":"1225","wilaya_id":"35","code_postal":"35033"},{"longitude":3.2633918,"latitude":36.6781231,"nom":"Hammedi","id":"1227","wilaya_id":"35","code_postal":"35036"},{"longitude":3.3288183,"latitude":36.6385933,"nom":"Khemis El Khechna","id":"1228","wilaya_id":"35","code_postal":"35037"},{"longitude":3.4296446,"latitude":36.6141776,"nom":"El Kharrouba","id":"1229","wilaya_id":"35","code_postal":"35038"},{"longitude":8.2869478,"latitude":36.7298829,"nom":"El Tarf","id":"1230","wilaya_id":"36","code_postal":"36001"},{"longitude":8.112011599999999,"latitude":36.5275079,"nom":"Bouhadjar","id":"1231","wilaya_id":"36","code_postal":"36002"},{"longitude":7.981084500000001,"latitude":36.7508388,"nom":"Ben Mhidi","id":"1232","wilaya_id":"36","code_postal":"36003"},{"longitude":8.374571699999999,"latitude":36.68089880000001,"nom":"Bougous","id":"1233","wilaya_id":"36","code_postal":"36004"},{"longitude":8.4450763,"latitude":36.8904568,"nom":"El Kala","id":"1234","wilaya_id":"36","code_postal":"36005"},{"longitude":8.4293891,"latitude":36.7947505,"nom":"Ain El Assel","id":"1235","wilaya_id":"36","code_postal":"36006"},{"longitude":8.6270628,"latitude":36.8232929,"nom":"El Aioun","id":"1236","wilaya_id":"36","code_postal":"36007"},{"longitude":8.1994276,"latitude":36.7787756,"nom":"Bouteldja","id":"1237","wilaya_id":"36","code_postal":"36008"},{"longitude":8.5940814,"latitude":36.8791039,"nom":"Souarekh","id":"1238","wilaya_id":"36","code_postal":"36009"},{"longitude":8.068343,"latitude":36.8305549,"nom":"Berrihane","id":"1239","wilaya_id":"36","code_postal":"36010"},{"longitude":8.101092000000001,"latitude":36.7748272,"nom":"Lac Des Oiseaux","id":"1240","wilaya_id":"36","code_postal":"36011"},{"longitude":8.112011599999999,"latitude":36.6562562,"nom":"Chefia","id":"1241","wilaya_id":"36","code_postal":"36012"},{"longitude":7.730807,"latitude":36.6923855,"nom":"Drean","id":"1242","wilaya_id":"36","code_postal":"36013"},{"longitude":7.850395099999999,"latitude":36.6309261,"nom":"Chihani","id":"1243","wilaya_id":"36","code_postal":"36014"},{"longitude":7.7090854,"latitude":36.7366692,"nom":"Chebaita Mokhtar","id":"1244","wilaya_id":"36","code_postal":"36015"},{"longitude":7.806885100000001,"latitude":36.7195675,"nom":"Besbes","id":"1245","wilaya_id":"36","code_postal":"36016"},{"longitude":7.981084500000001,"latitude":36.6651214,"nom":"Asfour","id":"1246","wilaya_id":"36","code_postal":"36017"},{"longitude":7.861276699999999,"latitude":36.8123586,"nom":"Echatt","id":"1247","wilaya_id":"36","code_postal":"36018"},{"longitude":7.904820000000001,"latitude":36.7238061,"nom":"Zerizer","id":"1248","wilaya_id":"36","code_postal":"36019"},{"longitude":8.243174699999999,"latitude":36.6472292,"nom":"Zitouna","id":"1249","wilaya_id":"36","code_postal":"36020"},{"longitude":8.1994276,"latitude":36.5644539,"nom":"Ain Kerma","id":"1250","wilaya_id":"36","code_postal":"36021"},{"longitude":8.0356087,"latitude":36.4359809,"nom":"Oued Zitoun","id":"1251","wilaya_id":"36","code_postal":"36022"},{"longitude":7.981084500000001,"latitude":36.536361,"nom":"Hammam Beni Salah","id":"1252","wilaya_id":"36","code_postal":"36023"},{"longitude":8.5355489,"latitude":36.7865239,"nom":"Raml Souk","id":"1253","wilaya_id":"36","code_postal":"36024"},{"longitude":-8.1276526,"latitude":27.6761012,"nom":"Tindouf","id":"1254","wilaya_id":"37","code_postal":"37001"},{"longitude":-5.393955099999999,"latitude":28.1934255,"nom":"Oum El Assel","id":"1255","wilaya_id":"37","code_postal":"37002"},{"longitude":1.8074586,"latitude":35.6015182,"nom":"Tissemsilt","id":"1256","wilaya_id":"38","code_postal":"38001"},{"longitude":1.615375,"latitude":35.8526248,"nom":"Bordj Bou Naama","id":"1257","wilaya_id":"38","code_postal":"38002"},{"longitude":2.0077316,"latitude":35.8767044,"nom":"Theniet El Had","id":"1258","wilaya_id":"38","code_postal":"38003"},{"longitude":1.5620347,"latitude":35.9350445,"nom":"Lazharia","id":"1259","wilaya_id":"38","code_postal":"38004"},{"longitude":1.5450766,"latitude":35.7471861,"nom":"Lardjem","id":"1261","wilaya_id":"38","code_postal":"38006"},{"longitude":1.3360772,"latitude":35.7128273,"nom":"Melaab","id":"1262","wilaya_id":"38","code_postal":"38007"},{"longitude":1.5064654,"latitude":35.6961771,"nom":"Sidi Lantri","id":"1263","wilaya_id":"38","code_postal":"38008"},{"longitude":2.2605775,"latitude":35.864058,"nom":"Bordj El Emir Abdelkader","id":"1264","wilaya_id":"38","code_postal":"38009"},{"longitude":1.9954938,"latitude":35.6887221,"nom":"Layoune","id":"1265","wilaya_id":"38","code_postal":"38010"},{"longitude":1.961246,"latitude":35.6674352,"nom":"Khemisti","id":"1266","wilaya_id":"38","code_postal":"38011"},{"longitude":1.866667,"latitude":35.683333,"nom":"Ouled Bessem","id":"1267","wilaya_id":"38","code_postal":"38012"},{"longitude":1.7510636,"latitude":35.6725615,"nom":"Ammari","id":"1268","wilaya_id":"38","code_postal":"38013"},{"longitude":2.1125019,"latitude":35.947749,"nom":"Youssoufia","id":"1269","wilaya_id":"38","code_postal":"38014"},{"longitude":1.9484098,"latitude":35.8252207,"nom":"Sidi Boutouchent","id":"1270","wilaya_id":"38","code_postal":"38015"},{"longitude":1.7076637,"latitude":35.7422684,"nom":"Sidi Abed","id":"1273","wilaya_id":"38","code_postal":"38018"},{"longitude":1.6842771,"latitude":35.8651956,"nom":"Sidi Slimane","id":"1275","wilaya_id":"38","code_postal":"38020"},{"longitude":1.615375,"latitude":35.8907698,"nom":"Boucaid","id":"1276","wilaya_id":"38","code_postal":"38021"},{"longitude":1.6894332,"latitude":35.8148108,"nom":"Beni Lahcene","id":"1277","wilaya_id":"38","code_postal":"38022"},{"longitude":6.8479682,"latitude":33.3713397,"nom":"El Oued","id":"1278","wilaya_id":"39","code_postal":"39001"},{"longitude":6.9048148,"latitude":33.2859695,"nom":"Robbah","id":"1279","wilaya_id":"39","code_postal":"39002"},{"longitude":6.7547522,"latitude":33.2383162,"nom":"Oued El Alenda","id":"1280","wilaya_id":"39","code_postal":"39003"},{"longitude":6.8930418,"latitude":33.3209357,"nom":"Bayadha","id":"1281","wilaya_id":"39","code_postal":"39004"},{"longitude":6.9504378,"latitude":33.2806326,"nom":"Nakhla","id":"1282","wilaya_id":"39","code_postal":"39005"},{"longitude":6.8029489,"latitude":33.5092788,"nom":"Guemar","id":"1283","wilaya_id":"39","code_postal":"39006"},{"longitude":6.829740300000001,"latitude":33.4018134,"nom":"Kouinine","id":"1284","wilaya_id":"39","code_postal":"39007"},{"longitude":6.722640999999999,"latitude":33.5638323,"nom":"Reguiba","id":"1285","wilaya_id":"39","code_postal":"39008"},{"longitude":6.2303867,"latitude":34.1108764,"nom":"Hamraia","id":"1286","wilaya_id":"39","code_postal":"39009"},{"longitude":6.797592,"latitude":33.470536,"nom":"Taghzout","id":"1287","wilaya_id":"39","code_postal":"39010"},{"longitude":6.952532799999999,"latitude":33.5148096,"nom":"Debila","id":"1288","wilaya_id":"39","code_postal":"39011"},{"longitude":6.894084599999999,"latitude":33.4763609,"nom":"Hassani Abdelkrim","id":"1289","wilaya_id":"39","code_postal":"39012"},{"longitude":6.9907197,"latitude":33.5601263,"nom":"Hassi Khelifa","id":"1290","wilaya_id":"39","code_postal":"39013"},{"longitude":7.394882000000001,"latitude":33.7091203,"nom":"Taleb Larbi","id":"1291","wilaya_id":"39","code_postal":"39014"},{"longitude":7.6114217,"latitude":32.6678571,"nom":"Douar El Ma","id":"1292","wilaya_id":"39","code_postal":"39015"},{"longitude":6.9067231,"latitude":33.5451746,"nom":"Sidi Aoun","id":"1293","wilaya_id":"39","code_postal":"39016"},{"longitude":6.935674,"latitude":33.4196537,"nom":"Trifaoui","id":"1294","wilaya_id":"39","code_postal":"39017"},{"longitude":6.9308492,"latitude":33.56150909999999,"nom":"Magrane","id":"1295","wilaya_id":"39","code_postal":"39018"},{"longitude":7.179025999999999,"latitude":34.0327057,"nom":"Beni Guecha","id":"1296","wilaya_id":"39","code_postal":"39019"},{"longitude":6.7828626,"latitude":33.4141525,"nom":"Ourmas","id":"1297","wilaya_id":"39","code_postal":"39020"},{"longitude":5.772120399999999,"latitude":34.3284258,"nom":"Still","id":"1298","wilaya_id":"39","code_postal":"39021"},{"longitude":5.6628859,"latitude":33.4703125,"nom":"Mrara","id":"1299","wilaya_id":"39","code_postal":"39022"},{"longitude":5.9607892,"latitude":33.8381481,"nom":"Sidi Khellil","id":"1300","wilaya_id":"39","code_postal":"39023"},{"longitude":6.033511400000001,"latitude":33.6745734,"nom":"Tendla","id":"1301","wilaya_id":"39","code_postal":"39024"},{"longitude":6.943726600000001,"latitude":33.2460788,"nom":"El Ogla","id":"1302","wilaya_id":"39","code_postal":"39025"},{"longitude":6.707928700000001,"latitude":33.197504,"nom":"Mih Ouansa","id":"1303","wilaya_id":"39","code_postal":"39026"},{"longitude":5.9304039,"latitude":33.9327331,"nom":"El Mghair","id":"1304","wilaya_id":"39","code_postal":"39027"},{"longitude":5.986358600000001,"latitude":33.5383569,"nom":"Djamaa","id":"1305","wilaya_id":"39","code_postal":"39028"},{"longitude":6.012463899999999,"latitude":33.499649,"nom":"Sidi Amrane","id":"1307","wilaya_id":"39","code_postal":"39030"},{"longitude":7.1467072,"latitude":35.4309947,"nom":"Khenchela","id":"1308","wilaya_id":"40","code_postal":"40001"},{"longitude":7.2450588,"latitude":35.6007746,"nom":"Mtoussa","id":"1309","wilaya_id":"40","code_postal":"40002"},{"longitude":6.9262805,"latitude":35.4929142,"nom":"Kais","id":"1310","wilaya_id":"40","code_postal":"40003"},{"longitude":7.113058199999999,"latitude":35.5215422,"nom":"Baghai","id":"1311","wilaya_id":"40","code_postal":"40004"},{"longitude":7.0848063,"latitude":35.4646303,"nom":"El Hamma","id":"1312","wilaya_id":"40","code_postal":"40005"},{"longitude":7.464693700000001,"latitude":35.44189190000001,"nom":"Ain Touila","id":"1313","wilaya_id":"40","code_postal":"40006"},{"longitude":6.7467229,"latitude":35.3202828,"nom":"Bouhmama","id":"1315","wilaya_id":"40","code_postal":"40008"},{"longitude":6.6831929,"latitude":34.9151135,"nom":"El Oueldja","id":"1316","wilaya_id":"40","code_postal":"40009"},{"longitude":6.8981083,"latitude":35.5721583,"nom":"Remila","id":"1317","wilaya_id":"40","code_postal":"40010"},{"longitude":7.0095263,"latitude":35.0372584,"nom":"Cherchar","id":"1318","wilaya_id":"40","code_postal":"40011"},{"longitude":6.8927435,"latitude":34.9191877,"nom":"Djellal","id":"1319","wilaya_id":"40","code_postal":"40012"},{"longitude":7.100948799999999,"latitude":35.1688096,"nom":"Babar","id":"1320","wilaya_id":"40","code_postal":"40013"},{"longitude":6.833333,"latitude":35.316667,"nom":"Tamza","id":"1321","wilaya_id":"40","code_postal":"40014"},{"longitude":7.1419953,"latitude":35.395142,"nom":"Ensigha","id":"1322","wilaya_id":"40","code_postal":"40015"},{"longitude":7.352415399999999,"latitude":35.2956216,"nom":"Ouled Rechache","id":"1323","wilaya_id":"40","code_postal":"40016"},{"longitude":6.574334899999999,"latitude":35.2382122,"nom":"Msara","id":"1325","wilaya_id":"40","code_postal":"40018"},{"longitude":6.643769,"latitude":35.41198809999999,"nom":"Yabous","id":"1326","wilaya_id":"40","code_postal":"40019"},{"longitude":6.760774899999999,"latitude":34.9986118,"nom":"Khirane","id":"1327","wilaya_id":"40","code_postal":"40020"},{"longitude":6.7801849,"latitude":35.3634675,"nom":"Chelia","id":"1328","wilaya_id":"40","code_postal":"40021"},{"longitude":7.948389799999999,"latitude":36.2695872,"nom":"Souk Ahras","id":"1329","wilaya_id":"41","code_postal":"41001"},{"longitude":7.532566000000001,"latitude":36.13085600000001,"nom":"Sedrata","id":"1330","wilaya_id":"41","code_postal":"41002"},{"longitude":7.7878579,"latitude":36.261304,"nom":"Hanancha","id":"1331","wilaya_id":"41","code_postal":"41003"},{"longitude":7.835435500000001,"latitude":36.3565044,"nom":"Mechroha","id":"1332","wilaya_id":"41","code_postal":"41004"},{"longitude":7.7878579,"latitude":36.1911936,"nom":"Tiffech","id":"1334","wilaya_id":"41","code_postal":"41006"},{"longitude":7.956561999999999,"latitude":36.228617,"nom":"Zaarouria","id":"1335","wilaya_id":"41","code_postal":"41007"},{"longitude":8.0437909,"latitude":36.163447,"nom":"Taoura","id":"1336","wilaya_id":"41","code_postal":"41008"},{"longitude":7.8816843,"latitude":36.1216219,"nom":"Drea","id":"1337","wilaya_id":"41","code_postal":"41009"},{"longitude":8.333485099999999,"latitude":36.229847,"nom":"Haddada","id":"1338","wilaya_id":"41","code_postal":"41010"},{"longitude":8.3225325,"latitude":36.284474,"nom":"Khedara","id":"1339","wilaya_id":"41","code_postal":"41011"},{"longitude":8.150243300000001,"latitude":36.1966832,"nom":"Merahna","id":"1340","wilaya_id":"41","code_postal":"41012"},{"longitude":8.3307468,"latitude":36.3834462,"nom":"Ouled Moumen","id":"1341","wilaya_id":"41","code_postal":"41013"},{"longitude":7.4300234,"latitude":36.0140333,"nom":"Bir Bouhouche","id":"1342","wilaya_id":"41","code_postal":"41014"},{"longitude":7.8204791,"latitude":36.0756762,"nom":"Mdaourouche","id":"1343","wilaya_id":"41","code_postal":"41015"},{"longitude":7.6032892,"latitude":36.0302067,"nom":"Oum El Adhaim","id":"1344","wilaya_id":"41","code_postal":"41016"},{"longitude":8.1912279,"latitude":36.4011867,"nom":"Ain Zana","id":"1345","wilaya_id":"41","code_postal":"41017"},{"longitude":7.4915642,"latitude":35.9296769,"nom":"Safel El Ouiden","id":"1349","wilaya_id":"41","code_postal":"41021"},{"longitude":7.6520984,"latitude":36.194568,"nom":"Khemissa","id":"1351","wilaya_id":"41","code_postal":"41023"},{"longitude":7.917071299999999,"latitude":35.9246613,"nom":"Oued Keberit","id":"1352","wilaya_id":"41","code_postal":"41024"},{"longitude":7.597868099999999,"latitude":35.884391,"nom":"Terraguelt","id":"1353","wilaya_id":"41","code_postal":"41025"},{"longitude":8.1378124,"latitude":35.9596833,"nom":"Zouabi","id":"1354","wilaya_id":"41","code_postal":"41026"},{"longitude":2.3912362,"latitude":36.6178786,"nom":"Tipaza","id":"1355","wilaya_id":"42","code_postal":"42001"},{"longitude":2.2433487,"latitude":36.4803387,"nom":"Menaceur","id":"1356","wilaya_id":"42","code_postal":"42002"},{"longitude":1.8023093,"latitude":36.5570162,"nom":"Larhat","id":"1357","wilaya_id":"42","code_postal":"42003"},{"longitude":2.7972634,"latitude":36.6785804,"nom":"Douaouda","id":"1358","wilaya_id":"42","code_postal":"42004"},{"longitude":2.5098914,"latitude":36.4858595,"nom":"Bourkika","id":"1359","wilaya_id":"42","code_postal":"42005"},{"longitude":2.6834778,"latitude":36.6170732,"nom":"Khemisti","id":"1360","wilaya_id":"42","code_postal":"42006"},{"longitude":2.4141276,"latitude":36.5124409,"nom":"Hadjout","id":"1362","wilaya_id":"42","code_postal":"42012"},{"longitude":2.3123031,"latitude":36.5330597,"nom":"Sidi Amar","id":"1363","wilaya_id":"42","code_postal":"42013"},{"longitude":1.9294681,"latitude":36.5290373,"nom":"Gouraya","id":"1364","wilaya_id":"42","code_postal":"42014"},{"longitude":2.3665549,"latitude":36.5805948,"nom":"Nodor","id":"1365","wilaya_id":"42","code_postal":"42015"},{"longitude":2.728219,"latitude":36.6106665,"nom":"Chaiba","id":"1366","wilaya_id":"42","code_postal":"42016"},{"longitude":2.5842062,"latitude":36.5868863,"nom":"Ain Tagourait","id":"1367","wilaya_id":"42","code_postal":"42017"},{"longitude":2.2039933,"latitude":36.567504,"nom":"Cherchel","id":"1368","wilaya_id":"42","code_postal":"42022"},{"longitude":1.7052325,"latitude":36.5000176,"nom":"Damous","id":"1369","wilaya_id":"42","code_postal":"42023"},{"longitude":2.3714901,"latitude":36.4670595,"nom":"Meurad","id":"1370","wilaya_id":"42","code_postal":"42024"},{"longitude":2.7530936,"latitude":36.65863160000001,"nom":"Fouka","id":"1371","wilaya_id":"42","code_postal":"42025"},{"longitude":2.7033575,"latitude":36.6381992,"nom":"Bou Ismail","id":"1372","wilaya_id":"42","code_postal":"42026"},{"longitude":2.5693337,"latitude":36.5062122,"nom":"Ahmer El Ain","id":"1373","wilaya_id":"42","code_postal":"42027"},{"longitude":2.6536742,"latitude":36.6177382,"nom":"Bou Haroun","id":"1374","wilaya_id":"42","code_postal":"42030"},{"longitude":2.1155691,"latitude":36.5583006,"nom":"Sidi Ghiles","id":"1375","wilaya_id":"42","code_postal":"42032"},{"longitude":2.0077316,"latitude":36.4845193,"nom":"Messelmoun","id":"1376","wilaya_id":"42","code_postal":"42033"},{"longitude":2.5296971,"latitude":36.5502644,"nom":"Sidi Rached","id":"1377","wilaya_id":"42","code_postal":"42034"},{"longitude":2.7708021,"latitude":36.6432441,"nom":"Kolea","id":"1378","wilaya_id":"42","code_postal":"42035"},{"longitude":2.6387795,"latitude":36.558707,"nom":"Attatba","id":"1379","wilaya_id":"42","code_postal":"42036"},{"longitude":2.086133,"latitude":36.4831797,"nom":"Sidi Semiane","id":"1380","wilaya_id":"42","code_postal":"42040"},{"longitude":1.7344155,"latitude":36.4455299,"nom":"Beni Milleuk","id":"1381","wilaya_id":"42","code_postal":"42041"},{"longitude":2.0567163,"latitude":36.5593263,"nom":"Hadjerat Ennous","id":"1382","wilaya_id":"42","code_postal":"42042"},{"longitude":6.2535257,"latitude":36.4512301,"nom":"Mila","id":"1383","wilaya_id":"43","code_postal":"43001"},{"longitude":5.9304039,"latitude":36.4084009,"nom":"Ferdjioua","id":"1384","wilaya_id":"43","code_postal":"43002"},{"longitude":6.195132,"latitude":36.1464769,"nom":"Chelghoum Laid","id":"1385","wilaya_id":"43","code_postal":"43003"},{"longitude":6.3438785,"latitude":36.2900333,"nom":"Oued Athmenia","id":"1386","wilaya_id":"43","code_postal":"43004"},{"longitude":6.173911599999999,"latitude":36.2557129,"nom":"Ain Mellouk","id":"1387","wilaya_id":"43","code_postal":"43005"},{"longitude":6.3438785,"latitude":36.0737429,"nom":"Telerghma","id":"1388","wilaya_id":"43","code_postal":"43006"},{"longitude":6.429036,"latitude":36.199047,"nom":"Oued Seguen","id":"1389","wilaya_id":"43","code_postal":"43007"},{"longitude":6.0044121,"latitude":36.1345369,"nom":"Tadjenanet","id":"1390","wilaya_id":"43","code_postal":"43008"},{"longitude":6.0044121,"latitude":36.22109409999999,"nom":"Benyahia Abderrahmane","id":"1391","wilaya_id":"43","code_postal":"43009"},{"longitude":6.2092318,"latitude":36.521883,"nom":"Oued Endja","id":"1392","wilaya_id":"43","code_postal":"43010"},{"longitude":6.131492799999999,"latitude":36.3442991,"nom":"Ahmed Rachedi","id":"1393","wilaya_id":"43","code_postal":"43011"},{"longitude":6.089103199999999,"latitude":36.00025370000001,"nom":"Ouled Khalouf","id":"1394","wilaya_id":"43","code_postal":"43012"},{"longitude":6.0573302,"latitude":36.4020351,"nom":"Tiberguent","id":"1395","wilaya_id":"43","code_postal":"43013"},{"longitude":6.0467429,"latitude":36.3054223,"nom":"Bouhatem","id":"1396","wilaya_id":"43","code_postal":"43014"},{"longitude":5.993833899999999,"latitude":36.4699357,"nom":"Rouached","id":"1397","wilaya_id":"43","code_postal":"43015"},{"longitude":6.317290600000001,"latitude":36.5232782,"nom":"Grarem Gouga","id":"1399","wilaya_id":"43","code_postal":"43017"},{"longitude":6.2482149,"latitude":36.4999929,"nom":"Sidi Merouane","id":"1400","wilaya_id":"43","code_postal":"43018"},{"longitude":5.7932008,"latitude":36.5337153,"nom":"Tassadane Haddada","id":"1401","wilaya_id":"43","code_postal":"43019"},{"longitude":5.9198387,"latitude":36.3117689,"nom":"Derradji Bousselah","id":"1402","wilaya_id":"43","code_postal":"43020"},{"longitude":5.9304039,"latitude":36.5377483,"nom":"Minar Zarza","id":"1403","wilaya_id":"43","code_postal":"43021"},{"longitude":6.142094699999999,"latitude":36.5485751,"nom":"Terrai Bainen","id":"1405","wilaya_id":"43","code_postal":"43023"},{"longitude":6.341219199999999,"latitude":36.5731327,"nom":"Hamala","id":"1406","wilaya_id":"43","code_postal":"43024"},{"longitude":6.325265799999999,"latitude":36.3962417,"nom":"Ain Tine","id":"1407","wilaya_id":"43","code_postal":"43025"},{"longitude":6.2163597,"latitude":36.0370883,"nom":"El Mechira","id":"1408","wilaya_id":"43","code_postal":"43026"},{"longitude":6.2535257,"latitude":36.3649586,"nom":"Sidi Khelifa","id":"1409","wilaya_id":"43","code_postal":"43027"},{"longitude":6.173911599999999,"latitude":36.4715385,"nom":"Zeghaia","id":"1410","wilaya_id":"43","code_postal":"43028"},{"longitude":5.824835200000001,"latitude":36.4351668,"nom":"Elayadi Barbes","id":"1411","wilaya_id":"43","code_postal":"43029"},{"longitude":5.8670405,"latitude":36.389948,"nom":"Ain Beida Harriche","id":"1412","wilaya_id":"43","code_postal":"43030"},{"longitude":5.993833899999999,"latitude":36.383658,"nom":"Yahia Beniguecha","id":"1413","wilaya_id":"43","code_postal":"43031"},{"longitude":6.2216678,"latitude":36.5605977,"nom":"Chigara","id":"1414","wilaya_id":"43","code_postal":"43032"},{"longitude":1.9641065,"latitude":36.263186,"nom":"Ain Defla","id":"1415","wilaya_id":"44","code_postal":"44001"},{"longitude":2.2335066,"latitude":36.3181921,"nom":"Miliana","id":"1416","wilaya_id":"44","code_postal":"44002"},{"longitude":2.5197932,"latitude":36.3450137,"nom":"Boumedfaa","id":"1417","wilaya_id":"44","code_postal":"44003"},{"longitude":2.2138289,"latitude":36.2535274,"nom":"Khemis Miliana","id":"1418","wilaya_id":"44","code_postal":"44004"},{"longitude":2.3616203,"latitude":36.3915345,"nom":"Hammam Righa","id":"1419","wilaya_id":"44","code_postal":"44005"},{"longitude":2.0469151,"latitude":36.3540148,"nom":"Arib","id":"1420","wilaya_id":"44","code_postal":"44006"},{"longitude":2.086133,"latitude":36.1798746,"nom":"Djelida","id":"1421","wilaya_id":"44","code_postal":"44007"},{"longitude":1.851343,"latitude":36.3571923,"nom":"El Amra","id":"1422","wilaya_id":"44","code_postal":"44008"},{"longitude":1.9294681,"latitude":36.1824916,"nom":"Bourached","id":"1423","wilaya_id":"44","code_postal":"44009"},{"longitude":1.7052325,"latitude":36.2184385,"nom":"El Attaf","id":"1424","wilaya_id":"44","code_postal":"44010"},{"longitude":1.6566377,"latitude":36.2733492,"nom":"El Abadia","id":"1425","wilaya_id":"44","code_postal":"44011"},{"longitude":2.4136924,"latitude":36.2181875,"nom":"Djendel","id":"1426","wilaya_id":"44","code_postal":"44012"},{"longitude":2.5495112,"latitude":36.1383732,"nom":"Oued Chorfa","id":"1427","wilaya_id":"44","code_postal":"44013"},{"longitude":2.4011124,"latitude":36.1305702,"nom":"Ain Lechiakh","id":"1428","wilaya_id":"44","code_postal":"44014"},{"longitude":2.3616203,"latitude":36.04442969999999,"nom":"Oued Djemaa","id":"1429","wilaya_id":"44","code_postal":"44015"},{"longitude":1.8220818,"latitude":36.2384198,"nom":"Rouina","id":"1430","wilaya_id":"44","code_postal":"44016"},{"longitude":1.8220818,"latitude":36.1515977,"nom":"Zeddine","id":"1431","wilaya_id":"44","code_postal":"44017"},{"longitude":1.9294681,"latitude":36.0086314,"nom":"El Hassania","id":"1432","wilaya_id":"44","code_postal":"44018"},{"longitude":2.2138289,"latitude":36.1884431,"nom":"Bir Ouled Khelifa","id":"1433","wilaya_id":"44","code_postal":"44019"},{"longitude":2.325157700000001,"latitude":36.23139030000001,"nom":"Ain Soltane","id":"1434","wilaya_id":"44","code_postal":"44020"},{"longitude":2.1646722,"latitude":35.9611096,"nom":"Tarik Ibn Ziad","id":"1435","wilaya_id":"44","code_postal":"44021"},{"longitude":2.1646722,"latitude":36.09160809999999,"nom":"Bordj Emir Khaled","id":"1436","wilaya_id":"44","code_postal":"44022"},{"longitude":2.2827384,"latitude":36.3497591,"nom":"Ain Torki","id":"1437","wilaya_id":"44","code_postal":"44023"},{"longitude":0.4431618,"latitude":36.1618701,"nom":"Sidi Lakhdar","id":"1438","wilaya_id":"44","code_postal":"44024"},{"longitude":2.1646722,"latitude":36.3519477,"nom":"Ben Allal","id":"1439","wilaya_id":"44","code_postal":"44025"},{"longitude":2.3764258,"latitude":36.3533538,"nom":"Ain Benian","id":"1440","wilaya_id":"44","code_postal":"44026"},{"longitude":2.4011124,"latitude":36.3041215,"nom":"Hoceinia","id":"1441","wilaya_id":"44","code_postal":"44027"},{"longitude":2.4900943,"latitude":36.0961767,"nom":"Barbouche","id":"1442","wilaya_id":"44","code_postal":"44028"},{"longitude":2.0077316,"latitude":36.0943295,"nom":"Djemaa Ouled Chikh","id":"1443","wilaya_id":"44","code_postal":"44029"},{"longitude":1.9588007,"latitude":36.3446556,"nom":"Mekhatria","id":"1444","wilaya_id":"44","code_postal":"44030"},{"longitude":1.7830973,"latitude":35.9346997,"nom":"Bathia","id":"1445","wilaya_id":"44","code_postal":"44031"},{"longitude":1.7733566,"latitude":36.3150386,"nom":"Ain Bouyahia","id":"1447","wilaya_id":"44","code_postal":"44033"},{"longitude":1.7344155,"latitude":36.09858,"nom":"El Maine","id":"1448","wilaya_id":"44","code_postal":"44034"},{"longitude":1.6469253,"latitude":36.1541243,"nom":"Tiberkanine","id":"1449","wilaya_id":"44","code_postal":"44035"},{"longitude":1.8512951,"latitude":35.9824454,"nom":"Belaas","id":"1450","wilaya_id":"44","code_postal":"44036"},{"longitude":-0.3748354,"latitude":33.1683267,"nom":"Naama","id":"1451","wilaya_id":"45","code_postal":"45001"},{"longitude":-0.2762707,"latitude":33.5442772,"nom":"Mechria","id":"1452","wilaya_id":"45","code_postal":"45002"},{"longitude":-0.5778033,"latitude":32.75633320000001,"nom":"Ain Sefra","id":"1453","wilaya_id":"45","code_postal":"45003"},{"longitude":-0.4266584,"latitude":32.7682249,"nom":"Tiout","id":"1454","wilaya_id":"45","code_postal":"45004"},{"longitude":-0.9820667999999999,"latitude":32.8046166,"nom":"Sfissifa","id":"1455","wilaya_id":"45","code_postal":"45005"},{"longitude":-0.5754372999999999,"latitude":32.5161631,"nom":"Moghrar","id":"1456","wilaya_id":"45","code_postal":"45006"},{"longitude":-0.0793488,"latitude":33.005701,"nom":"Assela","id":"1457","wilaya_id":"45","code_postal":"45007"},{"longitude":-0.9438468,"latitude":32.397902,"nom":"Djeniane Bourzeg","id":"1458","wilaya_id":"45","code_postal":"45008"},{"longitude":-0.763049,"latitude":33.288551,"nom":"Ain Ben Khelil","id":"1459","wilaya_id":"45","code_postal":"45009"},{"longitude":-0.7271479000000001,"latitude":33.7189056,"nom":"Makman Ben Amer","id":"1460","wilaya_id":"45","code_postal":"45010"},{"longitude":-1.375755,"latitude":33.713589,"nom":"Kasdir","id":"1461","wilaya_id":"45","code_postal":"45011"},{"longitude":-0.1284404,"latitude":33.7600866,"nom":"El Biod","id":"1462","wilaya_id":"45","code_postal":"45012"},{"longitude":-1.1424514,"latitude":35.3072501,"nom":"Ain Temouchent","id":"1463","wilaya_id":"46","code_postal":"46001"},{"longitude":-1.1017334,"latitude":35.3361405,"nom":"Chaabet El Ham","id":"1464","wilaya_id":"46","code_postal":"46002"},{"longitude":-1.2001181,"latitude":35.2006828,"nom":"Ain Kihal","id":"1465","wilaya_id":"46","code_postal":"46003"},{"longitude":-0.9677300999999999,"latitude":35.3701948,"nom":"Hammam Bouhadjar","id":"1466","wilaya_id":"46","code_postal":"46004"},{"longitude":-1.1424989,"latitude":35.5795438,"nom":"Bou Zedjar","id":"1467","wilaya_id":"46","code_postal":"46005"},{"longitude":-0.9856518000000001,"latitude":35.2204682,"nom":"Oued Berkeche","id":"1468","wilaya_id":"46","code_postal":"46006"},{"longitude":-1.065797,"latitude":35.2019341,"nom":"Aghlal","id":"1469","wilaya_id":"46","code_postal":"46007"},{"longitude":-1.1797022,"latitude":35.4190324,"nom":"Terga","id":"1470","wilaya_id":"46","code_postal":"46008"},{"longitude":-0.8818151,"latitude":35.4037488,"nom":"Ain El Arbaa","id":"1471","wilaya_id":"46","code_postal":"46009"},{"longitude":-0.6607039,"latitude":35.4133773,"nom":"Tamzoura","id":"1472","wilaya_id":"46","code_postal":"46010"},{"longitude":-1.0119509,"latitude":35.29988,"nom":"Chentouf","id":"1473","wilaya_id":"46","code_postal":"46011"},{"longitude":-1.1809029,"latitude":35.3052158,"nom":"Sidi Ben Adda","id":"1474","wilaya_id":"46","code_postal":"46012"},{"longitude":-0.9928226000000001,"latitude":35.1379554,"nom":"Aoubellil","id":"1475","wilaya_id":"46","code_postal":"46013"},{"longitude":-1.0945436,"latitude":35.3883099,"nom":"El Malah","id":"1476","wilaya_id":"46","code_postal":"46014"},{"longitude":-0.8949292999999999,"latitude":35.35292740000001,"nom":"Sidi Boumediene","id":"1477","wilaya_id":"46","code_postal":"46015"},{"longitude":-0.8127369000000001,"latitude":35.3740738,"nom":"Oued Sabah","id":"1478","wilaya_id":"46","code_postal":"46016"},{"longitude":-1.1917104,"latitude":35.4709656,"nom":"Ouled Boudjemaa","id":"1479","wilaya_id":"46","code_postal":"46017"},{"longitude":-1.2530057,"latitude":35.2550837,"nom":"Ain Tolba","id":"1480","wilaya_id":"46","code_postal":"46018"},{"longitude":-1.0179304,"latitude":35.5259362,"nom":"El Amria","id":"1481","wilaya_id":"46","code_postal":"46019"},{"longitude":-1.0514312,"latitude":35.4544602,"nom":"Hassi El Ghella","id":"1482","wilaya_id":"46","code_postal":"46020"},{"longitude":-0.9880123,"latitude":35.273753,"nom":"Hassasna","id":"1483","wilaya_id":"46","code_postal":"46021"},{"longitude":-1.2217459,"latitude":35.3733876,"nom":"Ouled Kihal","id":"1484","wilaya_id":"46","code_postal":"46022"},{"longitude":-1.3710402,"latitude":35.3004743,"nom":"Beni Saf","id":"1485","wilaya_id":"46","code_postal":"46023"},{"longitude":-1.3107772,"latitude":35.2819277,"nom":"Sidi Safi","id":"1486","wilaya_id":"46","code_postal":"46024"},{"longitude":-1.1424514,"latitude":35.3072501,"nom":"Oulhaca El Gheraba","id":"1487","wilaya_id":"46","code_postal":"46025"},{"longitude":-1.4476979,"latitude":35.24262340000001,"nom":"Tadmaya","id":"1488","wilaya_id":"46","code_postal":"46026"},{"longitude":-1.4072392,"latitude":35.2204402,"nom":"El Emir Abdelkader","id":"1489","wilaya_id":"46","code_postal":"46027"},{"longitude":3.6738412,"latitude":32.4902246,"nom":"Ghardaia","id":"1491","wilaya_id":"47","code_postal":"47001"},{"longitude":2.8876436,"latitude":30.59958869999999,"nom":"El Meniaa","id":"1492","wilaya_id":"47","code_postal":"47002"},{"longitude":3.6116494,"latitude":32.5421541,"nom":"Dhayet Bendhahoua","id":"1493","wilaya_id":"47","code_postal":"47003"},{"longitude":3.7718098,"latitude":32.8337669,"nom":"Berriane","id":"1494","wilaya_id":"47","code_postal":"47004"},{"longitude":3.5989888,"latitude":32.2908262,"nom":"Metlili","id":"1495","wilaya_id":"47","code_postal":"47005"},{"longitude":4.492221499999999,"latitude":32.7900544,"nom":"El Guerrara","id":"1496","wilaya_id":"47","code_postal":"47006"},{"longitude":3.7471211,"latitude":32.4766504,"nom":"El Atteuf","id":"1497","wilaya_id":"47","code_postal":"47007"},{"longitude":4.2230836,"latitude":32.4101618,"nom":"Zelfana","id":"1498","wilaya_id":"47","code_postal":"47008"},{"longitude":3.5838002,"latitude":32.1666038,"nom":"Sebseb","id":"1499","wilaya_id":"47","code_postal":"47009"},{"longitude":3.6015207,"latitude":32.4633255,"nom":"Bounoura","id":"1500","wilaya_id":"47","code_postal":"47010"},{"longitude":3.6762683,"latitude":31.6027043,"nom":"Hassi Fehal","id":"1501","wilaya_id":"47","code_postal":"47011"},{"longitude":2.9126022,"latitude":30.5472849,"nom":"Hassi Gara","id":"1502","wilaya_id":"47","code_postal":"47012"},{"longitude":3.751126799999999,"latitude":31.9802146,"nom":"Mansoura","id":"1503","wilaya_id":"47","code_postal":"47013"},{"longitude":0.5588787,"latitude":35.7339361,"nom":"Relizane","id":"1504","wilaya_id":"48","code_postal":"48001"},{"longitude":0.9199773,"latitude":35.9607107,"nom":"Oued Rhiou","id":"1505","wilaya_id":"48","code_postal":"48002"},{"longitude":0.5057015,"latitude":35.8528374,"nom":"Belaassel Bouzegza","id":"1506","wilaya_id":"48","code_postal":"48003"},{"longitude":0.3407167,"latitude":35.6760307,"nom":"Sidi Saada","id":"1507","wilaya_id":"48","code_postal":"48004"},{"longitude":0.9641466999999999,"latitude":35.8255092,"nom":"Ouled Aiche","id":"1508","wilaya_id":"48","code_postal":"48005"},{"longitude":0.7782418,"latitude":35.6466822,"nom":"Sidi Lazreg","id":"1509","wilaya_id":"48","code_postal":"48006"},{"longitude":0.774675,"latitude":35.90454769999999,"nom":"El Hamadna","id":"1510","wilaya_id":"48","code_postal":"48007"},{"longitude":0.8413067999999999,"latitude":36.1434513,"nom":"Sidi Mhamed Ben Ali","id":"1511","wilaya_id":"48","code_postal":"48008"},{"longitude":0.7544692000000001,"latitude":36.1263731,"nom":"Mediouna","id":"1512","wilaya_id":"48","code_postal":"48009"},{"longitude":0.5139688,"latitude":35.9113884,"nom":"Sidi Khettab","id":"1513","wilaya_id":"48","code_postal":"48010"},{"longitude":1.1089244,"latitude":35.8692431,"nom":"Ammi Moussa","id":"1514","wilaya_id":"48","code_postal":"48011"},{"longitude":0.7509045,"latitude":35.7247051,"nom":"Zemmoura","id":"1515","wilaya_id":"48","code_postal":"48012"},{"longitude":0.8317813000000001,"latitude":35.9259567,"nom":"Djidiouia","id":"1517","wilaya_id":"48","code_postal":"48014"},{"longitude":0.8246386,"latitude":36.091951,"nom":"El Guettar","id":"1518","wilaya_id":"48","code_postal":"48015"},{"longitude":0.701233,"latitude":36.019135,"nom":"Hamri","id":"1519","wilaya_id":"48","code_postal":"48016"},{"longitude":0.4620313,"latitude":35.731615,"nom":"El Matmar","id":"1520","wilaya_id":"48","code_postal":"48017"},{"longitude":0.5872689999999999,"latitude":35.6026539,"nom":"Sidi Mhamed Ben Aouda","id":"1521","wilaya_id":"48","code_postal":"48018"},{"longitude":1.1377008,"latitude":35.7762676,"nom":"Ain Tarek","id":"1522","wilaya_id":"48","code_postal":"48019"},{"longitude":0.9259434000000001,"latitude":35.5800262,"nom":"Oued Essalem","id":"1523","wilaya_id":"48","code_postal":"48020"},{"longitude":0.8996991999999999,"latitude":36.0465615,"nom":"Ouarizane","id":"1524","wilaya_id":"48","code_postal":"48021"},{"longitude":0.8770473,"latitude":36.1187509,"nom":"Mazouna","id":"1525","wilaya_id":"48","code_postal":"48022"},{"longitude":0.3289585,"latitude":35.5803849,"nom":"Kalaa","id":"1526","wilaya_id":"48","code_postal":"48023"},{"longitude":0.3919059,"latitude":35.6246337,"nom":"Ain Rahma","id":"1527","wilaya_id":"48","code_postal":"48024"},{"longitude":0.3536548,"latitude":35.7210595,"nom":"Yellel","id":"1528","wilaya_id":"48","code_postal":"48025"},{"longitude":0.6796767000000001,"latitude":35.7960821,"nom":"Oued El Djemaa","id":"1529","wilaya_id":"48","code_postal":"48026"},{"longitude":1.2818815,"latitude":35.8675295,"nom":"Ramka","id":"1530","wilaya_id":"48","code_postal":"48027"},{"longitude":0.8651302999999999,"latitude":35.6474585,"nom":"Mendes","id":"1531","wilaya_id":"48","code_postal":"48028"},{"longitude":0.9796769999999999,"latitude":35.8921599,"nom":"Lahlef","id":"1532","wilaya_id":"48","code_postal":"48029"},{"longitude":0.6642606999999999,"latitude":36.1106051,"nom":"Beni Zentis","id":"1533","wilaya_id":"48","code_postal":"48030"},{"longitude":1.248195,"latitude":35.9550366,"nom":"Souk El Haad","id":"1534","wilaya_id":"48","code_postal":"48031"},{"longitude":0.6832351,"latitude":35.6991649,"nom":"Dar Ben Abdellah","id":"1535","wilaya_id":"48","code_postal":"48032"},{"longitude":-0.6618221999999999,"latitude":35.6895866,"nom":"El Hassi","id":"1536","wilaya_id":"48","code_postal":"48033"},{"longitude":1.1484972,"latitude":35.6792524,"nom":"Had Echkalla","id":"1537","wilaya_id":"48","code_postal":"48034"},{"longitude":0.5186938,"latitude":35.7150028,"nom":"Bendaoud","id":"1538","wilaya_id":"48","code_postal":"48035"},{"longitude":1.1185143,"latitude":35.9072969,"nom":"El Ouldja","id":"1539","wilaya_id":"48","code_postal":"48036"}]
+[
+    {
+     "longitude": -0.1869644,
+     "latitude": 27.9716342,
+     "nom": "Adrar",
+     "id": "1",
+     "wilaya_id": "1",
+     "code_postal": "01001"
+    },
+    {
+     "longitude": -0.2457477,
+     "latitude": 27.4257241,
+     "nom": "Tamest",
+     "id": "2",
+     "wilaya_id": "1",
+     "code_postal": "01002"
+    },
+    {
+     "longitude": -0.259657,
+     "latitude": 29.0195565,
+     "nom": "Charouine",
+     "id": "3",
+     "wilaya_id": "1",
+     "code_postal": "01003"
+    },
+    {
+     "longitude": -1.5208624,
+     "latitude": 25.2759633,
+     "nom": "Reggane",
+     "id": "4",
+     "wilaya_id": "1",
+     "code_postal": "01004"
+    },
+    {
+     "longitude": 1.4869856,
+     "latitude": 26.936237,
+     "nom": "Tit",
+     "id": "6",
+     "wilaya_id": "1",
+     "code_postal": "01006"
+    },
+    {
+     "longitude": 0.3724815,
+     "latitude": 29.5827395,
+     "nom": "Ksar Kaddour",
+     "id": "7",
+     "wilaya_id": "1",
+     "code_postal": "01007"
+    },
+    {
+     "longitude": -0.2186041,
+     "latitude": 28.3504036,
+     "nom": "Tsabit",
+     "id": "8",
+     "wilaya_id": "1",
+     "code_postal": "01008"
+    },
+    {
+     "longitude": 0.2385387,
+     "latitude": 29.2609217,
+     "nom": "Timimoun",
+     "id": "9",
+     "wilaya_id": "1",
+     "code_postal": "01009"
+    },
+    {
+     "longitude": 0.2455769,
+     "latitude": 29.4206093,
+     "nom": "Ouled Said",
+     "id": "10",
+     "wilaya_id": "1",
+     "code_postal": "01010"
+    },
+    {
+     "longitude": -0.2010233,
+     "latitude": 27.2263135,
+     "nom": "Zaouiet Kounta",
+     "id": "11",
+     "wilaya_id": "1",
+     "code_postal": "01011"
+    },
+    {
+     "longitude": 1.0729818,
+     "latitude": 26.9752935,
+     "nom": "Aoulef",
+     "id": "12",
+     "wilaya_id": "1",
+     "code_postal": "01012"
+    },
+    {
+     "longitude": 1.0442502,
+     "latitude": 27.0225931,
+     "nom": "Timokten",
+     "id": "13",
+     "wilaya_id": "1",
+     "code_postal": "01013"
+    },
+    {
+     "longitude": -0.266699,
+     "latitude": 27.7664008,
+     "nom": "Tamentit",
+     "id": "14",
+     "wilaya_id": "1",
+     "code_postal": "01014"
+    },
+    {
+     "longitude": -0.3042778,
+     "latitude": 27.6490194,
+     "nom": "Fenoughil",
+     "id": "15",
+     "wilaya_id": "1",
+     "code_postal": "01015"
+    },
+    {
+     "longitude": 0.7105267,
+     "latitude": 29.711749,
+     "nom": "Tinerkouk",
+     "id": "16",
+     "wilaya_id": "1",
+     "code_postal": "01016"
+    },
+    {
+     "longitude": -0.0877444,
+     "latitude": 27.0363493,
+     "nom": "Sali",
+     "id": "18",
+     "wilaya_id": "1",
+     "code_postal": "01018"
+    },
+    {
+     "longitude": 1.3613923,
+     "latitude": 26.7018955,
+     "nom": "Akabli",
+     "id": "19",
+     "wilaya_id": "1",
+     "code_postal": "01019"
+    },
+    {
+     "longitude": -0.1448182,
+     "latitude": 28.5972281,
+     "nom": "Metarfa",
+     "id": "20",
+     "wilaya_id": "1",
+     "code_postal": "01020"
+    },
+    {
+     "longitude": -0.2807577,
+     "latitude": 27.8515174,
+     "nom": "O Ahmed Timmi",
+     "id": "21",
+     "wilaya_id": "1",
+     "code_postal": "01021"
+    },
+    {
+     "longitude": -0.4246315,
+     "latitude": 27.9554196,
+     "nom": "Bouda",
+     "id": "22",
+     "wilaya_id": "1",
+     "code_postal": "01022"
+    },
+    {
+     "longitude": 0.25,
+     "latitude": 28.75,
+     "nom": "Aougrout",
+     "id": "23",
+     "wilaya_id": "1",
+     "code_postal": "01023"
+    },
+    {
+     "longitude": -0.9056623,
+     "latitude": 23.760643,
+     "nom": "B Badji Mokhtar",
+     "id": "25",
+     "wilaya_id": "1",
+     "code_postal": "01025"
+    },
+    {
+     "longitude": -0.1729106,
+     "latitude": 28.211617,
+     "nom": "Sbaa",
+     "id": "26",
+     "wilaya_id": "1",
+     "code_postal": "01026"
+    },
+    {
+     "longitude": -0.08869479999999999,
+     "latitude": 29.4237071,
+     "nom": "Ouled Aissa",
+     "id": "27",
+     "wilaya_id": "1",
+     "code_postal": "01027"
+    },
+    {
+     "longitude": 1.6760691,
+     "latitude": 20.8948062,
+     "nom": "Timiaouine",
+     "id": "28",
+     "wilaya_id": "1",
+     "code_postal": "01028"
+    },
+    {
+     "longitude": 1.3083685,
+     "latitude": 36.147424,
+     "nom": "Chlef",
+     "id": "29",
+     "wilaya_id": "2",
+     "code_postal": "02001"
+    },
+    {
+     "longitude": 1.3180042,
+     "latitude": 36.5049038,
+     "nom": "Tenes",
+     "id": "30",
+     "wilaya_id": "2",
+     "code_postal": "02002"
+    },
+    {
+     "longitude": 1.374987,
+     "latitude": 36.3540039,
+     "nom": "Benairia",
+     "id": "31",
+     "wilaya_id": "2",
+     "code_postal": "02003"
+    },
+    {
+     "longitude": 1.5693045,
+     "latitude": 36.08997910000001,
+     "nom": "El Karimia",
+     "id": "32",
+     "wilaya_id": "2",
+     "code_postal": "02004"
+    },
+    {
+     "longitude": 1.1377008,
+     "latitude": 36.3254557,
+     "nom": "Tadjna",
+     "id": "33",
+     "wilaya_id": "2",
+     "code_postal": "02005"
+    },
+    {
+     "longitude": 0.9223635999999998,
+     "latitude": 36.2459846,
+     "nom": "Taougrite",
+     "id": "34",
+     "wilaya_id": "2",
+     "code_postal": "02006"
+    },
+    {
+     "longitude": 1.5402327,
+     "latitude": 36.4914417,
+     "nom": "Beni Haoua",
+     "id": "35",
+     "wilaya_id": "2",
+     "code_postal": "02007"
+    },
+    {
+     "longitude": 1.110123,
+     "latitude": 36.1100346,
+     "nom": "Sobha",
+     "id": "36",
+     "wilaya_id": "2",
+     "code_postal": "02008"
+    },
+    {
+     "longitude": 1.4918235,
+     "latitude": 36.1126987,
+     "nom": "Harchoun",
+     "id": "37",
+     "wilaya_id": "2",
+     "code_postal": "02009"
+    },
+    {
+     "longitude": 1.236999,
+     "latitude": 36.2316052,
+     "nom": "Ouled Fares",
+     "id": "38",
+     "wilaya_id": "2",
+     "code_postal": "02010"
+    },
+    {
+     "longitude": 1.3469247,
+     "latitude": 36.4505105,
+     "nom": "Sidi Akacha",
+     "id": "39",
+     "wilaya_id": "2",
+     "code_postal": "02011"
+    },
+    {
+     "longitude": 1.1209121,
+     "latitude": 36.0569401,
+     "nom": "Boukadir",
+     "id": "40",
+     "wilaya_id": "2",
+     "code_postal": "02012"
+    },
+    {
+     "longitude": 1.5015009,
+     "latitude": 36.2753891,
+     "nom": "Beni Rached",
+     "id": "41",
+     "wilaya_id": "2",
+     "code_postal": "02013"
+    },
+    {
+     "longitude": 1.0849592,
+     "latitude": 36.4288223,
+     "nom": "Talassa",
+     "id": "42",
+     "wilaya_id": "2",
+     "code_postal": "02014"
+    },
+    {
+     "longitude": 1.0514312,
+     "latitude": 36.2449244,
+     "nom": "Herenfa",
+     "id": "43",
+     "wilaya_id": "2",
+     "code_postal": "02015"
+    },
+    {
+     "longitude": 1.4531355,
+     "latitude": 36.5033408,
+     "nom": "Oued Goussine",
+     "id": "44",
+     "wilaya_id": "2",
+     "code_postal": "02016"
+    },
+    {
+     "longitude": 0.8508345,
+     "latitude": 36.25736,
+     "nom": "Dahra",
+     "id": "45",
+     "wilaya_id": "2",
+     "code_postal": "02017"
+    },
+    {
+     "longitude": 1.4918235,
+     "latitude": 36.2212775,
+     "nom": "Ouled Abbes",
+     "id": "46",
+     "wilaya_id": "2",
+     "code_postal": "02018"
+    },
+    {
+     "longitude": 1.4241426,
+     "latitude": 36.0591718,
+     "nom": "Sendjas",
+     "id": "47",
+     "wilaya_id": "2",
+     "code_postal": "02019"
+    },
+    {
+     "longitude": 1.4628042,
+     "latitude": 36.4058679,
+     "nom": "Zeboudja",
+     "id": "48",
+     "wilaya_id": "2",
+     "code_postal": "02020"
+    },
+    {
+     "longitude": 1.2313618,
+     "latitude": 36.1047797,
+     "nom": "Oued Sly",
+     "id": "49",
+     "wilaya_id": "2",
+     "code_postal": "02021"
+    },
+    {
+     "longitude": 1.1929114,
+     "latitude": 36.4088563,
+     "nom": "Abou El Hassen",
+     "id": "50",
+     "wilaya_id": "2",
+     "code_postal": "02022"
+    },
+    {
+     "longitude": 0.9175911,
+     "latitude": 36.4031597,
+     "nom": "El Marsa",
+     "id": "51",
+     "wilaya_id": "2",
+     "code_postal": "02023"
+    },
+    {
+     "longitude": 1.2409799,
+     "latitude": 36.1589988,
+     "nom": "Chettia",
+     "id": "52",
+     "wilaya_id": "2",
+     "code_postal": "02024"
+    },
+    {
+     "longitude": 1.0957418,
+     "latitude": 36.4922766,
+     "nom": "Sidi Abderrahmane",
+     "id": "53",
+     "wilaya_id": "2",
+     "code_postal": "02025"
+    },
+    {
+     "longitude": 1.0083637,
+     "latitude": 36.3536988,
+     "nom": "Moussadek",
+     "id": "54",
+     "wilaya_id": "2",
+     "code_postal": "02026"
+    },
+    {
+     "longitude": 1.3469247,
+     "latitude": 36.0165552,
+     "nom": "El Hadjadj",
+     "id": "55",
+     "wilaya_id": "2",
+     "code_postal": "02027"
+    },
+    {
+     "longitude": 1.3855161,
+     "latitude": 36.2767832,
+     "nom": "Labiod Medjadja",
+     "id": "56",
+     "wilaya_id": "2",
+     "code_postal": "02028"
+    },
+    {
+     "longitude": 1.5499211,
+     "latitude": 36.1988388,
+     "nom": "Oued Fodda",
+     "id": "57",
+     "wilaya_id": "2",
+     "code_postal": "02029"
+    },
+    {
+     "longitude": 1.2698475,
+     "latitude": 36.0173924,
+     "nom": "Ouled Ben Abdelkader",
+     "id": "58",
+     "wilaya_id": "2",
+     "code_postal": "02030"
+    },
+    {
+     "longitude": 1.2417743,
+     "latitude": 36.3397492,
+     "nom": "Bouzghaia",
+     "id": "59",
+     "wilaya_id": "2",
+     "code_postal": "02031"
+    },
+    {
+     "longitude": 0.9778686,
+     "latitude": 36.1608508,
+     "nom": "Ain Merane",
+     "id": "60",
+     "wilaya_id": "2",
+     "code_postal": "02032"
+    },
+    {
+     "longitude": 1.4144827,
+     "latitude": 36.200509,
+     "nom": "Oum Drou",
+     "id": "61",
+     "wilaya_id": "2",
+     "code_postal": "02033"
+    },
+    {
+     "longitude": 1.5789994,
+     "latitude": 36.447678,
+     "nom": "Breira",
+     "id": "62",
+     "wilaya_id": "2",
+     "code_postal": "02034"
+    },
+    {
+     "longitude": 2.8694065,
+     "latitude": 33.7972551,
+     "nom": "Laghouat",
+     "id": "64",
+     "wilaya_id": "3",
+     "code_postal": "03001"
+    },
+    {
+     "longitude": 3.1328011,
+     "latitude": 33.7847662,
+     "nom": "Ksar El Hirane",
+     "id": "65",
+     "wilaya_id": "3",
+     "code_postal": "03002"
+    },
+    {
+     "longitude": 3.0050628,
+     "latitude": 33.7516533,
+     "nom": "Benacer Ben Chohra",
+     "id": "66",
+     "wilaya_id": "3",
+     "code_postal": "03003"
+    },
+    {
+     "longitude": 3.014781,
+     "latitude": 34.127625,
+     "nom": "Sidi Makhlouf",
+     "id": "67",
+     "wilaya_id": "3",
+     "code_postal": "03004"
+    },
+    {
+     "longitude": 3.5483781,
+     "latitude": 33.4186197,
+     "nom": "Hassi Delaa",
+     "id": "68",
+     "wilaya_id": "3",
+     "code_postal": "03005"
+    },
+    {
+     "longitude": 3.2684215,
+     "latitude": 32.9349916,
+     "nom": "Hassi R Mel",
+     "id": "69",
+     "wilaya_id": "3",
+     "code_postal": "03006"
+    },
+    {
+     "longitude": 2.2999821,
+     "latitude": 33.7946585,
+     "nom": "Ain Mahdi",
+     "id": "70",
+     "wilaya_id": "3",
+     "code_postal": "03007"
+    },
+    {
+     "longitude": 2.5272209,
+     "latitude": 33.8794929,
+     "nom": "Tadjmout",
+     "id": "71",
+     "wilaya_id": "3",
+     "code_postal": "03008"
+    },
+    {
+     "longitude": 2.7954106,
+     "latitude": 33.7453939,
+     "nom": "Kheneg",
+     "id": "72",
+     "wilaya_id": "3",
+     "code_postal": "03009"
+    },
+    {
+     "longitude": 1.9416877,
+     "latitude": 34.2962822,
+     "nom": "Gueltat Sidi Saad",
+     "id": "73",
+     "wilaya_id": "3",
+     "code_postal": "03010"
+    },
+    {
+     "longitude": 1.55,
+     "latitude": 34.1666669,
+     "nom": "Ain Sidi Ali",
+     "id": "74",
+     "wilaya_id": "3",
+     "code_postal": "03011"
+    },
+    {
+     "longitude": 1.7502311,
+     "latitude": 33.9500722,
+     "nom": "Brida",
+     "id": "76",
+     "wilaya_id": "3",
+     "code_postal": "03013"
+    },
+    {
+     "longitude": 2.1437968,
+     "latitude": 33.9299401,
+     "nom": "El Ghicha",
+     "id": "77",
+     "wilaya_id": "3",
+     "code_postal": "03014"
+    },
+    {
+     "longitude": 1.5992068,
+     "latitude": 33.9571296,
+     "nom": "Hadj Mechri",
+     "id": "78",
+     "wilaya_id": "3",
+     "code_postal": "03015"
+    },
+    {
+     "longitude": 1.8635409,
+     "latitude": 33.8689577,
+     "nom": "Taouiala",
+     "id": "80",
+     "wilaya_id": "3",
+     "code_postal": "03017"
+    },
+    {
+     "longitude": 2.101217,
+     "latitude": 33.503632,
+     "nom": "Tadjrouna",
+     "id": "81",
+     "wilaya_id": "3",
+     "code_postal": "03018"
+    },
+    {
+     "longitude": 2.1008486,
+     "latitude": 34.10748640000001,
+     "nom": "Aflou",
+     "id": "82",
+     "wilaya_id": "3",
+     "code_postal": "03019"
+    },
+    {
+     "longitude": 2.990057,
+     "latitude": 33.824559,
+     "nom": "El Assafia",
+     "id": "83",
+     "wilaya_id": "3",
+     "code_postal": "03020"
+    },
+    {
+     "longitude": 2.3166669,
+     "latitude": 34.1666669,
+     "nom": "Oued Morra",
+     "id": "84",
+     "wilaya_id": "3",
+     "code_postal": "03021"
+    },
+    {
+     "longitude": 2.8694065,
+     "latitude": 33.7972551,
+     "nom": "Oued M Zi",
+     "id": "85",
+     "wilaya_id": "3",
+     "code_postal": "03022"
+    },
+    {
+     "longitude": 2.263468,
+     "latitude": 34.342998,
+     "nom": "Sidi Bouzid",
+     "id": "87",
+     "wilaya_id": "3",
+     "code_postal": "03024"
+    },
+    {
+     "longitude": 7.1197867,
+     "latitude": 35.873056,
+     "nom": "Oum El Bouaghi",
+     "id": "88",
+     "wilaya_id": "4",
+     "code_postal": "04001"
+    },
+    {
+     "longitude": 7.392173400000001,
+     "latitude": 35.7981327,
+     "nom": "Ain Beida",
+     "id": "89",
+     "wilaya_id": "4",
+     "code_postal": "04002"
+    },
+    {
+     "longitude": 6.556988199999999,
+     "latitude": 36.0189518,
+     "nom": "Ainmlila",
+     "id": "90",
+     "wilaya_id": "4",
+     "code_postal": "04003"
+    },
+    {
+     "longitude": 7.7185878,
+     "latitude": 35.7940171,
+     "nom": "Behir Chergui",
+     "id": "91",
+     "wilaya_id": "4",
+     "code_postal": "04004"
+    },
+    {
+     "longitude": 6.904832099999999,
+     "latitude": 36.1101777,
+     "nom": "El Amiria",
+     "id": "92",
+     "wilaya_id": "4",
+     "code_postal": "04005"
+    },
+    {
+     "longitude": 6.770813800000001,
+     "latitude": 36.09368440000001,
+     "nom": "Sigus",
+     "id": "93",
+     "wilaya_id": "4",
+     "code_postal": "04006"
+    },
+    {
+     "longitude": 7.788537400000001,
+     "latitude": 35.6653463,
+     "nom": "El Belala",
+     "id": "94",
+     "wilaya_id": "4",
+     "code_postal": "04007"
+    },
+    {
+     "longitude": 7.181719999999999,
+     "latitude": 35.9425396,
+     "nom": "Ain Babouche",
+     "id": "95",
+     "wilaya_id": "4",
+     "code_postal": "04008"
+    },
+    {
+     "longitude": 7.3759671,
+     "latitude": 35.9144973,
+     "nom": "Berriche",
+     "id": "96",
+     "wilaya_id": "4",
+     "code_postal": "04009"
+    },
+    {
+     "longitude": 6.471658,
+     "latitude": 36.0669135,
+     "nom": "Ouled Hamla",
+     "id": "97",
+     "wilaya_id": "4",
+     "code_postal": "04010"
+    },
+    {
+     "longitude": 7.549096999999999,
+     "latitude": 35.4582557,
+     "nom": "Dhala",
+     "id": "98",
+     "wilaya_id": "4",
+     "code_postal": "04011"
+    },
+    {
+     "longitude": 6.6905458,
+     "latitude": 35.9302835,
+     "nom": "Ain Kercha",
+     "id": "99",
+     "wilaya_id": "4",
+     "code_postal": "04012"
+    },
+    {
+     "longitude": 6.7413706,
+     "latitude": 35.9355726,
+     "nom": "Hanchir Toumghani",
+     "id": "100",
+     "wilaya_id": "4",
+     "code_postal": "04013"
+    },
+    {
+     "longitude": 7.507127099999999,
+     "latitude": 35.6635514,
+     "nom": "El Djazia",
+     "id": "101",
+     "wilaya_id": "4",
+     "code_postal": "04014"
+    },
+    {
+     "longitude": 7.300360400000001,
+     "latitude": 35.6640497,
+     "nom": "Fkirina",
+     "id": "103",
+     "wilaya_id": "4",
+     "code_postal": "04016"
+    },
+    {
+     "longitude": 6.386442799999999,
+     "latitude": 35.9414231,
+     "nom": "Souk Naamane",
+     "id": "104",
+     "wilaya_id": "4",
+     "code_postal": "04017"
+    },
+    {
+     "longitude": 6.5143087,
+     "latitude": 35.8477341,
+     "nom": "Ouled Zouai",
+     "id": "107",
+     "wilaya_id": "4",
+     "code_postal": "04020"
+    },
+    {
+     "longitude": 6.2925058,
+     "latitude": 35.8966254,
+     "nom": "Bir Chouhada",
+     "id": "108",
+     "wilaya_id": "4",
+     "code_postal": "04021"
+    },
+    {
+     "longitude": 7.2571943,
+     "latitude": 36.0841308,
+     "nom": "Ksar Sbahi",
+     "id": "109",
+     "wilaya_id": "4",
+     "code_postal": "04022"
+    },
+    {
+     "longitude": 7.347604800000001,
+     "latitude": 35.5700761,
+     "nom": "Oued Nini",
+     "id": "110",
+     "wilaya_id": "4",
+     "code_postal": "04023"
+    },
+    {
+     "longitude": 7.6710889,
+     "latitude": 35.6328262,
+     "nom": "Meskiana",
+     "id": "111",
+     "wilaya_id": "4",
+     "code_postal": "04024"
+    },
+    {
+     "longitude": 6.8708486,
+     "latitude": 35.9736892,
+     "nom": "Ain Fekroune",
+     "id": "112",
+     "wilaya_id": "4",
+     "code_postal": "04025"
+    },
+    {
+     "longitude": 7.666667,
+     "latitude": 35.716667,
+     "nom": "Rahia",
+     "id": "113",
+     "wilaya_id": "4",
+     "code_postal": "04026"
+    },
+    {
+     "longitude": 6.935674,
+     "latitude": 35.6842651,
+     "nom": "Ain Zitoun",
+     "id": "114",
+     "wilaya_id": "4",
+     "code_postal": "04027"
+    },
+    {
+     "longitude": 6.6223966,
+     "latitude": 35.9245726,
+     "nom": "El Harmilia",
+     "id": "116",
+     "wilaya_id": "4",
+     "code_postal": "04029"
+    },
+    {
+     "longitude": 6.173911599999999,
+     "latitude": 35.5610218,
+     "nom": "Batna",
+     "id": "117",
+     "wilaya_id": "5",
+     "code_postal": "05001"
+    },
+    {
+     "longitude": 6.2163597,
+     "latitude": 35.0777543,
+     "nom": "Ghassira",
+     "id": "118",
+     "wilaya_id": "5",
+     "code_postal": "05002"
+    },
+    {
+     "longitude": 5.8775964,
+     "latitude": 35.269936,
+     "nom": "Maafa",
+     "id": "119",
+     "wilaya_id": "5",
+     "code_postal": "05003"
+    },
+    {
+     "longitude": 5.909275399999999,
+     "latitude": 35.6287744,
+     "nom": "Merouana",
+     "id": "120",
+     "wilaya_id": "5",
+     "code_postal": "05004"
+    },
+    {
+     "longitude": 6.173911599999999,
+     "latitude": 35.6917406,
+     "nom": "Seriana",
+     "id": "121",
+     "wilaya_id": "5",
+     "code_postal": "05005"
+    },
+    {
+     "longitude": 6.089103199999999,
+     "latitude": 35.1280608,
+     "nom": "Menaa",
+     "id": "122",
+     "wilaya_id": "5",
+     "code_postal": "05006"
+    },
+    {
+     "longitude": 6.386442799999999,
+     "latitude": 35.6371149,
+     "nom": "El Madher",
+     "id": "123",
+     "wilaya_id": "5",
+     "code_postal": "05007"
+    },
+    {
+     "longitude": 6.258836899999999,
+     "latitude": 35.5130278,
+     "nom": "Tazoult",
+     "id": "124",
+     "wilaya_id": "5",
+     "code_postal": "05008"
+    },
+    {
+     "longitude": 5.593239,
+     "latitude": 35.5566128,
+     "nom": "Ngaous",
+     "id": "125",
+     "wilaya_id": "5",
+     "code_postal": "05009"
+    },
+    {
+     "longitude": 5.572229699999999,
+     "latitude": 35.73196009999999,
+     "nom": "Guigba",
+     "id": "126",
+     "wilaya_id": "5",
+     "code_postal": "05010"
+    },
+    {
+     "longitude": 6.5463156,
+     "latitude": 35.2684424,
+     "nom": "Inoughissen",
+     "id": "127",
+     "wilaya_id": "5",
+     "code_postal": "05011"
+    },
+    {
+     "longitude": 6.3438785,
+     "latitude": 35.552203,
+     "nom": "Ouyoun El Assafir",
+     "id": "128",
+     "wilaya_id": "5",
+     "code_postal": "05012"
+    },
+    {
+     "longitude": 6.3013432,
+     "latitude": 35.6851412,
+     "nom": "Djerma",
+     "id": "129",
+     "wilaya_id": "5",
+     "code_postal": "05013"
+    },
+    {
+     "longitude": 5.3520876,
+     "latitude": 35.1408805,
+     "nom": "Bitam",
+     "id": "130",
+     "wilaya_id": "5",
+     "code_postal": "05014"
+    },
+    {
+     "longitude": 5.183641,
+     "latitude": 35.3687479,
+     "nom": "Metkaouak",
+     "id": "131",
+     "wilaya_id": "5",
+     "code_postal": "05015"
+    },
+    {
+     "longitude": 6.354516900000001,
+     "latitude": 35.3005374,
+     "nom": "Arris",
+     "id": "132",
+     "wilaya_id": "5",
+     "code_postal": "05016"
+    },
+    {
+     "longitude": 6.471658,
+     "latitude": 34.9766508,
+     "nom": "Kimmel",
+     "id": "133",
+     "wilaya_id": "5",
+     "code_postal": "05017"
+    },
+    {
+     "longitude": 5.624766999999999,
+     "latitude": 35.28194149999999,
+     "nom": "Tilatou",
+     "id": "134",
+     "wilaya_id": "5",
+     "code_postal": "05018"
+    },
+    {
+     "longitude": 6.0044121,
+     "latitude": 35.8308281,
+     "nom": "Ain Djasser",
+     "id": "135",
+     "wilaya_id": "5",
+     "code_postal": "05019"
+    },
+    {
+     "longitude": 5.7932008,
+     "latitude": 35.8411857,
+     "nom": "Ouled Selam",
+     "id": "136",
+     "wilaya_id": "5",
+     "code_postal": "05020"
+    },
+    {
+     "longitude": 5.9621106,
+     "latitude": 35.0905115,
+     "nom": "Tigherghar",
+     "id": "137",
+     "wilaya_id": "5",
+     "code_postal": "05021"
+    },
+    {
+     "longitude": 6.429036,
+     "latitude": 35.8088781,
+     "nom": "Ain Yagout",
+     "id": "138",
+     "wilaya_id": "5",
+     "code_postal": "05022"
+    },
+    {
+     "longitude": 6.2269763,
+     "latitude": 35.6127845,
+     "nom": "Fesdis",
+     "id": "139",
+     "wilaya_id": "5",
+     "code_postal": "05023"
+    },
+    {
+     "longitude": 5.593239,
+     "latitude": 35.4255853,
+     "nom": "Sefiane",
+     "id": "140",
+     "wilaya_id": "5",
+     "code_postal": "05024"
+    },
+    {
+     "longitude": 5.6563119,
+     "latitude": 35.7280419,
+     "nom": "Rahbat",
+     "id": "141",
+     "wilaya_id": "5",
+     "code_postal": "05025"
+    },
+    {
+     "longitude": 6.2694608,
+     "latitude": 35.1955527,
+     "nom": "Tighanimine",
+     "id": "142",
+     "wilaya_id": "5",
+     "code_postal": "05026"
+    },
+    {
+     "longitude": 5.7826597,
+     "latitude": 35.6349128,
+     "nom": "Lemsane",
+     "id": "143",
+     "wilaya_id": "5",
+     "code_postal": "05027"
+    },
+    {
+     "longitude": 5.8775964,
+     "latitude": 35.706563,
+     "nom": "Ksar Belezma",
+     "id": "144",
+     "wilaya_id": "5",
+     "code_postal": "05028"
+    },
+    {
+     "longitude": 5.5407299,
+     "latitude": 35.3295911,
+     "nom": "Seggana",
+     "id": "145",
+     "wilaya_id": "5",
+     "code_postal": "05029"
+    },
+    {
+     "longitude": 6.429036,
+     "latitude": 35.285666,
+     "nom": "Ichmoul",
+     "id": "146",
+     "wilaya_id": "5",
+     "code_postal": "05030"
+    },
+    {
+     "longitude": 6.5143087,
+     "latitude": 35.368536,
+     "nom": "Foum Toub",
+     "id": "147",
+     "wilaya_id": "5",
+     "code_postal": "05031"
+    },
+    {
+     "longitude": 6.0467429,
+     "latitude": 35.3928288,
+     "nom": "Beni Foudhala El Hakania",
+     "id": "148",
+     "wilaya_id": "5",
+     "code_postal": "05032"
+    },
+    {
+     "longitude": 6.0044121,
+     "latitude": 35.6567552,
+     "nom": "Oued El Ma",
+     "id": "149",
+     "wilaya_id": "5",
+     "code_postal": "05033"
+    },
+    {
+     "longitude": 5.751047499999999,
+     "latitude": 35.71267030000001,
+     "nom": "Talkhamt",
+     "id": "150",
+     "wilaya_id": "5",
+     "code_postal": "05034"
+    },
+    {
+     "longitude": 6.0996978,
+     "latitude": 35.26989530000001,
+     "nom": "Bouzina",
+     "id": "151",
+     "wilaya_id": "5",
+     "code_postal": "05035"
+    },
+    {
+     "longitude": 6.5996963,
+     "latitude": 35.6256226,
+     "nom": "Chemora",
+     "id": "152",
+     "wilaya_id": "5",
+     "code_postal": "05036"
+    },
+    {
+     "longitude": 6.0467429,
+     "latitude": 35.5238393,
+     "nom": "Oued Chaaba",
+     "id": "153",
+     "wilaya_id": "5",
+     "code_postal": "05037"
+    },
+    {
+     "longitude": 5.7932008,
+     "latitude": 35.5799027,
+     "nom": "Taxlent",
+     "id": "154",
+     "wilaya_id": "5",
+     "code_postal": "05038"
+    },
+    {
+     "longitude": 5.456813299999999,
+     "latitude": 35.6391967,
+     "nom": "Gosbat",
+     "id": "155",
+     "wilaya_id": "5",
+     "code_postal": "05039"
+    },
+    {
+     "longitude": 5.751047499999999,
+     "latitude": 35.450956,
+     "nom": "Ouled Aouf",
+     "id": "156",
+     "wilaya_id": "5",
+     "code_postal": "05040"
+    },
+    {
+     "longitude": 5.551228,
+     "latitude": 35.4930629,
+     "nom": "Boumagueur",
+     "id": "157",
+     "wilaya_id": "5",
+     "code_postal": "05041"
+    },
+    {
+     "longitude": 5.2893433,
+     "latitude": 35.3845934,
+     "nom": "Barika",
+     "id": "158",
+     "wilaya_id": "5",
+     "code_postal": "05042"
+    },
+    {
+     "longitude": 5.3311652,
+     "latitude": 35.51389229999999,
+     "nom": "Djezzar",
+     "id": "159",
+     "wilaya_id": "5",
+     "code_postal": "05043"
+    },
+    {
+     "longitude": 6.3438785,
+     "latitude": 35.1588259,
+     "nom": "Tkout",
+     "id": "160",
+     "wilaya_id": "5",
+     "code_postal": "05044"
+    },
+    {
+     "longitude": 5.9198387,
+     "latitude": 35.3991089,
+     "nom": "Ain Touta",
+     "id": "161",
+     "wilaya_id": "5",
+     "code_postal": "05045"
+    },
+    {
+     "longitude": 5.9198387,
+     "latitude": 35.5301294,
+     "nom": "Hidoussa",
+     "id": "162",
+     "wilaya_id": "5",
+     "code_postal": "05046"
+    },
+    {
+     "longitude": 6.183332999999999,
+     "latitude": 35.25,
+     "nom": "Teniet El Abed",
+     "id": "163",
+     "wilaya_id": "5",
+     "code_postal": "05047"
+    },
+    {
+     "longitude": 6.3438785,
+     "latitude": 35.4212867,
+     "nom": "Oued Taga",
+     "id": "164",
+     "wilaya_id": "5",
+     "code_postal": "05048"
+    },
+    {
+     "longitude": 6.685198199999999,
+     "latitude": 35.5337671,
+     "nom": "Ouled Fadel",
+     "id": "165",
+     "wilaya_id": "5",
+     "code_postal": "05049"
+    },
+    {
+     "longitude": 6.5143087,
+     "latitude": 35.4995081,
+     "nom": "Timgad",
+     "id": "166",
+     "wilaya_id": "5",
+     "code_postal": "05050"
+    },
+    {
+     "longitude": 5.5827334,
+     "latitude": 35.6770224,
+     "nom": "Ras El Aioun",
+     "id": "167",
+     "wilaya_id": "5",
+     "code_postal": "05051"
+    },
+    {
+     "longitude": 6.131492799999999,
+     "latitude": 35.2135627,
+     "nom": "Chir",
+     "id": "168",
+     "wilaya_id": "5",
+     "code_postal": "05052"
+    },
+    {
+     "longitude": 5.6668306,
+     "latitude": 35.5859034,
+     "nom": "Ouled Si Slimane",
+     "id": "169",
+     "wilaya_id": "5",
+     "code_postal": "05053"
+    },
+    {
+     "longitude": 6.1102943,
+     "latitude": 35.8037586,
+     "nom": "Zanat El Beida",
+     "id": "170",
+     "wilaya_id": "5",
+     "code_postal": "05054"
+    },
+    {
+     "longitude": 5.1640605,
+     "latitude": 35.1270837,
+     "nom": "Amdoukal",
+     "id": "171",
+     "wilaya_id": "5",
+     "code_postal": "05055"
+    },
+    {
+     "longitude": 5.1640605,
+     "latitude": 35.4774579,
+     "nom": "Ouled Ammar",
+     "id": "172",
+     "wilaya_id": "5",
+     "code_postal": "05056"
+    },
+    {
+     "longitude": 5.951539899999999,
+     "latitude": 35.7790971,
+     "nom": "El Hassi",
+     "id": "173",
+     "wilaya_id": "5",
+     "code_postal": "05057"
+    },
+    {
+     "longitude": 6.3013432,
+     "latitude": 35.7721622,
+     "nom": "Lazrou",
+     "id": "174",
+     "wilaya_id": "5",
+     "code_postal": "05058"
+    },
+    {
+     "longitude": 6.5143087,
+     "latitude": 35.7173264,
+     "nom": "Boumia",
+     "id": "175",
+     "wilaya_id": "5",
+     "code_postal": "05059"
+    },
+    {
+     "longitude": 6.642433,
+     "latitude": 35.7538128,
+     "nom": "Boulhilat",
+     "id": "176",
+     "wilaya_id": "5",
+     "code_postal": "05060"
+    },
+    {
+     "longitude": 6.120892599999999,
+     "latitude": 35.3344502,
+     "nom": "Larbaa",
+     "id": "177",
+     "wilaya_id": "5",
+     "code_postal": "05061"
+    },
+    {
+     "longitude": 5.056733299999999,
+     "latitude": 36.7508896,
+     "nom": "Bejaia",
+     "id": "178",
+     "wilaya_id": "6",
+     "code_postal": "06001"
+    },
+    {
+     "longitude": 4.903334,
+     "latitude": 36.6421159,
+     "nom": "Amizour",
+     "id": "179",
+     "wilaya_id": "6",
+     "code_postal": "06002"
+    },
+    {
+     "longitude": 4.8647019,
+     "latitude": 36.55740470000001,
+     "nom": "Ferraoun",
+     "id": "180",
+     "wilaya_id": "6",
+     "code_postal": "06003"
+    },
+    {
+     "longitude": 4.738101299999999,
+     "latitude": 36.72021549999999,
+     "nom": "Taourirt Ighil",
+     "id": "181",
+     "wilaya_id": "6",
+     "code_postal": "06004"
+    },
+    {
+     "longitude": 4.5108862,
+     "latitude": 36.5135502,
+     "nom": "Chelata",
+     "id": "182",
+     "wilaya_id": "6",
+     "code_postal": "06005"
+    },
+    {
+     "longitude": 4.667343199999999,
+     "latitude": 36.3983738,
+     "nom": "Tamokra",
+     "id": "183",
+     "wilaya_id": "6",
+     "code_postal": "06006"
+    },
+    {
+     "longitude": 4.7749158,
+     "latitude": 36.6151583,
+     "nom": "Timzrit",
+     "id": "184",
+     "wilaya_id": "6",
+     "code_postal": "06007"
+    },
+    {
+     "longitude": 5.3360215,
+     "latitude": 36.6256524,
+     "nom": "Souk El Thenine",
+     "id": "185",
+     "wilaya_id": "6",
+     "code_postal": "06008"
+    },
+    {
+     "longitude": 4.710368,
+     "latitude": 36.56340700000001,
+     "nom": "Mcisna",
+     "id": "186",
+     "wilaya_id": "6",
+     "code_postal": "06009"
+    },
+    {
+     "longitude": 4.70189,
+     "latitude": 36.6301547,
+     "nom": "Thinabdher",
+     "id": "187",
+     "wilaya_id": "6",
+     "code_postal": "06010"
+    },
+    {
+     "longitude": 5.1550882,
+     "latitude": 36.6682721,
+     "nom": "Tichi",
+     "id": "188",
+     "wilaya_id": "6",
+     "code_postal": "06011"
+    },
+    {
+     "longitude": 4.823662,
+     "latitude": 36.61496100000001,
+     "nom": "Semaoun",
+     "id": "189",
+     "wilaya_id": "6",
+     "code_postal": "06012"
+    },
+    {
+     "longitude": 5.0268199,
+     "latitude": 36.5404083,
+     "nom": "Kendira",
+     "id": "190",
+     "wilaya_id": "6",
+     "code_postal": "06013"
+    },
+    {
+     "longitude": 4.6963496,
+     "latitude": 36.6667365,
+     "nom": "Tifra",
+     "id": "191",
+     "wilaya_id": "6",
+     "code_postal": "06014"
+    },
+    {
+     "longitude": 4.5048939,
+     "latitude": 36.4624661,
+     "nom": "Ighram",
+     "id": "192",
+     "wilaya_id": "6",
+     "code_postal": "06015"
+    },
+    {
+     "longitude": 4.632585300000001,
+     "latitude": 36.4774626,
+     "nom": "Amalou",
+     "id": "193",
+     "wilaya_id": "6",
+     "code_postal": "06016"
+    },
+    {
+     "longitude": 4.4702131,
+     "latitude": 36.3379865,
+     "nom": "Ighil Ali",
+     "id": "194",
+     "wilaya_id": "6",
+     "code_postal": "06017"
+    },
+    {
+     "longitude": 4.8899903,
+     "latitude": 36.7490754,
+     "nom": "Toudja",
+     "id": "196",
+     "wilaya_id": "6",
+     "code_postal": "06019"
+    },
+    {
+     "longitude": 5.305989600000001,
+     "latitude": 36.5646323,
+     "nom": "Darguina",
+     "id": "197",
+     "wilaya_id": "6",
+     "code_postal": "06020"
+    },
+    {
+     "longitude": 4.7159414,
+     "latitude": 36.6122273,
+     "nom": "Sidi Ayad",
+     "id": "198",
+     "wilaya_id": "6",
+     "code_postal": "06021"
+    },
+    {
+     "longitude": 5.2440622,
+     "latitude": 36.6369535,
+     "nom": "Aokas",
+     "id": "199",
+     "wilaya_id": "6",
+     "code_postal": "06022"
+    },
+    {
+     "longitude": 4.810767999999999,
+     "latitude": 36.5729271,
+     "nom": "Beni Djellil",
+     "id": "200",
+     "wilaya_id": "6",
+     "code_postal": "06023"
+    },
+    {
+     "longitude": 4.669073,
+     "latitude": 36.6942103,
+     "nom": "Adekar",
+     "id": "201",
+     "wilaya_id": "6",
+     "code_postal": "06024"
+    },
+    {
+     "longitude": 4.5334783,
+     "latitude": 36.45901610000001,
+     "nom": "Akbou",
+     "id": "202",
+     "wilaya_id": "6",
+     "code_postal": "06025"
+    },
+    {
+     "longitude": 4.6868666,
+     "latitude": 36.5446668,
+     "nom": "Seddouk",
+     "id": "203",
+     "wilaya_id": "6",
+     "code_postal": "06026"
+    },
+    {
+     "longitude": 4.4079213,
+     "latitude": 36.3878041,
+     "nom": "Tazmalt",
+     "id": "204",
+     "wilaya_id": "6",
+     "code_postal": "06027"
+    },
+    {
+     "longitude": 4.5315029,
+     "latitude": 36.3831907,
+     "nom": "Ait Rizine",
+     "id": "205",
+     "wilaya_id": "6",
+     "code_postal": "06028"
+    },
+    {
+     "longitude": 4.6152308,
+     "latitude": 36.5956868,
+     "nom": "Chemini",
+     "id": "206",
+     "wilaya_id": "6",
+     "code_postal": "06029"
+    },
+    {
+     "longitude": 4.6295394,
+     "latitude": 36.6114371,
+     "nom": "Souk Oufella",
+     "id": "207",
+     "wilaya_id": "6",
+     "code_postal": "06030"
+    },
+    {
+     "longitude": 5.284117699999999,
+     "latitude": 36.5519437,
+     "nom": "Taskriout",
+     "id": "208",
+     "wilaya_id": "6",
+     "code_postal": "06031"
+    },
+    {
+     "longitude": 4.6513509,
+     "latitude": 36.6127223,
+     "nom": "Tibane",
+     "id": "209",
+     "wilaya_id": "6",
+     "code_postal": "06032"
+    },
+    {
+     "longitude": 5.0078451,
+     "latitude": 36.68767950000001,
+     "nom": "Tala Hamza",
+     "id": "210",
+     "wilaya_id": "6",
+     "code_postal": "06033"
+    },
+    {
+     "longitude": 4.971239,
+     "latitude": 36.5729398,
+     "nom": "Barbacha",
+     "id": "211",
+     "wilaya_id": "6",
+     "code_postal": "06034"
+    },
+    {
+     "longitude": 4.707061599999999,
+     "latitude": 36.839681,
+     "nom": "Beni Ksila",
+     "id": "212",
+     "wilaya_id": "6",
+     "code_postal": "06035"
+    },
+    {
+     "longitude": 4.5334783,
+     "latitude": 36.45901610000001,
+     "nom": "Ouzallaguen",
+     "id": "213",
+     "wilaya_id": "6",
+     "code_postal": "06036"
+    },
+    {
+     "longitude": 4.6853713,
+     "latitude": 36.4452822,
+     "nom": "Bouhamza",
+     "id": "214",
+     "wilaya_id": "6",
+     "code_postal": "06037"
+    },
+    {
+     "longitude": 4.414018899999999,
+     "latitude": 36.4463751,
+     "nom": "Beni Melikeche",
+     "id": "215",
+     "wilaya_id": "6",
+     "code_postal": "06038"
+    },
+    {
+     "longitude": 4.691548399999999,
+     "latitude": 36.6090172,
+     "nom": "Sidi Aich",
+     "id": "216",
+     "wilaya_id": "6",
+     "code_postal": "06039"
+    },
+    {
+     "longitude": 4.854562899999999,
+     "latitude": 36.6803265,
+     "nom": "El Kseur",
+     "id": "217",
+     "wilaya_id": "6",
+     "code_postal": "06040"
+    },
+    {
+     "longitude": 5.3834854,
+     "latitude": 36.6282747,
+     "nom": "Melbou",
+     "id": "218",
+     "wilaya_id": "6",
+     "code_postal": "06041"
+    },
+    {
+     "longitude": 4.6243989,
+     "latitude": 36.6307165,
+     "nom": "Akfadou",
+     "id": "219",
+     "wilaya_id": "6",
+     "code_postal": "06042"
+    },
+    {
+     "longitude": 4.6714261,
+     "latitude": 36.6090298,
+     "nom": "Leflaye",
+     "id": "220",
+     "wilaya_id": "6",
+     "code_postal": "06043"
+    },
+    {
+     "longitude": 5.278127599999999,
+     "latitude": 36.4931377,
+     "nom": "Kherrata",
+     "id": "221",
+     "wilaya_id": "6",
+     "code_postal": "06044"
+    },
+    {
+     "longitude": 5.2475518,
+     "latitude": 36.4295337,
+     "nom": "Draa Kaid",
+     "id": "222",
+     "wilaya_id": "6",
+     "code_postal": "06045"
+    },
+    {
+     "longitude": 5.4253757,
+     "latitude": 36.5833119,
+     "nom": "Tamridjet",
+     "id": "223",
+     "wilaya_id": "6",
+     "code_postal": "06046"
+    },
+    {
+     "longitude": 5.2302325,
+     "latitude": 36.5463433,
+     "nom": "Ait Smail",
+     "id": "224",
+     "wilaya_id": "6",
+     "code_postal": "06047"
+    },
+    {
+     "longitude": 5.0880839,
+     "latitude": 36.6698411,
+     "nom": "Boukhelifa",
+     "id": "225",
+     "wilaya_id": "6",
+     "code_postal": "06048"
+    },
+    {
+     "longitude": 5.2176317,
+     "latitude": 36.6134619,
+     "nom": "Tizi Nberber",
+     "id": "226",
+     "wilaya_id": "6",
+     "code_postal": "06049"
+    },
+    {
+     "longitude": 4.7578312,
+     "latitude": 36.5070785,
+     "nom": "Beni Maouch",
+     "id": "227",
+     "wilaya_id": "6",
+     "code_postal": "06050"
+    },
+    {
+     "longitude": 4.9795489,
+     "latitude": 36.7093915,
+     "nom": "Oued Ghir",
+     "id": "228",
+     "wilaya_id": "6",
+     "code_postal": "06051"
+    },
+    {
+     "longitude": 4.4111706,
+     "latitude": 36.3506738,
+     "nom": "Boudjellil",
+     "id": "229",
+     "wilaya_id": "6",
+     "code_postal": "06052"
+    },
+    {
+     "longitude": 5.751047499999999,
+     "latitude": 34.8370347,
+     "nom": "Biskra",
+     "id": "230",
+     "wilaya_id": "7",
+     "code_postal": "07001"
+    },
+    {
+     "longitude": 5.772120399999999,
+     "latitude": 34.5936352,
+     "nom": "Oumache",
+     "id": "231",
+     "wilaya_id": "7",
+     "code_postal": "07002"
+    },
+    {
+     "longitude": 5.7932008,
+     "latitude": 34.9669667,
+     "nom": "Branis",
+     "id": "232",
+     "wilaya_id": "7",
+     "code_postal": "07003"
+    },
+    {
+     "longitude": 5.8775964,
+     "latitude": 34.87499,
+     "nom": "Chetma",
+     "id": "233",
+     "wilaya_id": "7",
+     "code_postal": "07004"
+    },
+    {
+     "longitude": 5.1015225,
+     "latitude": 34.4466834,
+     "nom": "Ouled Djellal",
+     "id": "234",
+     "wilaya_id": "7",
+     "code_postal": "07005"
+    },
+    {
+     "longitude": 4.645035,
+     "latitude": 33.9767317,
+     "nom": "Ras El Miaad",
+     "id": "235",
+     "wilaya_id": "7",
+     "code_postal": "07006"
+    },
+    {
+     "longitude": 4.976654,
+     "latitude": 34.1415665,
+     "nom": "Besbes",
+     "id": "236",
+     "wilaya_id": "7",
+     "code_postal": "07007"
+    },
+    {
+     "longitude": 4.9558696,
+     "latitude": 34.3862694,
+     "nom": "Sidi Khaled",
+     "id": "237",
+     "wilaya_id": "7",
+     "code_postal": "07008"
+    },
+    {
+     "longitude": 5.1015225,
+     "latitude": 34.6234715,
+     "nom": "Doucen",
+     "id": "238",
+     "wilaya_id": "7",
+     "code_postal": "07009"
+    },
+    {
+     "longitude": 4.8105955,
+     "latitude": 34.679416,
+     "nom": "Ech Chaiba",
+     "id": "239",
+     "wilaya_id": "7",
+     "code_postal": "07010"
+    },
+    {
+     "longitude": 5.9198387,
+     "latitude": 34.7849283,
+     "nom": "Sidi Okba",
+     "id": "240",
+     "wilaya_id": "7",
+     "code_postal": "07011"
+    },
+    {
+     "longitude": 6.0255738,
+     "latitude": 34.9337006,
+     "nom": "Mchouneche",
+     "id": "241",
+     "wilaya_id": "7",
+     "code_postal": "07012"
+    },
+    {
+     "longitude": 6.0255738,
+     "latitude": 34.5813972,
+     "nom": "El Haouch",
+     "id": "242",
+     "wilaya_id": "7",
+     "code_postal": "07013"
+    },
+    {
+     "longitude": 6.195132,
+     "latitude": 34.6611164,
+     "nom": "Ain Naga",
+     "id": "243",
+     "wilaya_id": "7",
+     "code_postal": "07014"
+    },
+    {
+     "longitude": 6.5038787,
+     "latitude": 34.6878171,
+     "nom": "Zeribet El Oued",
+     "id": "244",
+     "wilaya_id": "7",
+     "code_postal": "07015"
+    },
+    {
+     "longitude": 6.5356449,
+     "latitude": 34.4668996,
+     "nom": "El Feidh",
+     "id": "245",
+     "wilaya_id": "7",
+     "code_postal": "07016"
+    },
+    {
+     "longitude": 5.6668306,
+     "latitude": 35.192365,
+     "nom": "El Kantara",
+     "id": "246",
+     "wilaya_id": "7",
+     "code_postal": "07017"
+    },
+    {
+     "longitude": 5.8353837,
+     "latitude": 35.1843701,
+     "nom": "Ain Zaatout",
+     "id": "247",
+     "wilaya_id": "7",
+     "code_postal": "07018"
+    },
+    {
+     "longitude": 5.5827334,
+     "latitude": 34.9768124,
+     "nom": "El Outaya",
+     "id": "248",
+     "wilaya_id": "7",
+     "code_postal": "07019"
+    },
+    {
+     "longitude": 5.7089241,
+     "latitude": 35.1026843,
+     "nom": "Djemorah",
+     "id": "249",
+     "wilaya_id": "7",
+     "code_postal": "07020"
+    },
+    {
+     "longitude": 5.3802134,
+     "latitude": 34.7291803,
+     "nom": "Tolga",
+     "id": "250",
+     "wilaya_id": "7",
+     "code_postal": "07021"
+    },
+    {
+     "longitude": 5.3961323,
+     "latitude": 34.636809,
+     "nom": "Lioua",
+     "id": "251",
+     "wilaya_id": "7",
+     "code_postal": "07022"
+    },
+    {
+     "longitude": 5.4253757,
+     "latitude": 34.7528735,
+     "nom": "Lichana",
+     "id": "252",
+     "wilaya_id": "7",
+     "code_postal": "07023"
+    },
+    {
+     "longitude": 5.5407299,
+     "latitude": 34.5381104,
+     "nom": "Ourlal",
+     "id": "253",
+     "wilaya_id": "7",
+     "code_postal": "07024"
+    },
+    {
+     "longitude": 5.624766999999999,
+     "latitude": 34.5784354,
+     "nom": "Mlili",
+     "id": "254",
+     "wilaya_id": "7",
+     "code_postal": "07025"
+    },
+    {
+     "longitude": 5.299795899999999,
+     "latitude": 34.7583947,
+     "nom": "Foughala",
+     "id": "255",
+     "wilaya_id": "7",
+     "code_postal": "07026"
+    },
+    {
+     "longitude": 5.3573194,
+     "latitude": 34.7062854,
+     "nom": "Bordj Ben Azzouz",
+     "id": "256",
+     "wilaya_id": "7",
+     "code_postal": "07027"
+    },
+    {
+     "longitude": 6.2800864,
+     "latitude": 34.8328954,
+     "nom": "Meziraa",
+     "id": "257",
+     "wilaya_id": "7",
+     "code_postal": "07028"
+    },
+    {
+     "longitude": 5.4665823,
+     "latitude": 34.7208281,
+     "nom": "Bouchagroun",
+     "id": "258",
+     "wilaya_id": "7",
+     "code_postal": "07029"
+    },
+    {
+     "longitude": 5.4463322,
+     "latitude": 34.5533941,
+     "nom": "Mekhadma",
+     "id": "259",
+     "wilaya_id": "7",
+     "code_postal": "07030"
+    },
+    {
+     "longitude": 5.284393,
+     "latitude": 34.705819,
+     "nom": "El Ghrous",
+     "id": "260",
+     "wilaya_id": "7",
+     "code_postal": "07031"
+    },
+    {
+     "longitude": 5.624766999999999,
+     "latitude": 34.7989056,
+     "nom": "El Hadjab",
+     "id": "261",
+     "wilaya_id": "7",
+     "code_postal": "07032"
+    },
+    {
+     "longitude": -2.2143231,
+     "latitude": 31.6182492,
+     "nom": "Bechar",
+     "id": "263",
+     "wilaya_id": "8",
+     "code_postal": "08001"
+    },
+    {
+     "longitude": -1.0598107,
+     "latitude": 29.2555013,
+     "nom": "Ouled Khoudir",
+     "id": "265",
+     "wilaya_id": "8",
+     "code_postal": "08003"
+    },
+    {
+     "longitude": -2.945068,
+     "latitude": 31.5517416,
+     "nom": "Meridja",
+     "id": "266",
+     "wilaya_id": "8",
+     "code_postal": "08004"
+    },
+    {
+     "longitude": -1.1269073,
+     "latitude": 29.3188506,
+     "nom": "Timoudi",
+     "id": "267",
+     "wilaya_id": "8",
+     "code_postal": "08005"
+    },
+    {
+     "longitude": -2.2581158,
+     "latitude": 31.9330162,
+     "nom": "Lahmar",
+     "id": "268",
+     "wilaya_id": "8",
+     "code_postal": "08006"
+    },
+    {
+     "longitude": -2.1671288,
+     "latitude": 30.1324686,
+     "nom": "Beni Abbes",
+     "id": "269",
+     "wilaya_id": "8",
+     "code_postal": "08007"
+    },
+    {
+     "longitude": -1.604054,
+     "latitude": 29.580219,
+     "nom": "Beni Ikhlef",
+     "id": "270",
+     "wilaya_id": "8",
+     "code_postal": "08008"
+    },
+    {
+     "longitude": -2.7375454,
+     "latitude": 30.9322468,
+     "nom": "Mechraa Houari B",
+     "id": "271",
+     "wilaya_id": "8",
+     "code_postal": "08009"
+    },
+    {
+     "longitude": -2.4233417,
+     "latitude": 31.5569451,
+     "nom": "Kenedsa",
+     "id": "272",
+     "wilaya_id": "8",
+     "code_postal": "08010"
+    },
+    {
+     "longitude": -2.2907524,
+     "latitude": 30.452471,
+     "nom": "Igli",
+     "id": "273",
+     "wilaya_id": "8",
+     "code_postal": "08011"
+    },
+    {
+     "longitude": -3.2557384,
+     "latitude": 29.4055402,
+     "nom": "Tabalbala",
+     "id": "274",
+     "wilaya_id": "8",
+     "code_postal": "08012"
+    },
+    {
+     "longitude": -2.0322172,
+     "latitude": 30.9201058,
+     "nom": "Taghit",
+     "id": "275",
+     "wilaya_id": "8",
+     "code_postal": "08013"
+    },
+    {
+     "longitude": -1.8269573,
+     "latitude": 29.8515849,
+     "nom": "El Ouata",
+     "id": "276",
+     "wilaya_id": "8",
+     "code_postal": "08014"
+    },
+    {
+     "longitude": -2.462651,
+     "latitude": 31.923019,
+     "nom": "Boukais",
+     "id": "277",
+     "wilaya_id": "8",
+     "code_postal": "08015"
+    },
+    {
+     "longitude": -2.2175179,
+     "latitude": 32.023248,
+     "nom": "Mogheul",
+     "id": "278",
+     "wilaya_id": "8",
+     "code_postal": "08016"
+    },
+    {
+     "longitude": -2.7431421,
+     "latitude": 31.0102291,
+     "nom": "Abadla",
+     "id": "279",
+     "wilaya_id": "8",
+     "code_postal": "08017"
+    },
+    {
+     "longitude": -1.4386366,
+     "latitude": 29.4624252,
+     "nom": "Kerzaz",
+     "id": "280",
+     "wilaya_id": "8",
+     "code_postal": "08018"
+    },
+    {
+     "longitude": -0.9725085,
+     "latitude": 29.1006615,
+     "nom": "Ksabi",
+     "id": "281",
+     "wilaya_id": "8",
+     "code_postal": "08019"
+    },
+    {
+     "longitude": -1.9,
+     "latitude": 29.916667,
+     "nom": "Tamtert",
+     "id": "282",
+     "wilaya_id": "8",
+     "code_postal": "08020"
+    },
+    {
+     "longitude": -1.2457898,
+     "latitude": 32.0492426,
+     "nom": "Beni Ounif",
+     "id": "283",
+     "wilaya_id": "8",
+     "code_postal": "08021"
+    },
+    {
+     "longitude": 2.8005677,
+     "latitude": 36.4798683,
+     "nom": "Blida",
+     "id": "284",
+     "wilaya_id": "9",
+     "code_postal": "09001"
+    },
+    {
+     "longitude": 3.0085182,
+     "latitude": 36.5782346,
+     "nom": "Chebli",
+     "id": "285",
+     "wilaya_id": "9",
+     "code_postal": "09002"
+    },
+    {
+     "longitude": 2.9875565,
+     "latitude": 36.5181119,
+     "nom": "Bouinan",
+     "id": "286",
+     "wilaya_id": "9",
+     "code_postal": "09003"
+    },
+    {
+     "longitude": 2.7680247,
+     "latitude": 36.5665832,
+     "nom": "Oued El Alleug",
+     "id": "287",
+     "wilaya_id": "9",
+     "code_postal": "09004"
+    },
+    {
+     "longitude": 2.8726747,
+     "latitude": 36.5047206,
+     "nom": "Ouled Yaich",
+     "id": "288",
+     "wilaya_id": "9",
+     "code_postal": "09007"
+    },
+    {
+     "longitude": 2.9076094,
+     "latitude": 36.4336226,
+     "nom": "Chrea",
+     "id": "289",
+     "wilaya_id": "9",
+     "code_postal": "09008"
+    },
+    {
+     "longitude": 2.6090043,
+     "latitude": 36.4404969,
+     "nom": "El Affroun",
+     "id": "290",
+     "wilaya_id": "9",
+     "code_postal": "09010"
+    },
+    {
+     "longitude": 2.728219,
+     "latitude": 36.4594664,
+     "nom": "Chiffa",
+     "id": "291",
+     "wilaya_id": "9",
+     "code_postal": "09011"
+    },
+    {
+     "longitude": 2.9975593,
+     "latitude": 36.4205919,
+     "nom": "Hammam Melouane",
+     "id": "292",
+     "wilaya_id": "9",
+     "code_postal": "09012"
+    },
+    {
+     "longitude": 2.847737,
+     "latitude": 36.6078803,
+     "nom": "Ben Khlil",
+     "id": "293",
+     "wilaya_id": "9",
+     "code_postal": "09013"
+    },
+    {
+     "longitude": 2.9076094,
+     "latitude": 36.4984753,
+     "nom": "Soumaa",
+     "id": "294",
+     "wilaya_id": "9",
+     "code_postal": "09014"
+    },
+    {
+     "longitude": 2.6785092,
+     "latitude": 36.4713985,
+     "nom": "Mouzaia",
+     "id": "295",
+     "wilaya_id": "9",
+     "code_postal": "09016"
+    },
+    {
+     "longitude": 3.2483058,
+     "latitude": 36.5329164,
+     "nom": "Souhane",
+     "id": "296",
+     "wilaya_id": "9",
+     "code_postal": "09017"
+    },
+    {
+     "longitude": 3.2281983,
+     "latitude": 36.6197872,
+     "nom": "Meftah",
+     "id": "297",
+     "wilaya_id": "9",
+     "code_postal": "09018"
+    },
+    {
+     "longitude": 3.1277854,
+     "latitude": 36.5145296,
+     "nom": "Ouled Selama",
+     "id": "298",
+     "wilaya_id": "9",
+     "code_postal": "09019"
+    },
+    {
+     "longitude": 2.9076094,
+     "latitude": 36.5848591,
+     "nom": "Boufarik",
+     "id": "299",
+     "wilaya_id": "9",
+     "code_postal": "09020"
+    },
+    {
+     "longitude": 3.1578875,
+     "latitude": 36.5893036,
+     "nom": "Larbaa",
+     "id": "300",
+     "wilaya_id": "9",
+     "code_postal": "09021"
+    },
+    {
+     "longitude": 2.5495112,
+     "latitude": 36.4201457,
+     "nom": "Oued Djer",
+     "id": "301",
+     "wilaya_id": "9",
+     "code_postal": "09022"
+    },
+    {
+     "longitude": 2.8277963,
+     "latitude": 36.5435922,
+     "nom": "Beni Tamou",
+     "id": "302",
+     "wilaya_id": "9",
+     "code_postal": "09023"
+    },
+    {
+     "longitude": 2.797901,
+     "latitude": 36.4254203,
+     "nom": "Bouarfa",
+     "id": "303",
+     "wilaya_id": "9",
+     "code_postal": "09024"
+    },
+    {
+     "longitude": 2.8527235,
+     "latitude": 36.5268016,
+     "nom": "Beni Mered",
+     "id": "304",
+     "wilaya_id": "9",
+     "code_postal": "09025"
+    },
+    {
+     "longitude": 3.1077277,
+     "latitude": 36.47183770000001,
+     "nom": "Bougara",
+     "id": "305",
+     "wilaya_id": "9",
+     "code_postal": "09026"
+    },
+    {
+     "longitude": 2.8826534,
+     "latitude": 36.4828707,
+     "nom": "Guerrouaou",
+     "id": "306",
+     "wilaya_id": "9",
+     "code_postal": "09027"
+    },
+    {
+     "longitude": 2.6487087,
+     "latitude": 36.3963569,
+     "nom": "Ain Romana",
+     "id": "307",
+     "wilaya_id": "9",
+     "code_postal": "09028"
+    },
+    {
+     "longitude": 3.2633918,
+     "latitude": 36.5810764,
+     "nom": "Djebabra",
+     "id": "308",
+     "wilaya_id": "9",
+     "code_postal": "09029"
+    },
+    {
+     "longitude": 3.8962348,
+     "latitude": 36.37763,
+     "nom": "Bouira",
+     "id": "309",
+     "wilaya_id": "10",
+     "code_postal": "10001"
+    },
+    {
+     "longitude": 4.0388918,
+     "latitude": 36.357569,
+     "nom": "El Asnam",
+     "id": "310",
+     "wilaya_id": "10",
+     "code_postal": "10002"
+    },
+    {
+     "longitude": 3.4296446,
+     "latitude": 36.4630499,
+     "nom": "Guerrouma",
+     "id": "311",
+     "wilaya_id": "10",
+     "code_postal": "10003"
+    },
+    {
+     "longitude": 3.637535,
+     "latitude": 36.3882249,
+     "nom": "Souk El Khemis",
+     "id": "312",
+     "wilaya_id": "10",
+     "code_postal": "10004"
+    },
+    {
+     "longitude": 3.6927531,
+     "latitude": 36.5200245,
+     "nom": "Kadiria",
+     "id": "313",
+     "wilaya_id": "10",
+     "code_postal": "10005"
+    },
+    {
+     "longitude": 4.2128337,
+     "latitude": 36.2541817,
+     "nom": "Hanif",
+     "id": "314",
+     "wilaya_id": "10",
+     "code_postal": "10006"
+    },
+    {
+     "longitude": 3.7545828,
+     "latitude": 35.9997826,
+     "nom": "Dirah",
+     "id": "315",
+     "wilaya_id": "10",
+     "code_postal": "10007"
+    },
+    {
+     "longitude": 3.8757119,
+     "latitude": 36.4494403,
+     "nom": "Ait Laaziz",
+     "id": "316",
+     "wilaya_id": "10",
+     "code_postal": "10008"
+    },
+    {
+     "longitude": 3.9572374,
+     "latitude": 36.4251625,
+     "nom": "Taghzout",
+     "id": "317",
+     "wilaya_id": "10",
+     "code_postal": "10009"
+    },
+    {
+     "longitude": 3.6319131,
+     "latitude": 36.2190042,
+     "nom": "Raouraoua",
+     "id": "318",
+     "wilaya_id": "10",
+     "code_postal": "10010"
+    },
+    {
+     "longitude": 4.0491077,
+     "latitude": 36.0863547,
+     "nom": "Mezdour",
+     "id": "319",
+     "wilaya_id": "10",
+     "code_postal": "10011"
+    },
+    {
+     "longitude": 4.0491077,
+     "latitude": 36.4328965,
+     "nom": "Haizer",
+     "id": "320",
+     "wilaya_id": "10",
+     "code_postal": "10012"
+    },
+    {
+     "longitude": 3.5913939,
+     "latitude": 36.5662811,
+     "nom": "Lakhdaria",
+     "id": "321",
+     "wilaya_id": "10",
+     "code_postal": "10013"
+    },
+    {
+     "longitude": 3.8693481,
+     "latitude": 36.4428933,
+     "nom": "Maala",
+     "id": "322",
+     "wilaya_id": "10",
+     "code_postal": "10014"
+    },
+    {
+     "longitude": 3.8153696,
+     "latitude": 36.2199413,
+     "nom": "El Hachimia",
+     "id": "323",
+     "wilaya_id": "10",
+     "code_postal": "10015"
+    },
+    {
+     "longitude": 3.7739869,
+     "latitude": 36.495896,
+     "nom": "Aomar",
+     "id": "324",
+     "wilaya_id": "10",
+     "code_postal": "10016"
+    },
+    {
+     "longitude": 4.3256918,
+     "latitude": 36.3691831,
+     "nom": "Chorfa",
+     "id": "325",
+     "wilaya_id": "10",
+     "code_postal": "10017"
+    },
+    {
+     "longitude": 3.9736961,
+     "latitude": 36.0817064,
+     "nom": "Bordj Oukhriss",
+     "id": "326",
+     "wilaya_id": "10",
+     "code_postal": "10018"
+    },
+    {
+     "longitude": 4.1616143,
+     "latitude": 36.3749965,
+     "nom": "El Adjiba",
+     "id": "327",
+     "wilaya_id": "10",
+     "code_postal": "10019"
+    },
+    {
+     "longitude": 3.7801961,
+     "latitude": 36.0914921,
+     "nom": "El Hakimia",
+     "id": "328",
+     "wilaya_id": "10",
+     "code_postal": "10020"
+    },
+    {
+     "longitude": 3.6015207,
+     "latitude": 36.3174072,
+     "nom": "El Khebouzia",
+     "id": "329",
+     "wilaya_id": "10",
+     "code_postal": "10021"
+    },
+    {
+     "longitude": 4.0491077,
+     "latitude": 36.259821,
+     "nom": "Ahl El Ksar",
+     "id": "330",
+     "wilaya_id": "10",
+     "code_postal": "10022"
+    },
+    {
+     "longitude": 3.4902391,
+     "latitude": 36.5692761,
+     "nom": "Bouderbala",
+     "id": "331",
+     "wilaya_id": "10",
+     "code_postal": "10023"
+    },
+    {
+     "longitude": 3.5306765,
+     "latitude": 36.4817207,
+     "nom": "Zbarbar",
+     "id": "332",
+     "wilaya_id": "10",
+     "code_postal": "10024"
+    },
+    {
+     "longitude": 3.7943157,
+     "latitude": 36.3655637,
+     "nom": "Ain El Hadjar",
+     "id": "333",
+     "wilaya_id": "10",
+     "code_postal": "10025"
+    },
+    {
+     "longitude": 3.7130493,
+     "latitude": 36.454596,
+     "nom": "Djebahia",
+     "id": "334",
+     "wilaya_id": "10",
+     "code_postal": "10026"
+    },
+    {
+     "longitude": 4.346237299999999,
+     "latitude": 36.4332801,
+     "nom": "Aghbalou",
+     "id": "335",
+     "wilaya_id": "10",
+     "code_postal": "10027"
+    },
+    {
+     "longitude": 3.9470396,
+     "latitude": 35.9811329,
+     "nom": "Taguedit",
+     "id": "336",
+     "wilaya_id": "10",
+     "code_postal": "10028"
+    },
+    {
+     "longitude": 3.8146526,
+     "latitude": 36.4081721,
+     "nom": "Ain Turk",
+     "id": "337",
+     "wilaya_id": "10",
+     "code_postal": "10029"
+    },
+    {
+     "longitude": 4.2538452,
+     "latitude": 36.4257962,
+     "nom": "Saharidj",
+     "id": "338",
+     "wilaya_id": "10",
+     "code_postal": "10030"
+    },
+    {
+     "longitude": 3.5765977,
+     "latitude": 36.1305919,
+     "nom": "Dechmia",
+     "id": "339",
+     "wilaya_id": "10",
+     "code_postal": "10031"
+    },
+    {
+     "longitude": 3.4619838,
+     "latitude": 36.0738504,
+     "nom": "Ridane",
+     "id": "340",
+     "wilaya_id": "10",
+     "code_postal": "10032"
+    },
+    {
+     "longitude": 4.0899911,
+     "latitude": 36.3450193,
+     "nom": "Bechloul",
+     "id": "341",
+     "wilaya_id": "10",
+     "code_postal": "10033"
+    },
+    {
+     "longitude": 3.3691241,
+     "latitude": 36.5295755,
+     "nom": "Boukram",
+     "id": "342",
+     "wilaya_id": "10",
+     "code_postal": "10034"
+    },
+    {
+     "longitude": 3.7232005,
+     "latitude": 36.4002383,
+     "nom": "Ain Bessam",
+     "id": "343",
+     "wilaya_id": "10",
+     "code_postal": "10035"
+    },
+    {
+     "longitude": 3.5711466,
+     "latitude": 36.2641708,
+     "nom": "Bir Ghbalou",
+     "id": "344",
+     "wilaya_id": "10",
+     "code_postal": "10036"
+    },
+    {
+     "longitude": 4.264103,
+     "latitude": 36.3713916,
+     "nom": "Mchedallah",
+     "id": "345",
+     "wilaya_id": "10",
+     "code_postal": "10037"
+    },
+    {
+     "longitude": 3.6901552,
+     "latitude": 36.1492231,
+     "nom": "Sour El Ghozlane",
+     "id": "346",
+     "wilaya_id": "10",
+     "code_postal": "10038"
+    },
+    {
+     "longitude": 3.551855,
+     "latitude": 36.0335667,
+     "nom": "Maamora",
+     "id": "347",
+     "wilaya_id": "10",
+     "code_postal": "10039"
+    },
+    {
+     "longitude": 4.0899911,
+     "latitude": 36.1717506,
+     "nom": "Ouled Rached",
+     "id": "348",
+     "wilaya_id": "10",
+     "code_postal": "10040"
+    },
+    {
+     "longitude": 3.753666299999999,
+     "latitude": 36.3019154,
+     "nom": "Ain Laloui",
+     "id": "349",
+     "wilaya_id": "10",
+     "code_postal": "10041"
+    },
+    {
+     "longitude": 3.8451731,
+     "latitude": 35.9191859,
+     "nom": "Hadjera Zerga",
+     "id": "350",
+     "wilaya_id": "10",
+     "code_postal": "10042"
+    },
+    {
+     "longitude": 4.2948884,
+     "latitude": 36.2945728,
+     "nom": "Ath Mansour",
+     "id": "351",
+     "wilaya_id": "10",
+     "code_postal": "10043"
+    },
+    {
+     "longitude": 3.6116494,
+     "latitude": 36.4360848,
+     "nom": "El Mokrani",
+     "id": "352",
+     "wilaya_id": "10",
+     "code_postal": "10044"
+    },
+    {
+     "longitude": 3.9266502,
+     "latitude": 36.2638925,
+     "nom": "Oued El Berdi",
+     "id": "353",
+     "wilaya_id": "10",
+     "code_postal": "10045"
+    },
+    {
+     "longitude": 5.5258107,
+     "latitude": 22.7888209,
+     "nom": "Tamanrasset",
+     "id": "354",
+     "wilaya_id": "11",
+     "code_postal": "11001"
+    },
+    {
+     "longitude": 4.0695454,
+     "latitude": 22.1877766,
+     "nom": "Abalessa",
+     "id": "355",
+     "wilaya_id": "11",
+     "code_postal": "11002"
+    },
+    {
+     "longitude": 1.9050391,
+     "latitude": 27.1077421,
+     "nom": "In Ghar",
+     "id": "356",
+     "wilaya_id": "11",
+     "code_postal": "11003"
+    },
+    {
+     "longitude": 5.7693847,
+     "latitude": 19.5708544,
+     "nom": "In Guezzam",
+     "id": "357",
+     "wilaya_id": "11",
+     "code_postal": "11004"
+    },
+    {
+     "longitude": 5.9343664,
+     "latitude": 23.8173973,
+     "nom": "Idles",
+     "id": "358",
+     "wilaya_id": "11",
+     "code_postal": "11005"
+    },
+    {
+     "longitude": 3.4195527,
+     "latitude": 20.6784913,
+     "nom": "Tinzaouatine",
+     "id": "360",
+     "wilaya_id": "11",
+     "code_postal": "11007"
+    },
+    {
+     "longitude": 2.4851463,
+     "latitude": 27.1927769,
+     "nom": "In Salah",
+     "id": "361",
+     "wilaya_id": "11",
+     "code_postal": "11008"
+    },
+    {
+     "longitude": 3.4195527,
+     "latitude": 24.4857286,
+     "nom": "In Amguel",
+     "id": "362",
+     "wilaya_id": "11",
+     "code_postal": "11009"
+    },
+    {
+     "longitude": 2.8452439,
+     "latitude": 27.3592301,
+     "nom": "Foggaret Ezzaouia",
+     "id": "363",
+     "wilaya_id": "11",
+     "code_postal": "11010"
+    },
+    {
+     "longitude": 8.101092000000001,
+     "latitude": 35.4142494,
+     "nom": "Tebessa",
+     "id": "364",
+     "wilaya_id": "12",
+     "code_postal": "12001"
+    },
+    {
+     "longitude": 8.057429899999999,
+     "latitude": 34.7610886,
+     "nom": "Bir El Ater",
+     "id": "365",
+     "wilaya_id": "12",
+     "code_postal": "12002"
+    },
+    {
+     "longitude": 7.7471025,
+     "latitude": 35.2684831,
+     "nom": "Cheria",
+     "id": "366",
+     "wilaya_id": "12",
+     "code_postal": "12003"
+    },
+    {
+     "longitude": 7.885766500000001,
+     "latitude": 35.8658056,
+     "nom": "El Aouinet",
+     "id": "368",
+     "wilaya_id": "12",
+     "code_postal": "12005"
+    },
+    {
+     "longitude": 8.2801065,
+     "latitude": 35.2917478,
+     "nom": "Lahouidjbet",
+     "id": "369",
+     "wilaya_id": "12",
+     "code_postal": "12006"
+    },
+    {
+     "longitude": 8.2076282,
+     "latitude": 34.9565856,
+     "nom": "Safsaf El Ouesra",
+     "id": "370",
+     "wilaya_id": "12",
+     "code_postal": "12007"
+    },
+    {
+     "longitude": 7.953837799999999,
+     "latitude": 35.4512851,
+     "nom": "Hammamet",
+     "id": "371",
+     "wilaya_id": "12",
+     "code_postal": "12008"
+    },
+    {
+     "longitude": 7.5193093,
+     "latitude": 34.4820138,
+     "nom": "Negrine",
+     "id": "372",
+     "wilaya_id": "12",
+     "code_postal": "12009"
+    },
+    {
+     "longitude": 7.8096037,
+     "latitude": 35.3708248,
+     "nom": "Bir El Mokadem",
+     "id": "373",
+     "wilaya_id": "12",
+     "code_postal": "12010"
+    },
+    {
+     "longitude": 8.3225325,
+     "latitude": 35.4998244,
+     "nom": "El Kouif",
+     "id": "374",
+     "wilaya_id": "12",
+     "code_postal": "12011"
+    },
+    {
+     "longitude": 8.0110677,
+     "latitude": 35.6676901,
+     "nom": "Morsott",
+     "id": "375",
+     "wilaya_id": "12",
+     "code_postal": "12012"
+    },
+    {
+     "longitude": 7.466666999999999,
+     "latitude": 35.183333,
+     "nom": "El Ogla",
+     "id": "376",
+     "wilaya_id": "12",
+     "code_postal": "12013"
+    },
+    {
+     "longitude": 8.25,
+     "latitude": 35.366667,
+     "nom": "Bekkaria",
+     "id": "380",
+     "wilaya_id": "12",
+     "code_postal": "12017"
+    },
+    {
+     "longitude": 8.0328815,
+     "latitude": 35.7476345,
+     "nom": "Boukhadra",
+     "id": "381",
+     "wilaya_id": "12",
+     "code_postal": "12018"
+    },
+    {
+     "longitude": 8.1393179,
+     "latitude": 35.9489963,
+     "nom": "Ouenza",
+     "id": "382",
+     "wilaya_id": "12",
+     "code_postal": "12019"
+    },
+    {
+     "longitude": 8.1693666,
+     "latitude": 35.2051832,
+     "nom": "El Ma El Biodh",
+     "id": "383",
+     "wilaya_id": "12",
+     "code_postal": "12020"
+    },
+    {
+     "longitude": 8.300632199999999,
+     "latitude": 35.0104461,
+     "nom": "Oum Ali",
+     "id": "384",
+     "wilaya_id": "12",
+     "code_postal": "12021"
+    },
+    {
+     "longitude": 7.766118799999998,
+     "latitude": 35.1170207,
+     "nom": "Thlidjene",
+     "id": "385",
+     "wilaya_id": "12",
+     "code_postal": "12022"
+    },
+    {
+     "longitude": 8.266667,
+     "latitude": 35.633333,
+     "nom": "Ain Zerga",
+     "id": "386",
+     "wilaya_id": "12",
+     "code_postal": "12023"
+    },
+    {
+     "longitude": 8.2295009,
+     "latitude": 35.7939476,
+     "nom": "El Meridj",
+     "id": "387",
+     "wilaya_id": "12",
+     "code_postal": "12024"
+    },
+    {
+     "longitude": 7.4746519,
+     "latitude": 35.3497731,
+     "nom": "Bedjene",
+     "id": "389",
+     "wilaya_id": "12",
+     "code_postal": "12026"
+    },
+    {
+     "longitude": 7.408395799999999,
+     "latitude": 34.5576609,
+     "nom": "Ferkane",
+     "id": "391",
+     "wilaya_id": "12",
+     "code_postal": "12028"
+    },
+    {
+     "longitude": -1.3180042,
+     "latitude": 34.88840620000001,
+     "nom": "Tlemcen",
+     "id": "392",
+     "wilaya_id": "13",
+     "code_postal": "13001"
+    },
+    {
+     "longitude": -1.4338047,
+     "latitude": 34.8650364,
+     "nom": "Beni Mester",
+     "id": "393",
+     "wilaya_id": "13",
+     "code_postal": "13002"
+    },
+    {
+     "longitude": -0.9557867,
+     "latitude": 34.92211040000001,
+     "nom": "Ain Tallout",
+     "id": "394",
+     "wilaya_id": "13",
+     "code_postal": "13003"
+    },
+    {
+     "longitude": -1.4289734,
+     "latitude": 35.0579657,
+     "nom": "Remchi",
+     "id": "395",
+     "wilaya_id": "13",
+     "code_postal": "13004"
+    },
+    {
+     "longitude": -1.2927151,
+     "latitude": 35.1158895,
+     "nom": "El Fehoul",
+     "id": "396",
+     "wilaya_id": "13",
+     "code_postal": "13005"
+    },
+    {
+     "longitude": -1.5281253,
+     "latitude": 34.8280257,
+     "nom": "Sabra",
+     "id": "397",
+     "wilaya_id": "13",
+     "code_postal": "13006"
+    },
+    {
+     "longitude": -1.8562218,
+     "latitude": 35.0962252,
+     "nom": "Ghazaouet",
+     "id": "398",
+     "wilaya_id": "13",
+     "code_postal": "13007"
+    },
+    {
+     "longitude": -1.9172519,
+     "latitude": 34.9218192,
+     "nom": "Souani",
+     "id": "399",
+     "wilaya_id": "13",
+     "code_postal": "13008"
+    },
+    {
+     "longitude": -1.8123324,
+     "latitude": 34.9592459,
+     "nom": "Djebala",
+     "id": "400",
+     "wilaya_id": "13",
+     "code_postal": "13009"
+    },
+    {
+     "longitude": -1.1520965,
+     "latitude": 34.6332195,
+     "nom": "El Gor",
+     "id": "401",
+     "wilaya_id": "13",
+     "code_postal": "13010"
+    },
+    {
+     "longitude": -1.1714782,
+     "latitude": 34.8290775,
+     "nom": "Oued Chouly",
+     "id": "402",
+     "wilaya_id": "13",
+     "code_postal": "13011"
+    },
+    {
+     "longitude": -1.2349683,
+     "latitude": 34.8768632,
+     "nom": "Ain Fezza",
+     "id": "403",
+     "wilaya_id": "13",
+     "code_postal": "13012"
+    },
+    {
+     "longitude": -1.0322845,
+     "latitude": 34.9049444,
+     "nom": "Ouled Mimoun",
+     "id": "404",
+     "wilaya_id": "13",
+     "code_postal": "13013"
+    },
+    {
+     "longitude": -1.375051,
+     "latitude": 35.0477582,
+     "nom": "Ain Youcef",
+     "id": "406",
+     "wilaya_id": "13",
+     "code_postal": "13015"
+    },
+    {
+     "longitude": -1.4479374,
+     "latitude": 35.0123044,
+     "nom": "Zenata",
+     "id": "407",
+     "wilaya_id": "13",
+     "code_postal": "13016"
+    },
+    {
+     "longitude": -1.5450766,
+     "latitude": 34.6593136,
+     "nom": "Beni Snous",
+     "id": "408",
+     "wilaya_id": "13",
+     "code_postal": "13017"
+    },
+    {
+     "longitude": -2.029768,
+     "latitude": 34.9640856,
+     "nom": "Bab El Assa",
+     "id": "409",
+     "wilaya_id": "13",
+     "code_postal": "13018"
+    },
+    {
+     "longitude": -1.5693045,
+     "latitude": 35.0177005,
+     "nom": "Fellaoucene",
+     "id": "411",
+     "wilaya_id": "13",
+     "code_postal": "13020"
+    },
+    {
+     "longitude": -1.4746046,
+     "latitude": 34.6794874,
+     "nom": "Azails",
+     "id": "412",
+     "wilaya_id": "13",
+     "code_postal": "13021"
+    },
+    {
+     "longitude": -1.3601865,
+     "latitude": 35.1563994,
+     "nom": "Sebbaa Chioukh",
+     "id": "413",
+     "wilaya_id": "13",
+     "code_postal": "13022"
+    },
+    {
+     "longitude": -1.2289576,
+     "latitude": 35.0739077,
+     "nom": "Bensekrane",
+     "id": "415",
+     "wilaya_id": "13",
+     "code_postal": "13024"
+    },
+    {
+     "longitude": -0.9313136,
+     "latitude": 35.0276866,
+     "nom": "Ain Nehala",
+     "id": "416",
+     "wilaya_id": "13",
+     "code_postal": "13025"
+    },
+    {
+     "longitude": -1.3710402,
+     "latitude": 34.9484714,
+     "nom": "Hennaya",
+     "id": "417",
+     "wilaya_id": "13",
+     "code_postal": "13026"
+    },
+    {
+     "longitude": -1.7349661,
+     "latitude": 34.8534497,
+     "nom": "Maghnia",
+     "id": "418",
+     "wilaya_id": "13",
+     "code_postal": "13027"
+    },
+    {
+     "longitude": -1.6444975,
+     "latitude": 34.8927177,
+     "nom": "Hammam Boughrara",
+     "id": "419",
+     "wilaya_id": "13",
+     "code_postal": "13028"
+    },
+    {
+     "longitude": -1.8952713,
+     "latitude": 35.0405953,
+     "nom": "Souahlia",
+     "id": "420",
+     "wilaya_id": "13",
+     "code_postal": "13029"
+    },
+    {
+     "longitude": -2.0518154,
+     "latitude": 35.0160389,
+     "nom": "Msirda Fouaga",
+     "id": "421",
+     "wilaya_id": "13",
+     "code_postal": "13030"
+    },
+    {
+     "longitude": -1.2554112,
+     "latitude": 34.2190891,
+     "nom": "El Aricha",
+     "id": "423",
+     "wilaya_id": "13",
+     "code_postal": "13032"
+    },
+    {
+     "longitude": -2.002836,
+     "latitude": 35.0168536,
+     "nom": "Souk Thlata",
+     "id": "424",
+     "wilaya_id": "13",
+     "code_postal": "13033"
+    },
+    {
+     "longitude": -1.1329034,
+     "latitude": 35.0638308,
+     "nom": "Sidi Abdelli",
+     "id": "425",
+     "wilaya_id": "13",
+     "code_postal": "13034"
+    },
+    {
+     "longitude": -1.332462,
+     "latitude": 34.6396882,
+     "nom": "Sebdou",
+     "id": "426",
+     "wilaya_id": "13",
+     "code_postal": "13035"
+    },
+    {
+     "longitude": -1.5559775,
+     "latitude": 35.082551,
+     "nom": "Beni Ouarsous",
+     "id": "427",
+     "wilaya_id": "13",
+     "code_postal": "13036"
+    },
+    {
+     "longitude": -1.6384287,
+     "latitude": 34.7755299,
+     "nom": "Sidi Medjahed",
+     "id": "428",
+     "wilaya_id": "13",
+     "code_postal": "13037"
+    },
+    {
+     "longitude": -1.7526648,
+     "latitude": 34.6496059,
+     "nom": "Beni Boussaid",
+     "id": "429",
+     "wilaya_id": "13",
+     "code_postal": "13038"
+    },
+    {
+     "longitude": -2.1352039,
+     "latitude": 35.0531381,
+     "nom": "Marsa Ben Mhidi",
+     "id": "430",
+     "wilaya_id": "13",
+     "code_postal": "13039"
+    },
+    {
+     "longitude": -1.7490143,
+     "latitude": 35.0097474,
+     "nom": "Nedroma",
+     "id": "431",
+     "wilaya_id": "13",
+     "code_postal": "13040"
+    },
+    {
+     "longitude": -1.5668811,
+     "latitude": 34.4458733,
+     "nom": "Sidi Djillali",
+     "id": "432",
+     "wilaya_id": "13",
+     "code_postal": "13041"
+    },
+    {
+     "longitude": -1.5123907,
+     "latitude": 34.7108589,
+     "nom": "Beni Bahdel",
+     "id": "433",
+     "wilaya_id": "13",
+     "code_postal": "13042"
+    },
+    {
+     "longitude": -1.6493532,
+     "latitude": 35.1789336,
+     "nom": "Honaine",
+     "id": "435",
+     "wilaya_id": "13",
+     "code_postal": "13044"
+    },
+    {
+     "longitude": -1.8391485,
+     "latitude": 35.049712,
+     "nom": "Tianet",
+     "id": "436",
+     "wilaya_id": "13",
+     "code_postal": "13045"
+    },
+    {
+     "longitude": -1.4978716,
+     "latitude": 34.9621354,
+     "nom": "Ouled Riyah",
+     "id": "437",
+     "wilaya_id": "13",
+     "code_postal": "13046"
+    },
+    {
+     "longitude": -1.571728,
+     "latitude": 34.7777862,
+     "nom": "Bouhlou",
+     "id": "438",
+     "wilaya_id": "13",
+     "code_postal": "13047"
+    },
+    {
+     "longitude": -1.5565831,
+     "latitude": 35.1725987,
+     "nom": "Souk El Khemis",
+     "id": "439",
+     "wilaya_id": "13",
+     "code_postal": "13048"
+    },
+    {
+     "longitude": -1.3879292,
+     "latitude": 34.7081886,
+     "nom": "Ain Ghoraba",
+     "id": "440",
+     "wilaya_id": "13",
+     "code_postal": "13049"
+    },
+    {
+     "longitude": -1.2975309,
+     "latitude": 34.92033420000001,
+     "nom": "Chetouane",
+     "id": "441",
+     "wilaya_id": "13",
+     "code_postal": "13050"
+    },
+    {
+     "longitude": -1.3565692,
+     "latitude": 34.8659187,
+     "nom": "Mansourah",
+     "id": "442",
+     "wilaya_id": "13",
+     "code_postal": "13051"
+    },
+    {
+     "longitude": -1.6784986,
+     "latitude": 35.0300112,
+     "nom": "Ain Kebira",
+     "id": "444",
+     "wilaya_id": "13",
+     "code_postal": "13053"
+    },
+    {
+     "longitude": 1.3220322,
+     "latitude": 35.3673553,
+     "nom": "Tiaret",
+     "id": "445",
+     "wilaya_id": "14",
+     "code_postal": "14001"
+    },
+    {
+     "longitude": 1.2049233,
+     "latitude": 35.1731543,
+     "nom": "Medroussa",
+     "id": "446",
+     "wilaya_id": "14",
+     "code_postal": "14002"
+    },
+    {
+     "longitude": 1.5136009,
+     "latitude": 35.3563885,
+     "nom": "Ain Bouchekif",
+     "id": "447",
+     "wilaya_id": "14",
+     "code_postal": "14003"
+    },
+    {
+     "longitude": 1.2253693,
+     "latitude": 35.56373689999999,
+     "nom": "Sidi Ali Mellal",
+     "id": "448",
+     "wilaya_id": "14",
+     "code_postal": "14004"
+    },
+    {
+     "longitude": 1.6651379,
+     "latitude": 35.3530331,
+     "nom": "Ain Zarit",
+     "id": "449",
+     "wilaya_id": "14",
+     "code_postal": "14005"
+    },
+    {
+     "longitude": 1.5450766,
+     "latitude": 34.8471273,
+     "nom": "Ain Deheb",
+     "id": "450",
+     "wilaya_id": "14",
+     "code_postal": "14006"
+    },
+    {
+     "longitude": 0.9777269000000001,
+     "latitude": 35.2393277,
+     "nom": "Sidi Bakhti",
+     "id": "451",
+     "wilaya_id": "14",
+     "code_postal": "14007"
+    },
+    {
+     "longitude": 1.2433848,
+     "latitude": 34.8919466,
+     "nom": "Medrissa",
+     "id": "452",
+     "wilaya_id": "14",
+     "code_postal": "14008"
+    },
+    {
+     "longitude": 2.3172324,
+     "latitude": 34.9121227,
+     "nom": "Zmalet El Emir Aek",
+     "id": "453",
+     "wilaya_id": "14",
+     "code_postal": "14009"
+    },
+    {
+     "longitude": 1.2337661,
+     "latitude": 35.2497888,
+     "nom": "Mellakou",
+     "id": "456",
+     "wilaya_id": "14",
+     "code_postal": "14012"
+    },
+    {
+     "longitude": 1.4759356,
+     "latitude": 35.4157148,
+     "nom": "Dahmouni",
+     "id": "457",
+     "wilaya_id": "14",
+     "code_postal": "14013"
+    },
+    {
+     "longitude": 1.0227145,
+     "latitude": 35.5313694,
+     "nom": "Rahouia",
+     "id": "458",
+     "wilaya_id": "14",
+     "code_postal": "14014"
+    },
+    {
+     "longitude": 1.7587496,
+     "latitude": 35.4270876,
+     "nom": "Mahdia",
+     "id": "459",
+     "wilaya_id": "14",
+     "code_postal": "14015"
+    },
+    {
+     "longitude": 1.4966619,
+     "latitude": 35.1781601,
+     "nom": "Sougueur",
+     "id": "460",
+     "wilaya_id": "14",
+     "code_postal": "14016"
+    },
+    {
+     "longitude": 0.8794310999999999,
+     "latitude": 35.0604194,
+     "nom": "Ain El Hadid",
+     "id": "462",
+     "wilaya_id": "14",
+     "code_postal": "14018"
+    },
+    {
+     "longitude": 1.4785205,
+     "latitude": 35.0917694,
+     "nom": "Naima",
+     "id": "464",
+     "wilaya_id": "14",
+     "code_postal": "14020"
+    },
+    {
+     "longitude": 1.3270326,
+     "latitude": 35.3632425,
+     "nom": "Meghila",
+     "id": "465",
+     "wilaya_id": "14",
+     "code_postal": "14021"
+    },
+    {
+     "longitude": 1.2578169,
+     "latitude": 35.39221,
+     "nom": "Guertoufa",
+     "id": "466",
+     "wilaya_id": "14",
+     "code_postal": "14022"
+    },
+    {
+     "longitude": 1.5184418,
+     "latitude": 35.4714207,
+     "nom": "Sidi Hosni",
+     "id": "467",
+     "wilaya_id": "14",
+     "code_postal": "14023"
+    },
+    {
+     "longitude": 0.8514301,
+     "latitude": 35.4443866,
+     "nom": "Djillali Ben Amar",
+     "id": "468",
+     "wilaya_id": "14",
+     "code_postal": "14024"
+    },
+    {
+     "longitude": 1.6020337,
+     "latitude": 35.4580212,
+     "nom": "Sebaine",
+     "id": "469",
+     "wilaya_id": "14",
+     "code_postal": "14025"
+    },
+    {
+     "longitude": 1.2758641,
+     "latitude": 35.1133168,
+     "nom": "Tousnina",
+     "id": "470",
+     "wilaya_id": "14",
+     "code_postal": "14026"
+    },
+    {
+     "longitude": 1.0538252,
+     "latitude": 35.0617882,
+     "nom": "Frenda",
+     "id": "471",
+     "wilaya_id": "14",
+     "code_postal": "14027"
+    },
+    {
+     "longitude": 1.0777723,
+     "latitude": 34.9238511,
+     "nom": "Ain Kermes",
+     "id": "472",
+     "wilaya_id": "14",
+     "code_postal": "14028"
+    },
+    {
+     "longitude": 2.3172324,
+     "latitude": 35.2202319,
+     "nom": "Ksar Chellala",
+     "id": "473",
+     "wilaya_id": "14",
+     "code_postal": "14029"
+    },
+    {
+     "longitude": 1.9710284,
+     "latitude": 35.4101241,
+     "nom": "Rechaiga",
+     "id": "474",
+     "wilaya_id": "14",
+     "code_postal": "14030"
+    },
+    {
+     "longitude": 1.2283566,
+     "latitude": 35.3356113,
+     "nom": "Tagdemt",
+     "id": "476",
+     "wilaya_id": "14",
+     "code_postal": "14032"
+    },
+    {
+     "longitude": 1.26705,
+     "latitude": 35.51192899999999,
+     "nom": "Oued Lilli",
+     "id": "477",
+     "wilaya_id": "14",
+     "code_postal": "14033"
+    },
+    {
+     "longitude": 1.8733017,
+     "latitude": 35.460979,
+     "nom": "Hamadia",
+     "id": "479",
+     "wilaya_id": "14",
+     "code_postal": "14035"
+    },
+    {
+     "longitude": 1.3047556,
+     "latitude": 34.8982002,
+     "nom": "Chehaima",
+     "id": "480",
+     "wilaya_id": "14",
+     "code_postal": "14036"
+    },
+    {
+     "longitude": 0.6844213,
+     "latitude": 35.1056992,
+     "nom": "Takhemaret",
+     "id": "481",
+     "wilaya_id": "14",
+     "code_postal": "14037"
+    },
+    {
+     "longitude": 1.1329034,
+     "latitude": 34.7992061,
+     "nom": "Sidi Abderrahmane",
+     "id": "482",
+     "wilaya_id": "14",
+     "code_postal": "14038"
+    },
+    {
+     "longitude": 2.4826726,
+     "latitude": 35.2581419,
+     "nom": "Serghine",
+     "id": "483",
+     "wilaya_id": "14",
+     "code_postal": "14039"
+    },
+    {
+     "longitude": 1.961246,
+     "latitude": 35.5581085,
+     "nom": "Bougara",
+     "id": "484",
+     "wilaya_id": "14",
+     "code_postal": "14040"
+    },
+    {
+     "longitude": 1.266238,
+     "latitude": 35.5824151,
+     "nom": "Tidda",
+     "id": "486",
+     "wilaya_id": "14",
+     "code_postal": "14042"
+    },
+    {
+     "longitude": 4.0593255,
+     "latitude": 36.7021906,
+     "nom": "Tizi Ouzou",
+     "id": "487",
+     "wilaya_id": "15",
+     "code_postal": "15001"
+    },
+    {
+     "longitude": 4.2846246,
+     "latitude": 36.5650202,
+     "nom": "Ain El Hammam",
+     "id": "488",
+     "wilaya_id": "15",
+     "code_postal": "15002"
+    },
+    {
+     "longitude": 4.3051542,
+     "latitude": 36.4995515,
+     "nom": "Akbil",
+     "id": "489",
+     "wilaya_id": "15",
+     "code_postal": "15003"
+    },
+    {
+     "longitude": 4.3177067,
+     "latitude": 36.7584263,
+     "nom": "Freha",
+     "id": "490",
+     "wilaya_id": "15",
+     "code_postal": "15004"
+    },
+    {
+     "longitude": 4.346237299999999,
+     "latitude": 36.6705552,
+     "nom": "Souamaa",
+     "id": "491",
+     "wilaya_id": "15",
+     "code_postal": "15005"
+    },
+    {
+     "longitude": 4.0049301,
+     "latitude": 36.5447993,
+     "nom": "Mechtrass",
+     "id": "492",
+     "wilaya_id": "15",
+     "code_postal": "15006"
+    },
+    {
+     "longitude": 4.1496093,
+     "latitude": 36.6613077,
+     "nom": "Irdjen",
+     "id": "493",
+     "wilaya_id": "15",
+     "code_postal": "15007"
+    },
+    {
+     "longitude": 4.2653984,
+     "latitude": 36.8024218,
+     "nom": "Timizart",
+     "id": "494",
+     "wilaya_id": "15",
+     "code_postal": "15008"
+    },
+    {
+     "longitude": 4.0624151,
+     "latitude": 36.7920474,
+     "nom": "Makouda",
+     "id": "495",
+     "wilaya_id": "15",
+     "code_postal": "15009"
+    },
+    {
+     "longitude": 3.8146526,
+     "latitude": 36.5593675,
+     "nom": "Draa El Mizan",
+     "id": "496",
+     "wilaya_id": "15",
+     "code_postal": "15010"
+    },
+    {
+     "longitude": 3.7760446,
+     "latitude": 36.5888512,
+     "nom": "Tizi Ghenif",
+     "id": "497",
+     "wilaya_id": "15",
+     "code_postal": "15011"
+    },
+    {
+     "longitude": 3.9364126,
+     "latitude": 36.4995751,
+     "nom": "Bounouh",
+     "id": "498",
+     "wilaya_id": "15",
+     "code_postal": "15012"
+    },
+    {
+     "longitude": 4.5255955,
+     "latitude": 36.8221623,
+     "nom": "Ait Chaffaa",
+     "id": "499",
+     "wilaya_id": "15",
+     "code_postal": "15013"
+    },
+    {
+     "longitude": 3.8757119,
+     "latitude": 36.49264429999999,
+     "nom": "Frikat",
+     "id": "500",
+     "wilaya_id": "15",
+     "code_postal": "15014"
+    },
+    {
+     "longitude": 4.0848789,
+     "latitude": 36.6636279,
+     "nom": "Beni Aissi",
+     "id": "501",
+     "wilaya_id": "15",
+     "code_postal": "15015"
+    },
+    {
+     "longitude": 4.039156,
+     "latitude": 36.636975,
+     "nom": "Beni Zmenzer",
+     "id": "502",
+     "wilaya_id": "15",
+     "code_postal": "15016"
+    },
+    {
+     "longitude": 4.3667907,
+     "latitude": 36.5404761,
+     "nom": "Iferhounene",
+     "id": "503",
+     "wilaya_id": "15",
+     "code_postal": "15017"
+    },
+    {
+     "longitude": 4.3667907,
+     "latitude": 36.7343859,
+     "nom": "Azazga",
+     "id": "504",
+     "wilaya_id": "15",
+     "code_postal": "15018"
+    },
+    {
+     "longitude": 4.442432,
+     "latitude": 36.5805668,
+     "nom": "Iloula Oumalou",
+     "id": "505",
+     "wilaya_id": "15",
+     "code_postal": "15019"
+    },
+    {
+     "longitude": 4.4386329,
+     "latitude": 36.7339217,
+     "nom": "Yakouren",
+     "id": "506",
+     "wilaya_id": "15",
+     "code_postal": "15020"
+    },
+    {
+     "longitude": 4.204093299999999,
+     "latitude": 36.63729319999999,
+     "nom": "Larba Nait Irathen",
+     "id": "507",
+     "wilaya_id": "15",
+     "code_postal": "15021"
+    },
+    {
+     "longitude": 4.2087286,
+     "latitude": 36.6799518,
+     "nom": "Tizi Rached",
+     "id": "508",
+     "wilaya_id": "15",
+     "code_postal": "15022"
+    },
+    {
+     "longitude": 4.583078899999999,
+     "latitude": 36.8015396,
+     "nom": "Zekri",
+     "id": "509",
+     "wilaya_id": "15",
+     "code_postal": "15023"
+    },
+    {
+     "longitude": 4.175088,
+     "latitude": 36.7700939,
+     "nom": "Ouaguenoun",
+     "id": "510",
+     "wilaya_id": "15",
+     "code_postal": "15024"
+    },
+    {
+     "longitude": 3.894797499999999,
+     "latitude": 36.5504491,
+     "nom": "Ain Zaouia",
+     "id": "511",
+     "wilaya_id": "15",
+     "code_postal": "15025"
+    },
+    {
+     "longitude": 3.7790684,
+     "latitude": 36.6305931,
+     "nom": "Mkira",
+     "id": "512",
+     "wilaya_id": "15",
+     "code_postal": "15026"
+    },
+    {
+     "longitude": 4.3256918,
+     "latitude": 36.6066637,
+     "nom": "Ait Yahia",
+     "id": "513",
+     "wilaya_id": "15",
+     "code_postal": "15027"
+    },
+    {
+     "longitude": 4.1121615,
+     "latitude": 36.6077811,
+     "nom": "Ait Mahmoud",
+     "id": "514",
+     "wilaya_id": "15",
+     "code_postal": "15028"
+    },
+    {
+     "longitude": 3.9572374,
+     "latitude": 36.6194358,
+     "nom": "Maatka",
+     "id": "515",
+     "wilaya_id": "15",
+     "code_postal": "15029"
+    },
+    {
+     "longitude": 4.1820961,
+     "latitude": 36.4823272,
+     "nom": "Ait Boumehdi",
+     "id": "516",
+     "wilaya_id": "15",
+     "code_postal": "15030"
+    },
+    {
+     "longitude": 4.3423883,
+     "latitude": 36.5389695,
+     "nom": "Abi Youcef",
+     "id": "517",
+     "wilaya_id": "15",
+     "code_postal": "15031"
+    },
+    {
+     "longitude": 4.0815246,
+     "latitude": 36.62054,
+     "nom": "Beni Douala",
+     "id": "518",
+     "wilaya_id": "15",
+     "code_postal": "15032"
+    },
+    {
+     "longitude": 4.3946198,
+     "latitude": 36.5161852,
+     "nom": "Illilten",
+     "id": "519",
+     "wilaya_id": "15",
+     "code_postal": "15033"
+    },
+    {
+     "longitude": 4.4725912,
+     "latitude": 36.6141303,
+     "nom": "Bouzguen",
+     "id": "520",
+     "wilaya_id": "15",
+     "code_postal": "15034"
+    },
+    {
+     "longitude": 4.2435893,
+     "latitude": 36.6096083,
+     "nom": "Ait Aggouacha",
+     "id": "521",
+     "wilaya_id": "15",
+     "code_postal": "15035"
+    },
+    {
+     "longitude": 4.0886525,
+     "latitude": 36.5559718,
+     "nom": "Ouadhia",
+     "id": "522",
+     "wilaya_id": "15",
+     "code_postal": "15036"
+    },
+    {
+     "longitude": 4.4240151,
+     "latitude": 36.8895311,
+     "nom": "Azzefoun",
+     "id": "523",
+     "wilaya_id": "15",
+     "code_postal": "15037"
+    },
+    {
+     "longitude": 4.1267837,
+     "latitude": 36.8905856,
+     "nom": "Tigzirt",
+     "id": "524",
+     "wilaya_id": "15",
+     "code_postal": "15038"
+    },
+    {
+     "longitude": 4.1155596,
+     "latitude": 36.7486964,
+     "nom": "Ait Aissa Mimoun",
+     "id": "525",
+     "wilaya_id": "15",
+     "code_postal": "15039"
+    },
+    {
+     "longitude": 3.9558753,
+     "latitude": 36.5410545,
+     "nom": "Boghni",
+     "id": "526",
+     "wilaya_id": "15",
+     "code_postal": "15040"
+    },
+    {
+     "longitude": 4.413693299999999,
+     "latitude": 36.6717744,
+     "nom": "Ifigha",
+     "id": "527",
+     "wilaya_id": "15",
+     "code_postal": "15041"
+    },
+    {
+     "longitude": 4.2282093,
+     "latitude": 36.6586389,
+     "nom": "Ait Oumalou",
+     "id": "528",
+     "wilaya_id": "15",
+     "code_postal": "15042"
+    },
+    {
+     "longitude": 3.9572785,
+     "latitude": 36.6756079,
+     "nom": "Tirmitine",
+     "id": "529",
+     "wilaya_id": "15",
+     "code_postal": "15043"
+    },
+    {
+     "longitude": 4.4490836,
+     "latitude": 36.817363,
+     "nom": "Akerrou",
+     "id": "530",
+     "wilaya_id": "15",
+     "code_postal": "15044"
+    },
+    {
+     "longitude": 4.2794935,
+     "latitude": 36.5274507,
+     "nom": "Yatafen",
+     "id": "531",
+     "wilaya_id": "15",
+     "code_postal": "15045"
+    },
+    {
+     "longitude": 4.5025157,
+     "latitude": 36.56280599999999,
+     "nom": "Beni Ziki",
+     "id": "532",
+     "wilaya_id": "15",
+     "code_postal": "15046"
+    },
+    {
+     "longitude": 3.9652509,
+     "latitude": 36.7309604,
+     "nom": "Draa Ben Khedda",
+     "id": "533",
+     "wilaya_id": "15",
+     "code_postal": "15047"
+    },
+    {
+     "longitude": 4.2179584,
+     "latitude": 36.5188468,
+     "nom": "Ouacif",
+     "id": "534",
+     "wilaya_id": "15",
+     "code_postal": "15048"
+    },
+    {
+     "longitude": 4.5418141,
+     "latitude": 36.6740411,
+     "nom": "Idjeur",
+     "id": "535",
+     "wilaya_id": "15",
+     "code_postal": "15049"
+    },
+    {
+     "longitude": 4.264103,
+     "latitude": 36.6735171,
+     "nom": "Mekla",
+     "id": "536",
+     "wilaya_id": "15",
+     "code_postal": "15050"
+    },
+    {
+     "longitude": 4.0388918,
+     "latitude": 36.5735762,
+     "nom": "Tizi Nthlata",
+     "id": "537",
+     "wilaya_id": "15",
+     "code_postal": "15051"
+    },
+    {
+     "longitude": 4.1820961,
+     "latitude": 36.5686516,
+     "nom": "Beni Yenni",
+     "id": "538",
+     "wilaya_id": "15",
+     "code_postal": "15052"
+    },
+    {
+     "longitude": 4.346237299999999,
+     "latitude": 36.8211575,
+     "nom": "Aghrib",
+     "id": "539",
+     "wilaya_id": "15",
+     "code_postal": "15053"
+    },
+    {
+     "longitude": 4.2230836,
+     "latitude": 36.86855930000001,
+     "nom": "Iflissen",
+     "id": "540",
+     "wilaya_id": "15",
+     "code_postal": "15054"
+    },
+    {
+     "longitude": 4.1411406,
+     "latitude": 36.8069616,
+     "nom": "Boudjima",
+     "id": "541",
+     "wilaya_id": "15",
+     "code_postal": "15055"
+    },
+    {
+     "longitude": 3.8757119,
+     "latitude": 36.6436636,
+     "nom": "Ait Yahia Moussa",
+     "id": "542",
+     "wilaya_id": "15",
+     "code_postal": "15056"
+    },
+    {
+     "longitude": 4.003152099999999,
+     "latitude": 36.5909543,
+     "nom": "Souk El Thenine",
+     "id": "543",
+     "wilaya_id": "15",
+     "code_postal": "15057"
+    },
+    {
+     "longitude": 4.3102879,
+     "latitude": 36.6664742,
+     "nom": "Ait Khelil",
+     "id": "544",
+     "wilaya_id": "15",
+     "code_postal": "15058"
+    },
+    {
+     "longitude": 3.9980485,
+     "latitude": 36.7688293,
+     "nom": "Sidi Naamane",
+     "id": "545",
+     "wilaya_id": "15",
+     "code_postal": "15059"
+    },
+    {
+     "longitude": 4.2435893,
+     "latitude": 36.5233354,
+     "nom": "Iboudraren",
+     "id": "546",
+     "wilaya_id": "15",
+     "code_postal": "15060"
+    },
+    {
+     "longitude": 4.079767299999999,
+     "latitude": 36.852067,
+     "nom": "Mizrana",
+     "id": "548",
+     "wilaya_id": "15",
+     "code_postal": "15062"
+    },
+    {
+     "longitude": 4.3924936,
+     "latitude": 36.5772781,
+     "nom": "Imsouhal",
+     "id": "549",
+     "wilaya_id": "15",
+     "code_postal": "15063"
+    },
+    {
+     "longitude": 3.8960811,
+     "latitude": 36.70763000000001,
+     "nom": "Tadmait",
+     "id": "550",
+     "wilaya_id": "15",
+     "code_postal": "15064"
+    },
+    {
+     "longitude": 4.0593255,
+     "latitude": 36.5081471,
+     "nom": "Ait Bouadou",
+     "id": "551",
+     "wilaya_id": "15",
+     "code_postal": "15065"
+    },
+    {
+     "longitude": 4.013361,
+     "latitude": 36.5043008,
+     "nom": "Assi Youcef",
+     "id": "552",
+     "wilaya_id": "15",
+     "code_postal": "15066"
+    },
+    {
+     "longitude": 4.1616143,
+     "latitude": 36.5262163,
+     "nom": "Ait Toudert",
+     "id": "553",
+     "wilaya_id": "15",
+     "code_postal": "15067"
+    },
+    {
+     "longitude": 3.0551159,
+     "latitude": 36.7724841,
+     "nom": "Alger Centre",
+     "id": "554",
+     "wilaya_id": "16",
+     "code_postal": "16001"
+    },
+    {
+     "longitude": 3.0587561,
+     "latitude": 36.753768,
+     "nom": "Sidi Mhamed",
+     "id": "555",
+     "wilaya_id": "16",
+     "code_postal": "16002"
+    },
+    {
+     "longitude": 3.0688896,
+     "latitude": 36.7411788,
+     "nom": "El Madania",
+     "id": "556",
+     "wilaya_id": "16",
+     "code_postal": "16003"
+    },
+    {
+     "longitude": 3.0781232,
+     "latitude": 36.7509629,
+     "nom": "Hamma Anassers",
+     "id": "557",
+     "wilaya_id": "16",
+     "code_postal": "16004"
+    },
+    {
+     "longitude": 3.0513601,
+     "latitude": 36.7927594,
+     "nom": "Bab El Oued",
+     "id": "558",
+     "wilaya_id": "16",
+     "code_postal": "16005"
+    },
+    {
+     "longitude": 3.0433403,
+     "latitude": 36.8037134,
+     "nom": "Bologhine Ibn Ziri",
+     "id": "559",
+     "wilaya_id": "16",
+     "code_postal": "16006"
+    },
+    {
+     "longitude": 3.058872,
+     "latitude": 36.7844961,
+     "nom": "Casbah",
+     "id": "560",
+     "wilaya_id": "16",
+     "code_postal": "16007"
+    },
+    {
+     "longitude": 3.0400945,
+     "latitude": 36.7836306,
+     "nom": "Oued Koriche",
+     "id": "561",
+     "wilaya_id": "16",
+     "code_postal": "16008"
+    },
+    {
+     "longitude": 3.0503737,
+     "latitude": 36.7353493,
+     "nom": "Bir Mourad Rais",
+     "id": "562",
+     "wilaya_id": "16",
+     "code_postal": "16009"
+    },
+    {
+     "longitude": 3.0309946,
+     "latitude": 36.7690092,
+     "nom": "El Biar",
+     "id": "563",
+     "wilaya_id": "16",
+     "code_postal": "16010"
+    },
+    {
+     "longitude": 3.0125674,
+     "latitude": 36.7816379,
+     "nom": "Bouzareah",
+     "id": "564",
+     "wilaya_id": "16",
+     "code_postal": "16011"
+    },
+    {
+     "longitude": 3.0425977,
+     "latitude": 36.7162726,
+     "nom": "Birkhadem",
+     "id": "565",
+     "wilaya_id": "16",
+     "code_postal": "16012"
+    },
+    {
+     "longitude": 3.1428341,
+     "latitude": 36.7029047,
+     "nom": "El Harrach",
+     "id": "566",
+     "wilaya_id": "16",
+     "code_postal": "16013"
+    },
+    {
+     "longitude": 3.0985796,
+     "latitude": 36.6672951,
+     "nom": "Baraki",
+     "id": "567",
+     "wilaya_id": "16",
+     "code_postal": "16014"
+    },
+    {
+     "longitude": 3.1754557,
+     "latitude": 36.6993487,
+     "nom": "Oued Smar",
+     "id": "568",
+     "wilaya_id": "16",
+     "code_postal": "16015"
+    },
+    {
+     "longitude": 3.1152484,
+     "latitude": 36.7117069,
+     "nom": "Bourouba",
+     "id": "569",
+     "wilaya_id": "16",
+     "code_postal": "16016"
+    },
+    {
+     "longitude": 3.1102345,
+     "latitude": 36.744147,
+     "nom": "Hussein Dey",
+     "id": "570",
+     "wilaya_id": "16",
+     "code_postal": "16017"
+    },
+    {
+     "longitude": 3.0814946,
+     "latitude": 36.7266729,
+     "nom": "Kouba",
+     "id": "571",
+     "wilaya_id": "16",
+     "code_postal": "16018"
+    },
+    {
+     "longitude": 3.1180085,
+     "latitude": 36.7261506,
+     "nom": "Bachedjerah",
+     "id": "572",
+     "wilaya_id": "16",
+     "code_postal": "16019"
+    },
+    {
+     "longitude": 3.2281983,
+     "latitude": 36.70601449999999,
+     "nom": "Dar El Beida",
+     "id": "573",
+     "wilaya_id": "16",
+     "code_postal": "16020"
+    },
+    {
+     "longitude": 3.1854975,
+     "latitude": 36.7206251,
+     "nom": "Bab Azzouar",
+     "id": "574",
+     "wilaya_id": "16",
+     "code_postal": "16021"
+    },
+    {
+     "longitude": 3.0100658,
+     "latitude": 36.7574811,
+     "nom": "Ben Aknoun",
+     "id": "575",
+     "wilaya_id": "16",
+     "code_postal": "16022"
+    },
+    {
+     "longitude": 2.9800558,
+     "latitude": 36.7528506,
+     "nom": "Dely Ibrahim",
+     "id": "576",
+     "wilaya_id": "16",
+     "code_postal": "16023"
+    },
+    {
+     "longitude": 3.0019362,
+     "latitude": 36.8162039,
+     "nom": "Bains Romains",
+     "id": "577",
+     "wilaya_id": "16",
+     "code_postal": "16024"
+    },
+    {
+     "longitude": 3.0100658,
+     "latitude": 36.8112925,
+     "nom": "Rais Hamidou",
+     "id": "578",
+     "wilaya_id": "16",
+     "code_postal": "16025"
+    },
+    {
+     "longitude": 3.079263,
+     "latitude": 36.6978776,
+     "nom": "Djasr Kasentina",
+     "id": "579",
+     "wilaya_id": "16",
+     "code_postal": "16026"
+    },
+    {
+     "longitude": 3.0488564,
+     "latitude": 36.7497677,
+     "nom": "El Mouradia",
+     "id": "580",
+     "wilaya_id": "16",
+     "code_postal": "16027"
+    },
+    {
+     "longitude": 3.0250778,
+     "latitude": 36.7409507,
+     "nom": "Hydra",
+     "id": "581",
+     "wilaya_id": "16",
+     "code_postal": "16028"
+    },
+    {
+     "longitude": 3.1528692,
+     "latitude": 36.73495279999999,
+     "nom": "Mohammadia",
+     "id": "582",
+     "wilaya_id": "16",
+     "code_postal": "16029"
+    },
+    {
+     "longitude": 3.190432,
+     "latitude": 36.747187,
+     "nom": "Bordj El Kiffan",
+     "id": "583",
+     "wilaya_id": "16",
+     "code_postal": "16030"
+    },
+    {
+     "longitude": 3.1114879,
+     "latitude": 36.7319999,
+     "nom": "El Magharia",
+     "id": "584",
+     "wilaya_id": "16",
+     "code_postal": "16031"
+    },
+    {
+     "longitude": 2.9725563,
+     "latitude": 36.782641,
+     "nom": "Beni Messous",
+     "id": "585",
+     "wilaya_id": "16",
+     "code_postal": "16032"
+    },
+    {
+     "longitude": 3.1679257,
+     "latitude": 36.6645264,
+     "nom": "Les Eucalyptus",
+     "id": "586",
+     "wilaya_id": "16",
+     "code_postal": "16033"
+    },
+    {
+     "longitude": 3.0476046,
+     "latitude": 36.6460945,
+     "nom": "Birtouta",
+     "id": "587",
+     "wilaya_id": "16",
+     "code_postal": "16034"
+    },
+    {
+     "longitude": 2.9225893,
+     "latitude": 36.6222556,
+     "nom": "Tassala El Merdja",
+     "id": "588",
+     "wilaya_id": "16",
+     "code_postal": "16035"
+    },
+    {
+     "longitude": 2.9875565,
+     "latitude": 36.6044691,
+     "nom": "Ouled Chebel",
+     "id": "589",
+     "wilaya_id": "16",
+     "code_postal": "16036"
+    },
+    {
+     "longitude": 3.1077277,
+     "latitude": 36.6229795,
+     "nom": "Sidi Moussa",
+     "id": "590",
+     "wilaya_id": "16",
+     "code_postal": "16037"
+    },
+    {
+     "longitude": 3.2835137,
+     "latitude": 36.7852529,
+     "nom": "Ain Taya",
+     "id": "591",
+     "wilaya_id": "16",
+     "code_postal": "16038"
+    },
+    {
+     "longitude": 3.2404681,
+     "latitude": 36.7791328,
+     "nom": "Bordj El Bahri",
+     "id": "592",
+     "wilaya_id": "16",
+     "code_postal": "16039"
+    },
+    {
+     "longitude": 3.2448731,
+     "latitude": 36.8111249,
+     "nom": "Marsa",
+     "id": "593",
+     "wilaya_id": "16",
+     "code_postal": "16040"
+    },
+    {
+     "longitude": 3.3086778,
+     "latitude": 36.7684157,
+     "nom": "Haraoua",
+     "id": "594",
+     "wilaya_id": "16",
+     "code_postal": "16041"
+    },
+    {
+     "longitude": 3.2885455,
+     "latitude": 36.7259091,
+     "nom": "Rouiba",
+     "id": "595",
+     "wilaya_id": "16",
+     "code_postal": "16042"
+    },
+    {
+     "longitude": 3.3387368,
+     "latitude": 36.7431477,
+     "nom": "Reghaia",
+     "id": "596",
+     "wilaya_id": "16",
+     "code_postal": "16043"
+    },
+    {
+     "longitude": 2.9337917,
+     "latitude": 36.7965083,
+     "nom": "Ain Benian",
+     "id": "597",
+     "wilaya_id": "16",
+     "code_postal": "16044"
+    },
+    {
+     "longitude": 2.8881795,
+     "latitude": 36.7516507,
+     "nom": "Staoueli",
+     "id": "598",
+     "wilaya_id": "16",
+     "code_postal": "16045"
+    },
+    {
+     "longitude": 2.8277963,
+     "latitude": 36.6946148,
+     "nom": "Zeralda",
+     "id": "599",
+     "wilaya_id": "16",
+     "code_postal": "16046"
+    },
+    {
+     "longitude": 2.8676861,
+     "latitude": 36.65054629999999,
+     "nom": "Mahelma",
+     "id": "600",
+     "wilaya_id": "16",
+     "code_postal": "16047"
+    },
+    {
+     "longitude": 2.9126022,
+     "latitude": 36.6764115,
+     "nom": "Rahmania",
+     "id": "601",
+     "wilaya_id": "16",
+     "code_postal": "16048"
+    },
+    {
+     "longitude": 2.9026172,
+     "latitude": 36.7089832,
+     "nom": "Souidania",
+     "id": "602",
+     "wilaya_id": "16",
+     "code_postal": "16049"
+    },
+    {
+     "longitude": 2.9225893,
+     "latitude": 36.7623459,
+     "nom": "Cheraga",
+     "id": "603",
+     "wilaya_id": "16",
+     "code_postal": "16050"
+    },
+    {
+     "longitude": 2.9425698,
+     "latitude": 36.7295502,
+     "nom": "Ouled Fayet",
+     "id": "604",
+     "wilaya_id": "16",
+     "code_postal": "16051"
+    },
+    {
+     "longitude": 2.9825559,
+     "latitude": 36.7285583,
+     "nom": "El Achour",
+     "id": "605",
+     "wilaya_id": "16",
+     "code_postal": "16052"
+    },
+    {
+     "longitude": 3.0025615,
+     "latitude": 36.7172858,
+     "nom": "Draria",
+     "id": "606",
+     "wilaya_id": "16",
+     "code_postal": "16053"
+    },
+    {
+     "longitude": 2.9275836,
+     "latitude": 36.6490943,
+     "nom": "Douera",
+     "id": "607",
+     "wilaya_id": "16",
+     "code_postal": "16054"
+    },
+    {
+     "longitude": 2.9731072,
+     "latitude": 36.6943775,
+     "nom": "Baba Hassen",
+     "id": "608",
+     "wilaya_id": "16",
+     "code_postal": "16055"
+    },
+    {
+     "longitude": 3.0275802,
+     "latitude": 36.6897194,
+     "nom": "Saoula",
+     "id": "610",
+     "wilaya_id": "16",
+     "code_postal": "16057"
+    },
+    {
+     "longitude": 3.2684215,
+     "latitude": 34.6751691,
+     "nom": "Djelfa",
+     "id": "611",
+     "wilaya_id": "17",
+     "code_postal": "17001"
+    },
+    {
+     "longitude": 3.4675075,
+     "latitude": 34.5065791,
+     "nom": "Moudjebara",
+     "id": "612",
+     "wilaya_id": "17",
+     "code_postal": "17002"
+    },
+    {
+     "longitude": 3.0275802,
+     "latitude": 35.07822850000001,
+     "nom": "Hassi Bahbah",
+     "id": "614",
+     "wilaya_id": "17",
+     "code_postal": "17004"
+    },
+    {
+     "longitude": 3.1328011,
+     "latitude": 34.8056891,
+     "nom": "Ain Maabed",
+     "id": "615",
+     "wilaya_id": "17",
+     "code_postal": "17005"
+    },
+    {
+     "longitude": 3.2256855,
+     "latitude": 33.9524075,
+     "nom": "Sed Rahal",
+     "id": "616",
+     "wilaya_id": "17",
+     "code_postal": "17006"
+    },
+    {
+     "longitude": 3.7816093,
+     "latitude": 34.5304864,
+     "nom": "Feidh El Botma",
+     "id": "617",
+     "wilaya_id": "17",
+     "code_postal": "17007"
+    },
+    {
+     "longitude": 3.2231727,
+     "latitude": 35.6267216,
+     "nom": "Birine",
+     "id": "618",
+     "wilaya_id": "17",
+     "code_postal": "17008"
+    },
+    {
+     "longitude": 3.1403256,
+     "latitude": 35.2429194,
+     "nom": "Bouira Lahdeb",
+     "id": "619",
+     "wilaya_id": "17",
+     "code_postal": "17009"
+    },
+    {
+     "longitude": 3.3250413,
+     "latitude": 34.4316233,
+     "nom": "Zaccar",
+     "id": "620",
+     "wilaya_id": "17",
+     "code_postal": "17010"
+    },
+    {
+     "longitude": 2.5966036,
+     "latitude": 35.2886856,
+     "nom": "El Khemis",
+     "id": "621",
+     "wilaya_id": "17",
+     "code_postal": "17011"
+    },
+    {
+     "longitude": 3.4321679,
+     "latitude": 35.0592433,
+     "nom": "Sidi Baizid",
+     "id": "622",
+     "wilaya_id": "17",
+     "code_postal": "17012"
+    },
+    {
+     "longitude": 3.4813978,
+     "latitude": 34.7562504,
+     "nom": "Mliliha",
+     "id": "623",
+     "wilaya_id": "17",
+     "code_postal": "17013"
+    },
+    {
+     "longitude": 2.5247449,
+     "latitude": 34.4548511,
+     "nom": "El Idrissia",
+     "id": "624",
+     "wilaya_id": "17",
+     "code_postal": "17014"
+    },
+    {
+     "longitude": 2.706634,
+     "latitude": 34.373924,
+     "nom": "Douis",
+     "id": "625",
+     "wilaya_id": "17",
+     "code_postal": "17015"
+    },
+    {
+     "longitude": 3.2533339,
+     "latitude": 35.1548428,
+     "nom": "Hassi El Euch",
+     "id": "626",
+     "wilaya_id": "17",
+     "code_postal": "17016"
+    },
+    {
+     "longitude": 3.495292,
+     "latitude": 34.1536688,
+     "nom": "Messaad",
+     "id": "627",
+     "wilaya_id": "17",
+     "code_postal": "17017"
+    },
+    {
+     "longitude": 4.6850858,
+     "latitude": 33.1610943,
+     "nom": "Guettara",
+     "id": "628",
+     "wilaya_id": "17",
+     "code_postal": "17018"
+    },
+    {
+     "longitude": 2.514842,
+     "latitude": 35.435674,
+     "nom": "Sidi Ladjel",
+     "id": "629",
+     "wilaya_id": "17",
+     "code_postal": "17019"
+    },
+    {
+     "longitude": 3.3615643,
+     "latitude": 35.3521531,
+     "nom": "Had Sahary",
+     "id": "630",
+     "wilaya_id": "17",
+     "code_postal": "17020"
+    },
+    {
+     "longitude": 2.6822356,
+     "latitude": 35.2003683,
+     "nom": "Guernini",
+     "id": "631",
+     "wilaya_id": "17",
+     "code_postal": "17021"
+    },
+    {
+     "longitude": 3.5991846,
+     "latitude": 34.1762857,
+     "nom": "Selmana",
+     "id": "632",
+     "wilaya_id": "17",
+     "code_postal": "17022"
+    },
+    {
+     "longitude": 2.522269,
+     "latitude": 34.2413281,
+     "nom": "Ain Chouhada",
+     "id": "633",
+     "wilaya_id": "17",
+     "code_postal": "17023"
+    },
+    {
+     "longitude": 4.530214099999999,
+     "latitude": 33.7206099,
+     "nom": "Oum Laadham",
+     "id": "634",
+     "wilaya_id": "17",
+     "code_postal": "17024"
+    },
+    {
+     "longitude": 2.8003916,
+     "latitude": 34.6176861,
+     "nom": "Charef",
+     "id": "636",
+     "wilaya_id": "17",
+     "code_postal": "17026"
+    },
+    {
+     "longitude": 2.783333,
+     "latitude": 34.466667,
+     "nom": "Beni Yacoub",
+     "id": "637",
+     "wilaya_id": "17",
+     "code_postal": "17027"
+    },
+    {
+     "longitude": 2.8502302,
+     "latitude": 34.8539773,
+     "nom": "Zaafrane",
+     "id": "638",
+     "wilaya_id": "17",
+     "code_postal": "17028"
+    },
+    {
+     "longitude": 3.2256855,
+     "latitude": 34.3525264,
+     "nom": "Ain El Ibel",
+     "id": "640",
+     "wilaya_id": "17",
+     "code_postal": "17030"
+    },
+    {
+     "longitude": 2.9076094,
+     "latitude": 35.4542653,
+     "nom": "Ain Oussera",
+     "id": "641",
+     "wilaya_id": "17",
+     "code_postal": "17031"
+    },
+    {
+     "longitude": 3.0113166,
+     "latitude": 35.4859395,
+     "nom": "Benhar",
+     "id": "642",
+     "wilaya_id": "17",
+     "code_postal": "17032"
+    },
+    {
+     "longitude": 3.8693481,
+     "latitude": 34.3547243,
+     "nom": "Amourah",
+     "id": "644",
+     "wilaya_id": "17",
+     "code_postal": "17034"
+    },
+    {
+     "longitude": 3.5407909,
+     "latitude": 35.4702472,
+     "nom": "Ain Fekka",
+     "id": "645",
+     "wilaya_id": "17",
+     "code_postal": "17035"
+    },
+    {
+     "longitude": 2.983333,
+     "latitude": 34.283333,
+     "nom": "Tadmit",
+     "id": "646",
+     "wilaya_id": "17",
+     "code_postal": "17036"
+    },
+    {
+     "longitude": 5.749093299999999,
+     "latitude": 36.81673869999999,
+     "nom": "Jijel",
+     "id": "647",
+     "wilaya_id": "18",
+     "code_postal": "18001"
+    },
+    {
+     "longitude": 5.569604099999999,
+     "latitude": 36.584745,
+     "nom": "Erraguene",
+     "id": "648",
+     "wilaya_id": "18",
+     "code_postal": "18002"
+    },
+    {
+     "longitude": 5.6352801,
+     "latitude": 36.7456809,
+     "nom": "El Aouana",
+     "id": "649",
+     "wilaya_id": "18",
+     "code_postal": "18003"
+    },
+    {
+     "longitude": 5.4987565,
+     "latitude": 36.6337798,
+     "nom": "Ziamma Mansouriah",
+     "id": "650",
+     "wilaya_id": "18",
+     "code_postal": "18004"
+    },
+    {
+     "longitude": 5.909275399999999,
+     "latitude": 36.7753597,
+     "nom": "Taher",
+     "id": "651",
+     "wilaya_id": "18",
+     "code_postal": "18005"
+    },
+    {
+     "longitude": 5.8459341,
+     "latitude": 36.77848669999999,
+     "nom": "Emir Abdelkader",
+     "id": "652",
+     "wilaya_id": "18",
+     "code_postal": "18006"
+    },
+    {
+     "longitude": 5.9581464,
+     "latitude": 36.771582,
+     "nom": "Chekfa",
+     "id": "653",
+     "wilaya_id": "18",
+     "code_postal": "18007"
+    },
+    {
+     "longitude": 5.9548431,
+     "latitude": 36.6770779,
+     "nom": "Chahna",
+     "id": "654",
+     "wilaya_id": "18",
+     "code_postal": "18008"
+    },
+    {
+     "longitude": 6.2853999,
+     "latitude": 36.7507275,
+     "nom": "El Milia",
+     "id": "655",
+     "wilaya_id": "18",
+     "code_postal": "18009"
+    },
+    {
+     "longitude": 6.273445199999999,
+     "latitude": 36.6425914,
+     "nom": "Sidi Maarouf",
+     "id": "656",
+     "wilaya_id": "18",
+     "code_postal": "18010"
+    },
+    {
+     "longitude": 6.3359009,
+     "latitude": 36.71852519999999,
+     "nom": "Settara",
+     "id": "657",
+     "wilaya_id": "18",
+     "code_postal": "18011"
+    },
+    {
+     "longitude": 6.1593269,
+     "latitude": 36.798905,
+     "nom": "El Ancer",
+     "id": "658",
+     "wilaya_id": "18",
+     "code_postal": "18012"
+    },
+    {
+     "longitude": 6.0526981,
+     "latitude": 36.8546552,
+     "nom": "Sidi Abdelaziz",
+     "id": "659",
+     "wilaya_id": "18",
+     "code_postal": "18013"
+    },
+    {
+     "longitude": 5.7405139,
+     "latitude": 36.7406564,
+     "nom": "Kaous",
+     "id": "660",
+     "wilaya_id": "18",
+     "code_postal": "18014"
+    },
+    {
+     "longitude": 6.387773399999999,
+     "latitude": 36.6284551,
+     "nom": "Ghebala",
+     "id": "661",
+     "wilaya_id": "18",
+     "code_postal": "18015"
+    },
+    {
+     "longitude": 6.104333599999999,
+     "latitude": 36.6977238,
+     "nom": "Bouraoui Belhadef",
+     "id": "662",
+     "wilaya_id": "18",
+     "code_postal": "18016"
+    },
+    {
+     "longitude": 5.624766999999999,
+     "latitude": 36.6709346,
+     "nom": "Selma Benziada",
+     "id": "664",
+     "wilaya_id": "18",
+     "code_postal": "18018"
+    },
+    {
+     "longitude": 6.018960000000001,
+     "latitude": 36.6422747,
+     "nom": "Boussif Ouled Askeur",
+     "id": "665",
+     "wilaya_id": "18",
+     "code_postal": "18019"
+    },
+    {
+     "longitude": 5.962771399999999,
+     "latitude": 36.82568029999999,
+     "nom": "El Kennar Nouchfi",
+     "id": "666",
+     "wilaya_id": "18",
+     "code_postal": "18020"
+    },
+    {
+     "longitude": 5.7826597,
+     "latitude": 36.5880677,
+     "nom": "Boudria Beni Yadjis",
+     "id": "668",
+     "wilaya_id": "18",
+     "code_postal": "18022"
+    },
+    {
+     "longitude": 5.751047499999999,
+     "latitude": 36.6649099,
+     "nom": "Texena",
+     "id": "670",
+     "wilaya_id": "18",
+     "code_postal": "18024"
+    },
+    {
+     "longitude": 6.1222175,
+     "latitude": 36.8088666,
+     "nom": "Djemaa Beni Habibi",
+     "id": "671",
+     "wilaya_id": "18",
+     "code_postal": "18025"
+    },
+    {
+     "longitude": 5.968859,
+     "latitude": 36.7707314,
+     "nom": "Bordj Taher",
+     "id": "672",
+     "wilaya_id": "18",
+     "code_postal": "18026"
+    },
+    {
+     "longitude": 6.169933599999999,
+     "latitude": 36.5969116,
+     "nom": "Ouled Rabah",
+     "id": "673",
+     "wilaya_id": "18",
+     "code_postal": "18027"
+    },
+    {
+     "longitude": 5.8881542,
+     "latitude": 36.6904688,
+     "nom": "Ouadjana",
+     "id": "674",
+     "wilaya_id": "18",
+     "code_postal": "18028"
+    },
+    {
+     "longitude": 5.4150871,
+     "latitude": 36.1969027,
+     "nom": "Setif",
+     "id": "675",
+     "wilaya_id": "19",
+     "code_postal": "19001"
+    },
+    {
+     "longitude": 5.509246999999999,
+     "latitude": 36.3637833,
+     "nom": "Ain El Kebira",
+     "id": "676",
+     "wilaya_id": "19",
+     "code_postal": "19002"
+    },
+    {
+     "longitude": 5.6563119,
+     "latitude": 36.4648323,
+     "nom": "Beni Aziz",
+     "id": "677",
+     "wilaya_id": "19",
+     "code_postal": "19003"
+    },
+    {
+     "longitude": 5.166666999999999,
+     "latitude": 35.733333,
+     "nom": "Ouled Sidi Ahmed",
+     "id": "678",
+     "wilaya_id": "19",
+     "code_postal": "19004"
+    },
+    {
+     "longitude": 5.2475518,
+     "latitude": 35.6920766,
+     "nom": "Boutaleb",
+     "id": "679",
+     "wilaya_id": "19",
+     "code_postal": "19005"
+    },
+    {
+     "longitude": 5.1953554,
+     "latitude": 36.3129898,
+     "nom": "Ain Roua",
+     "id": "680",
+     "wilaya_id": "19",
+     "code_postal": "19006"
+    },
+    {
+     "longitude": 4.9973939,
+     "latitude": 36.4379461,
+     "nom": "Draa Kebila",
+     "id": "681",
+     "wilaya_id": "19",
+     "code_postal": "19007"
+    },
+    {
+     "longitude": 5.7932008,
+     "latitude": 36.1016103,
+     "nom": "Bir El Arch",
+     "id": "682",
+     "wilaya_id": "19",
+     "code_postal": "19008"
+    },
+    {
+     "longitude": 4.9039424,
+     "latitude": 36.4764952,
+     "nom": "Beni Chebana",
+     "id": "683",
+     "wilaya_id": "19",
+     "code_postal": "19009"
+    },
+    {
+     "longitude": 5.1223608,
+     "latitude": 35.7845851,
+     "nom": "Ouled Tebben",
+     "id": "684",
+     "wilaya_id": "19",
+     "code_postal": "19010"
+    },
+    {
+     "longitude": 5.373017600000001,
+     "latitude": 35.6865509,
+     "nom": "Hamma",
+     "id": "685",
+     "wilaya_id": "19",
+     "code_postal": "19011"
+    },
+    {
+     "longitude": 5.6983979,
+     "latitude": 36.398105,
+     "nom": "Maaouia",
+     "id": "686",
+     "wilaya_id": "19",
+     "code_postal": "19012"
+    },
+    {
+     "longitude": 4.891024199999999,
+     "latitude": 36.4096669,
+     "nom": "Ain Legraj",
+     "id": "687",
+     "wilaya_id": "19",
+     "code_postal": "19013"
+    },
+    {
+     "longitude": 5.2893433,
+     "latitude": 36.2980641,
+     "nom": "Ain Abessa",
+     "id": "688",
+     "wilaya_id": "19",
+     "code_postal": "19014"
+    },
+    {
+     "longitude": 5.624766999999999,
+     "latitude": 36.3692058,
+     "nom": "Dehamcha",
+     "id": "689",
+     "wilaya_id": "19",
+     "code_postal": "19015"
+    },
+    {
+     "longitude": 5.4987565,
+     "latitude": 36.46140159999999,
+     "nom": "Babor",
+     "id": "690",
+     "wilaya_id": "19",
+     "code_postal": "19016"
+    },
+    {
+     "longitude": 5.4987565,
+     "latitude": 36.0721187,
+     "nom": "Guidjel",
+     "id": "691",
+     "wilaya_id": "19",
+     "code_postal": "19017"
+    },
+    {
+     "longitude": 5.541949700000001,
+     "latitude": 35.9372791,
+     "nom": "Ain Lahdjar",
+     "id": "692",
+     "wilaya_id": "19",
+     "code_postal": "19018"
+    },
+    {
+     "longitude": 5.0078451,
+     "latitude": 36.4937653,
+     "nom": "Bousselam",
+     "id": "693",
+     "wilaya_id": "19",
+     "code_postal": "19019"
+    },
+    {
+     "longitude": 5.6983979,
+     "latitude": 36.1603006,
+     "nom": "El Eulma",
+     "id": "694",
+     "wilaya_id": "19",
+     "code_postal": "19020"
+    },
+    {
+     "longitude": 5.7932008,
+     "latitude": 36.3179676,
+     "nom": "Djemila",
+     "id": "695",
+     "wilaya_id": "19",
+     "code_postal": "19021"
+    },
+    {
+     "longitude": 4.8525282,
+     "latitude": 36.44220550000001,
+     "nom": "Beni Ouartilane",
+     "id": "696",
+     "wilaya_id": "19",
+     "code_postal": "19022"
+    },
+    {
+     "longitude": 5.2475518,
+     "latitude": 35.7791966,
+     "nom": "Rosfa",
+     "id": "697",
+     "wilaya_id": "19",
+     "code_postal": "19023"
+    },
+    {
+     "longitude": 5.4672962,
+     "latitude": 36.344105,
+     "nom": "Ouled Addouane",
+     "id": "698",
+     "wilaya_id": "19",
+     "code_postal": "19024"
+    },
+    {
+     "longitude": 5.8775964,
+     "latitude": 36.2273854,
+     "nom": "Belaa",
+     "id": "699",
+     "wilaya_id": "19",
+     "code_postal": "19025"
+    },
+    {
+     "longitude": 5.3302913,
+     "latitude": 36.1755508,
+     "nom": "Ain Arnat",
+     "id": "700",
+     "wilaya_id": "19",
+     "code_postal": "19026"
+    },
+    {
+     "longitude": 5.414900299999999,
+     "latitude": 36.3788902,
+     "nom": "Amoucha",
+     "id": "701",
+     "wilaya_id": "19",
+     "code_postal": "19027"
+    },
+    {
+     "longitude": 5.2976288,
+     "latitude": 35.9147478,
+     "nom": "Ain Oulmane",
+     "id": "702",
+     "wilaya_id": "19",
+     "code_postal": "19028"
+    },
+    {
+     "longitude": 5.666313,
+     "latitude": 35.8941421,
+     "nom": "Beidha Bordj",
+     "id": "703",
+     "wilaya_id": "19",
+     "code_postal": "19029"
+    },
+    {
+     "longitude": 5.1119407,
+     "latitude": 36.5109283,
+     "nom": "Bouandas",
+     "id": "704",
+     "wilaya_id": "19",
+     "code_postal": "19030"
+    },
+    {
+     "longitude": 5.6668306,
+     "latitude": 36.0643003,
+     "nom": "Bazer Sakhra",
+     "id": "705",
+     "wilaya_id": "19",
+     "code_postal": "19031"
+    },
+    {
+     "longitude": 5.8353837,
+     "latitude": 35.96946399999999,
+     "nom": "Hammam Essokhna",
+     "id": "706",
+     "wilaya_id": "19",
+     "code_postal": "19032"
+    },
+    {
+     "longitude": 5.2475518,
+     "latitude": 36.08336389999999,
+     "nom": "Mezloug",
+     "id": "707",
+     "wilaya_id": "19",
+     "code_postal": "19033"
+    },
+    {
+     "longitude": 5.4987565,
+     "latitude": 35.9853448,
+     "nom": "Bir Haddada",
+     "id": "708",
+     "wilaya_id": "19",
+     "code_postal": "19034"
+    },
+    {
+     "longitude": 5.593239,
+     "latitude": 36.4678015,
+     "nom": "Serdj El Ghoul",
+     "id": "709",
+     "wilaya_id": "19",
+     "code_postal": "19035"
+    },
+    {
+     "longitude": 4.9247074,
+     "latitude": 36.3460467,
+     "nom": "Harbil",
+     "id": "710",
+     "wilaya_id": "19",
+     "code_postal": "19036"
+    },
+    {
+     "longitude": 5.414900299999999,
+     "latitude": 36.2924521,
+     "nom": "El Ouricia",
+     "id": "711",
+     "wilaya_id": "19",
+     "code_postal": "19037"
+    },
+    {
+     "longitude": 5.3625516,
+     "latitude": 36.4352238,
+     "nom": "Tizi Nbechar",
+     "id": "712",
+     "wilaya_id": "19",
+     "code_postal": "19038"
+    },
+    {
+     "longitude": 5.373017600000001,
+     "latitude": 35.8171868,
+     "nom": "Salah Bey",
+     "id": "713",
+     "wilaya_id": "19",
+     "code_postal": "19039"
+    },
+    {
+     "longitude": 5.5133952,
+     "latitude": 35.8184752,
+     "nom": "Ain Azal",
+     "id": "714",
+     "wilaya_id": "19",
+     "code_postal": "19040"
+    },
+    {
+     "longitude": 4.8209596,
+     "latitude": 36.3286473,
+     "nom": "Guenzet",
+     "id": "715",
+     "wilaya_id": "19",
+     "code_postal": "19041"
+    },
+    {
+     "longitude": 5.7089241,
+     "latitude": 35.9755409,
+     "nom": "Talaifacene",
+     "id": "716",
+     "wilaya_id": "19",
+     "code_postal": "19042"
+    },
+    {
+     "longitude": 5.1119407,
+     "latitude": 36.3381987,
+     "nom": "Bougaa",
+     "id": "717",
+     "wilaya_id": "19",
+     "code_postal": "19043"
+    },
+    {
+     "longitude": 5.5827334,
+     "latitude": 36.28474420000001,
+     "nom": "Beni Fouda",
+     "id": "718",
+     "wilaya_id": "19",
+     "code_postal": "19044"
+    },
+    {
+     "longitude": 5.7405139,
+     "latitude": 36.2664729,
+     "nom": "Tachouda",
+     "id": "719",
+     "wilaya_id": "19",
+     "code_postal": "19045"
+    },
+    {
+     "longitude": 4.9096065,
+     "latitude": 36.51669589999999,
+     "nom": "Beni Mouhli",
+     "id": "720",
+     "wilaya_id": "19",
+     "code_postal": "19046"
+    },
+    {
+     "longitude": 5.5407299,
+     "latitude": 36.1568639,
+     "nom": "Ouled Sabor",
+     "id": "721",
+     "wilaya_id": "19",
+     "code_postal": "19047"
+    },
+    {
+     "longitude": 5.3311652,
+     "latitude": 36.03630090000001,
+     "nom": "Guellal",
+     "id": "722",
+     "wilaya_id": "19",
+     "code_postal": "19048"
+    },
+    {
+     "longitude": 5.7194522,
+     "latitude": 36.4833899,
+     "nom": "Ain Sebt",
+     "id": "723",
+     "wilaya_id": "19",
+     "code_postal": "19049"
+    },
+    {
+     "longitude": 5.0548544,
+     "latitude": 36.3222675,
+     "nom": "Hammam Guergour",
+     "id": "724",
+     "wilaya_id": "19",
+     "code_postal": "19050"
+    },
+    {
+     "longitude": 5.0754854,
+     "latitude": 36.5394362,
+     "nom": "Ait Naoual Mezada",
+     "id": "725",
+     "wilaya_id": "19",
+     "code_postal": "19051"
+    },
+    {
+     "longitude": 5.2162283,
+     "latitude": 35.9870878,
+     "nom": "Ksar El Abtal",
+     "id": "726",
+     "wilaya_id": "19",
+     "code_postal": "19052"
+    },
+    {
+     "longitude": 5.1119407,
+     "latitude": 36.251687,
+     "nom": "Beni Hocine",
+     "id": "727",
+     "wilaya_id": "19",
+     "code_postal": "19053"
+    },
+    {
+     "longitude": 5.1327829,
+     "latitude": 36.5531554,
+     "nom": "Ait Tizi",
+     "id": "728",
+     "wilaya_id": "19",
+     "code_postal": "19054"
+    },
+    {
+     "longitude": 5.0769287,
+     "latitude": 36.3966491,
+     "nom": "Maouklane",
+     "id": "729",
+     "wilaya_id": "19",
+     "code_postal": "19055"
+    },
+    {
+     "longitude": 5.677351199999999,
+     "latitude": 36.2045916,
+     "nom": "Guelta Zerka",
+     "id": "730",
+     "wilaya_id": "19",
+     "code_postal": "19056"
+    },
+    {
+     "longitude": 5.4253757,
+     "latitude": 36.4971074,
+     "nom": "Oued El Barad",
+     "id": "731",
+     "wilaya_id": "19",
+     "code_postal": "19057"
+    },
+    {
+     "longitude": 5.9665303,
+     "latitude": 35.959337,
+     "nom": "Taya",
+     "id": "732",
+     "wilaya_id": "19",
+     "code_postal": "19058"
+    },
+    {
+     "longitude": 5.9198387,
+     "latitude": 36.0520855,
+     "nom": "El Ouldja",
+     "id": "733",
+     "wilaya_id": "19",
+     "code_postal": "19059"
+    },
+    {
+     "longitude": 5.7089241,
+     "latitude": 35.9755409,
+     "nom": "Tella",
+     "id": "734",
+     "wilaya_id": "19",
+     "code_postal": "19060"
+    },
+    {
+     "longitude": 0.1484305,
+     "latitude": 34.8412014,
+     "nom": "Saida",
+     "id": "735",
+     "wilaya_id": "20",
+     "code_postal": "20001"
+    },
+    {
+     "longitude": -0.0735088,
+     "latitude": 34.8941184,
+     "nom": "Doui Thabet",
+     "id": "736",
+     "wilaya_id": "20",
+     "code_postal": "20002"
+    },
+    {
+     "longitude": 0.15418,
+     "latitude": 34.7574087,
+     "nom": "Ain El Hadjar",
+     "id": "737",
+     "wilaya_id": "20",
+     "code_postal": "20003"
+    },
+    {
+     "longitude": 0.1524313,
+     "latitude": 34.8765984,
+     "nom": "Ouled Khaled",
+     "id": "738",
+     "wilaya_id": "20",
+     "code_postal": "20004"
+    },
+    {
+     "longitude": 0.0116586,
+     "latitude": 34.6497005,
+     "nom": "Moulay Larbi",
+     "id": "739",
+     "wilaya_id": "20",
+     "code_postal": "20005"
+    },
+    {
+     "longitude": -0.2080547,
+     "latitude": 34.92016100000001,
+     "nom": "Youb",
+     "id": "740",
+     "wilaya_id": "20",
+     "code_postal": "20006"
+    },
+    {
+     "longitude": -0.1148012,
+     "latitude": 35.0903759,
+     "nom": "Hounet",
+     "id": "741",
+     "wilaya_id": "20",
+     "code_postal": "20007"
+    },
+    {
+     "longitude": 0.1097315,
+     "latitude": 35.0249991,
+     "nom": "Sidi Amar",
+     "id": "742",
+     "wilaya_id": "20",
+     "code_postal": "20008"
+    },
+    {
+     "longitude": 0.0536592,
+     "latitude": 35.0305441,
+     "nom": "Sidi Boubekeur",
+     "id": "743",
+     "wilaya_id": "20",
+     "code_postal": "20009"
+    },
+    {
+     "longitude": 0.3301342,
+     "latitude": 34.8260947,
+     "nom": "El Hassasna",
+     "id": "744",
+     "wilaya_id": "20",
+     "code_postal": "20010"
+    },
+    {
+     "longitude": 0.4997973000000001,
+     "latitude": 34.6818661,
+     "nom": "Maamora",
+     "id": "745",
+     "wilaya_id": "20",
+     "code_postal": "20011"
+    },
+    {
+     "longitude": 0.259657,
+     "latitude": 34.5497948,
+     "nom": "Sidi Ahmed",
+     "id": "746",
+     "wilaya_id": "20",
+     "code_postal": "20012"
+    },
+    {
+     "longitude": 0.8441666999999999,
+     "latitude": 34.5044444,
+     "nom": "Ain Sekhouna",
+     "id": "747",
+     "wilaya_id": "20",
+     "code_postal": "20013"
+    },
+    {
+     "longitude": 0.4718608999999999,
+     "latitude": 34.986248,
+     "nom": "Ouled Brahim",
+     "id": "748",
+     "wilaya_id": "20",
+     "code_postal": "20014"
+    },
+    {
+     "longitude": 0.5529666,
+     "latitude": 34.9011622,
+     "nom": "Tircine",
+     "id": "749",
+     "wilaya_id": "20",
+     "code_postal": "20015"
+    },
+    {
+     "longitude": 0.3034289,
+     "latitude": 34.9675528,
+     "nom": "Ain Soltane",
+     "id": "750",
+     "wilaya_id": "20",
+     "code_postal": "20016"
+    },
+    {
+     "longitude": 6.910180599999999,
+     "latitude": 36.8715199,
+     "nom": "Skikda",
+     "id": "751",
+     "wilaya_id": "21",
+     "code_postal": "21001"
+    },
+    {
+     "longitude": 6.7888879,
+     "latitude": 36.8912294,
+     "nom": "Ain Zouit",
+     "id": "752",
+     "wilaya_id": "21",
+     "code_postal": "21002"
+    },
+    {
+     "longitude": 6.8873791,
+     "latitude": 36.8259805,
+     "nom": "El Hadaik",
+     "id": "753",
+     "wilaya_id": "21",
+     "code_postal": "21003"
+    },
+    {
+     "longitude": 7.1170952,
+     "latitude": 36.7441137,
+     "nom": "Azzaba",
+     "id": "754",
+     "wilaya_id": "21",
+     "code_postal": "21004"
+    },
+    {
+     "longitude": 7.169598099999999,
+     "latitude": 36.7824999,
+     "nom": "Djendel Saadi Mohamed",
+     "id": "755",
+     "wilaya_id": "21",
+     "code_postal": "21005"
+    },
+    {
+     "longitude": 7.223489900000001,
+     "latitude": 36.7336763,
+     "nom": "Ain Cherchar",
+     "id": "756",
+     "wilaya_id": "21",
+     "code_postal": "21006"
+    },
+    {
+     "longitude": 7.305758099999999,
+     "latitude": 36.700497,
+     "nom": "Bekkouche Lakhdar",
+     "id": "757",
+     "wilaya_id": "21",
+     "code_postal": "21007"
+    },
+    {
+     "longitude": 7.296312400000001,
+     "latitude": 36.8658203,
+     "nom": "Benazouz",
+     "id": "758",
+     "wilaya_id": "21",
+     "code_postal": "21008"
+    },
+    {
+     "longitude": 7.069999999999999,
+     "latitude": 36.6599999,
+     "nom": "Es Sebt",
+     "id": "759",
+     "wilaya_id": "21",
+     "code_postal": "21009"
+    },
+    {
+     "longitude": 6.554319899999999,
+     "latitude": 37.0013848,
+     "nom": "Collo",
+     "id": "760",
+     "wilaya_id": "21",
+     "code_postal": "21010"
+    },
+    {
+     "longitude": 6.4809854,
+     "latitude": 36.9318483,
+     "nom": "Beni Zid",
+     "id": "761",
+     "wilaya_id": "21",
+     "code_postal": "21011"
+    },
+    {
+     "longitude": 6.5876817,
+     "latitude": 36.9313308,
+     "nom": "Kerkera",
+     "id": "762",
+     "wilaya_id": "21",
+     "code_postal": "21012"
+    },
+    {
+     "longitude": 6.313303299999999,
+     "latitude": 36.9221397,
+     "nom": "Oued Zehour",
+     "id": "764",
+     "wilaya_id": "21",
+     "code_postal": "21014"
+    },
+    {
+     "longitude": 6.4556713,
+     "latitude": 36.9880728,
+     "nom": "Zitouna",
+     "id": "765",
+     "wilaya_id": "21",
+     "code_postal": "21015"
+    },
+    {
+     "longitude": 6.840459999999999,
+     "latitude": 36.6557031,
+     "nom": "El Harrouch",
+     "id": "766",
+     "wilaya_id": "21",
+     "code_postal": "21016"
+    },
+    {
+     "longitude": 6.972405699999999,
+     "latitude": 36.516375,
+     "nom": "Ouled Hebaba",
+     "id": "768",
+     "wilaya_id": "21",
+     "code_postal": "21018"
+    },
+    {
+     "longitude": 6.7186283,
+     "latitude": 36.6800923,
+     "nom": "Sidi Mezghiche",
+     "id": "769",
+     "wilaya_id": "21",
+     "code_postal": "21019"
+    },
+    {
+     "longitude": 6.805627599999999,
+     "latitude": 36.7033327,
+     "nom": "Emdjez Edchich",
+     "id": "770",
+     "wilaya_id": "21",
+     "code_postal": "21020"
+    },
+    {
+     "longitude": 6.634417699999999,
+     "latitude": 36.6270696,
+     "nom": "Beni Oulbane",
+     "id": "771",
+     "wilaya_id": "21",
+     "code_postal": "21021"
+    },
+    {
+     "longitude": 6.738694600000001,
+     "latitude": 36.6024073,
+     "nom": "Ain Bouziane",
+     "id": "772",
+     "wilaya_id": "21",
+     "code_postal": "21022"
+    },
+    {
+     "longitude": 6.894084599999999,
+     "latitude": 36.7599329,
+     "nom": "Ramdane Djamel",
+     "id": "773",
+     "wilaya_id": "21",
+     "code_postal": "21023"
+    },
+    {
+     "longitude": 6.933332999999999,
+     "latitude": 36.783333,
+     "nom": "Beni Bachir",
+     "id": "774",
+     "wilaya_id": "21",
+     "code_postal": "21024"
+    },
+    {
+     "longitude": 6.853861999999999,
+     "latitude": 36.7005645,
+     "nom": "Salah Bouchaour",
+     "id": "775",
+     "wilaya_id": "21",
+     "code_postal": "21025"
+    },
+    {
+     "longitude": 6.645105,
+     "latitude": 36.8357539,
+     "nom": "Tamalous",
+     "id": "776",
+     "wilaya_id": "21",
+     "code_postal": "21026"
+    },
+    {
+     "longitude": 6.431699000000001,
+     "latitude": 36.7455954,
+     "nom": "Ain Kechra",
+     "id": "777",
+     "wilaya_id": "21",
+     "code_postal": "21027"
+    },
+    {
+     "longitude": 6.5756695,
+     "latitude": 36.6894163,
+     "nom": "Oum Toub",
+     "id": "778",
+     "wilaya_id": "21",
+     "code_postal": "21028"
+    },
+    {
+     "longitude": 7.0821162,
+     "latitude": 36.8828035,
+     "nom": "Fil Fila",
+     "id": "780",
+     "wilaya_id": "21",
+     "code_postal": "21030"
+    },
+    {
+     "longitude": 6.512975399999999,
+     "latitude": 37.0023239,
+     "nom": "Cheraia",
+     "id": "781",
+     "wilaya_id": "21",
+     "code_postal": "21031"
+    },
+    {
+     "longitude": 6.4037428,
+     "latitude": 37.0376737,
+     "nom": "Kanoua",
+     "id": "782",
+     "wilaya_id": "21",
+     "code_postal": "21032"
+    },
+    {
+     "longitude": 6.9759468,
+     "latitude": 36.6867619,
+     "nom": "El Ghedir",
+     "id": "783",
+     "wilaya_id": "21",
+     "code_postal": "21033"
+    },
+    {
+     "longitude": 6.8,
+     "latitude": 36.783333,
+     "nom": "Bouchtata",
+     "id": "784",
+     "wilaya_id": "21",
+     "code_postal": "21034"
+    },
+    {
+     "longitude": 6.928964199999999,
+     "latitude": 36.8463287,
+     "nom": "Hamadi Krouma",
+     "id": "787",
+     "wilaya_id": "21",
+     "code_postal": "21037"
+    },
+    {
+     "longitude": 7.286867999999999,
+     "latitude": 37.0094161,
+     "nom": "El Marsa",
+     "id": "788",
+     "wilaya_id": "21",
+     "code_postal": "21038"
+    },
+    {
+     "longitude": -0.6298922,
+     "latitude": 35.2022249,
+     "nom": "Sidi Bel Abbes",
+     "id": "789",
+     "wilaya_id": "22",
+     "code_postal": "22001"
+    },
+    {
+     "longitude": -0.7818088999999999,
+     "latitude": 35.2672655,
+     "nom": "Tessala",
+     "id": "790",
+     "wilaya_id": "22",
+     "code_postal": "22002"
+    },
+    {
+     "longitude": -0.5730713,
+     "latitude": 35.268429,
+     "nom": "Sidi Brahim",
+     "id": "791",
+     "wilaya_id": "22",
+     "code_postal": "22003"
+    },
+    {
+     "longitude": -0.359435,
+     "latitude": 35.1925642,
+     "nom": "Mostefa Ben Brahim",
+     "id": "792",
+     "wilaya_id": "22",
+     "code_postal": "22004"
+    },
+    {
+     "longitude": -0.5446911999999999,
+     "latitude": 34.7949589,
+     "nom": "Telagh",
+     "id": "793",
+     "wilaya_id": "22",
+     "code_postal": "22005"
+    },
+    {
+     "longitude": -0.658333,
+     "latitude": 34.8385674,
+     "nom": "Mezaourou",
+     "id": "794",
+     "wilaya_id": "22",
+     "code_postal": "22006"
+    },
+    {
+     "longitude": -0.6962853,
+     "latitude": 35.0588511,
+     "nom": "Boukhanafis",
+     "id": "795",
+     "wilaya_id": "22",
+     "code_postal": "22007"
+    },
+    {
+     "longitude": -0.8336504,
+     "latitude": 35.1036318,
+     "nom": "Sidi Ali Boussidi",
+     "id": "796",
+     "wilaya_id": "22",
+     "code_postal": "22008"
+    },
+    {
+     "longitude": -0.8496433999999999,
+     "latitude": 35.0096949,
+     "nom": "Badredine El Mokrani",
+     "id": "797",
+     "wilaya_id": "22",
+     "code_postal": "22009"
+    },
+    {
+     "longitude": -0.1939932,
+     "latitude": 34.4446266,
+     "nom": "Marhoum",
+     "id": "798",
+     "wilaya_id": "22",
+     "code_postal": "22010"
+    },
+    {
+     "longitude": -0.2021951,
+     "latitude": 34.6923957,
+     "nom": "Tafissour",
+     "id": "799",
+     "wilaya_id": "22",
+     "code_postal": "22011"
+    },
+    {
+     "longitude": -0.610943,
+     "latitude": 35.0923336,
+     "nom": "Amarnas",
+     "id": "800",
+     "wilaya_id": "22",
+     "code_postal": "22012"
+    },
+    {
+     "longitude": -0.5352355999999999,
+     "latitude": 35.1806922,
+     "nom": "Tilmouni",
+     "id": "801",
+     "wilaya_id": "22",
+     "code_postal": "22013"
+    },
+    {
+     "longitude": -0.724773,
+     "latitude": 35.2016965,
+     "nom": "Sidi Lahcene",
+     "id": "802",
+     "wilaya_id": "22",
+     "code_postal": "22014"
+    },
+    {
+     "longitude": -0.6755257000000001,
+     "latitude": 35.2850615,
+     "nom": "Ain Thrid",
+     "id": "803",
+     "wilaya_id": "22",
+     "code_postal": "22015"
+    },
+    {
+     "longitude": -0.4307836,
+     "latitude": 35.4411307,
+     "nom": "Makedra",
+     "id": "804",
+     "wilaya_id": "22",
+     "code_postal": "22016"
+    },
+    {
+     "longitude": -0.5068824,
+     "latitude": 35.0157329,
+     "nom": "Tenira",
+     "id": "805",
+     "wilaya_id": "22",
+     "code_postal": "22017"
+    },
+    {
+     "longitude": -0.760411,
+     "latitude": 34.824175,
+     "nom": "Moulay Slissen",
+     "id": "806",
+     "wilaya_id": "22",
+     "code_postal": "22018"
+    },
+    {
+     "longitude": -0.7615995,
+     "latitude": 34.6984869,
+     "nom": "El Hacaiba",
+     "id": "807",
+     "wilaya_id": "22",
+     "code_postal": "22019"
+    },
+    {
+     "longitude": -0.8889678,
+     "latitude": 35.0273144,
+     "nom": "Hassi Zehana",
+     "id": "808",
+     "wilaya_id": "22",
+     "code_postal": "22020"
+    },
+    {
+     "longitude": -0.7437760999999999,
+     "latitude": 35.0255332,
+     "nom": "Tabia",
+     "id": "809",
+     "wilaya_id": "22",
+     "code_postal": "22021"
+    },
+    {
+     "longitude": -0.4478783000000001,
+     "latitude": 34.7815446,
+     "nom": "Merine",
+     "id": "810",
+     "wilaya_id": "22",
+     "code_postal": "22022"
+    },
+    {
+     "longitude": -0.8055975999999999,
+     "latitude": 34.5003381,
+     "nom": "Ras El Ma",
+     "id": "811",
+     "wilaya_id": "22",
+     "code_postal": "22023"
+    },
+    {
+     "longitude": -0.7212109999999999,
+     "latitude": 34.6876739,
+     "nom": "Ain Tindamine",
+     "id": "812",
+     "wilaya_id": "22",
+     "code_postal": "22024"
+    },
+    {
+     "longitude": -0.8567905,
+     "latitude": 35.136239,
+     "nom": "Ain Kada",
+     "id": "813",
+     "wilaya_id": "22",
+     "code_postal": "22025"
+    },
+    {
+     "longitude": -0.2469943999999999,
+     "latitude": 35.1386244,
+     "nom": "Mcid",
+     "id": "814",
+     "wilaya_id": "22",
+     "code_postal": "22026"
+    },
+    {
+     "longitude": -0.6678177,
+     "latitude": 35.1140441,
+     "nom": "Sidi Khaled",
+     "id": "815",
+     "wilaya_id": "22",
+     "code_postal": "22027"
+    },
+    {
+     "longitude": -0.5068824,
+     "latitude": 35.3675096,
+     "nom": "Ain El Berd",
+     "id": "816",
+     "wilaya_id": "22",
+     "code_postal": "22028"
+    },
+    {
+     "longitude": -0.2807868,
+     "latitude": 35.2365004,
+     "nom": "Sfissef",
+     "id": "817",
+     "wilaya_id": "22",
+     "code_postal": "22029"
+    },
+    {
+     "longitude": -0.2608306,
+     "latitude": 35.3285126,
+     "nom": "Ain Adden",
+     "id": "818",
+     "wilaya_id": "22",
+     "code_postal": "22030"
+    },
+    {
+     "longitude": -0.3266073,
+     "latitude": 34.8026387,
+     "nom": "Oued Taourira",
+     "id": "819",
+     "wilaya_id": "22",
+     "code_postal": "22031"
+    },
+    {
+     "longitude": -0.6216008,
+     "latitude": 34.6743959,
+     "nom": "Dhaya",
+     "id": "820",
+     "wilaya_id": "22",
+     "code_postal": "22032"
+    },
+    {
+     "longitude": -0.4313729,
+     "latitude": 35.23605930000001,
+     "nom": "Zerouala",
+     "id": "821",
+     "wilaya_id": "22",
+     "code_postal": "22033"
+    },
+    {
+     "longitude": -0.7989959999999999,
+     "latitude": 35.071492,
+     "nom": "Lamtar",
+     "id": "822",
+     "wilaya_id": "22",
+     "code_postal": "22034"
+    },
+    {
+     "longitude": -0.5470554,
+     "latitude": 34.5931437,
+     "nom": "Sidi Chaib",
+     "id": "823",
+     "wilaya_id": "22",
+     "code_postal": "22035"
+    },
+    {
+     "longitude": -0.7084642,
+     "latitude": 34.5871725,
+     "nom": "Oued Sbaa",
+     "id": "825",
+     "wilaya_id": "22",
+     "code_postal": "22037"
+    },
+    {
+     "longitude": -0.3236685,
+     "latitude": 35.3523658,
+     "nom": "Boudjebaa El Bordj",
+     "id": "826",
+     "wilaya_id": "22",
+     "code_postal": "22038"
+    },
+    {
+     "longitude": -0.8579818,
+     "latitude": 35.2228096,
+     "nom": "Sehala Thaoura",
+     "id": "827",
+     "wilaya_id": "22",
+     "code_postal": "22039"
+    },
+    {
+     "longitude": -0.7770528999999999,
+     "latitude": 35.1518977,
+     "nom": "Sidi Yacoub",
+     "id": "828",
+     "wilaya_id": "22",
+     "code_postal": "22040"
+    },
+    {
+     "longitude": -0.5163312,
+     "latitude": 35.3126031,
+     "nom": "Sidi Hamadouche",
+     "id": "829",
+     "wilaya_id": "22",
+     "code_postal": "22041"
+    },
+    {
+     "longitude": -0.4408037,
+     "latitude": 35.1370812,
+     "nom": "Belarbi",
+     "id": "830",
+     "wilaya_id": "22",
+     "code_postal": "22042"
+    },
+    {
+     "longitude": -0.5517843000000001,
+     "latitude": 34.8859984,
+     "nom": "Teghalimet",
+     "id": "832",
+     "wilaya_id": "22",
+     "code_postal": "22044"
+    },
+    {
+     "longitude": -0.8961217,
+     "latitude": 34.9363466,
+     "nom": "Ben Badis",
+     "id": "833",
+     "wilaya_id": "22",
+     "code_postal": "22045"
+    },
+    {
+     "longitude": -0.7342734,
+     "latitude": 34.9264009,
+     "nom": "Sidi Ali Benyoub",
+     "id": "834",
+     "wilaya_id": "22",
+     "code_postal": "22046"
+    },
+    {
+     "longitude": -0.8365437,
+     "latitude": 34.950551,
+     "nom": "Chetouane Belaila",
+     "id": "835",
+     "wilaya_id": "22",
+     "code_postal": "22047"
+    },
+    {
+     "longitude": -0.5009781,
+     "latitude": 34.4174164,
+     "nom": "Bir El Hammam",
+     "id": "836",
+     "wilaya_id": "22",
+     "code_postal": "22048"
+    },
+    {
+     "longitude": -0.1144079,
+     "latitude": 34.5887754,
+     "nom": "Taoudmout",
+     "id": "837",
+     "wilaya_id": "22",
+     "code_postal": "22049"
+    },
+    {
+     "longitude": -0.8091670999999999,
+     "latitude": 34.4268654,
+     "nom": "Redjem Demouche",
+     "id": "838",
+     "wilaya_id": "22",
+     "code_postal": "22050"
+    },
+    {
+     "longitude": -0.6130087,
+     "latitude": 34.963705,
+     "nom": "Benachiba Chelia",
+     "id": "839",
+     "wilaya_id": "22",
+     "code_postal": "22051"
+    },
+    {
+     "longitude": -0.5446911999999999,
+     "latitude": 35.1036532,
+     "nom": "Hassi Dahou",
+     "id": "840",
+     "wilaya_id": "22",
+     "code_postal": "22052"
+    },
+    {
+     "longitude": 7.752535200000001,
+     "latitude": 36.9264582,
+     "nom": "Annaba",
+     "id": "841",
+     "wilaya_id": "23",
+     "code_postal": "23001"
+    },
+    {
+     "longitude": 7.4597725,
+     "latitude": 36.8275635,
+     "nom": "Berrahel",
+     "id": "842",
+     "wilaya_id": "23",
+     "code_postal": "23002"
+    },
+    {
+     "longitude": 7.665662500000001,
+     "latitude": 36.7609066,
+     "nom": "El Hadjar",
+     "id": "843",
+     "wilaya_id": "23",
+     "code_postal": "23003"
+    },
+    {
+     "longitude": 7.4597725,
+     "latitude": 36.6989793,
+     "nom": "Eulma",
+     "id": "844",
+     "wilaya_id": "23",
+     "code_postal": "23004"
+    },
+    {
+     "longitude": 7.7431524,
+     "latitude": 36.8535764,
+     "nom": "El Bouni",
+     "id": "845",
+     "wilaya_id": "23",
+     "code_postal": "23005"
+    },
+    {
+     "longitude": 7.503066899999999,
+     "latitude": 36.9104322,
+     "nom": "Oued El Aneb",
+     "id": "846",
+     "wilaya_id": "23",
+     "code_postal": "23006"
+    },
+    {
+     "longitude": 7.5788975,
+     "latitude": 36.7236097,
+     "nom": "Cheurfa",
+     "id": "847",
+     "wilaya_id": "23",
+     "code_postal": "23007"
+    },
+    {
+     "longitude": 7.633112999999999,
+     "latitude": 36.944893,
+     "nom": "Seraidi",
+     "id": "848",
+     "wilaya_id": "23",
+     "code_postal": "23008"
+    },
+    {
+     "longitude": 7.590099500000001,
+     "latitude": 36.6449172,
+     "nom": "Ain Berda",
+     "id": "849",
+     "wilaya_id": "23",
+     "code_postal": "23009"
+    },
+    {
+     "longitude": 7.3732655,
+     "latitude": 37.0040741,
+     "nom": "Chetaibi",
+     "id": "850",
+     "wilaya_id": "23",
+     "code_postal": "23010"
+    },
+    {
+     "longitude": 7.665662500000001,
+     "latitude": 36.8037437,
+     "nom": "Sidi Amer",
+     "id": "851",
+     "wilaya_id": "23",
+     "code_postal": "23011"
+    },
+    {
+     "longitude": 7.4165053,
+     "latitude": 36.915875,
+     "nom": "Treat",
+     "id": "852",
+     "wilaya_id": "23",
+     "code_postal": "23012"
+    },
+    {
+     "longitude": 7.4327273,
+     "latitude": 36.458976,
+     "nom": "Guelma",
+     "id": "853",
+     "wilaya_id": "24",
+     "code_postal": "24001"
+    },
+    {
+     "longitude": 7.5111876,
+     "latitude": 36.61258309999999,
+     "nom": "Nechmaya",
+     "id": "854",
+     "wilaya_id": "24",
+     "code_postal": "24002"
+    },
+    {
+     "longitude": 7.3260032,
+     "latitude": 36.5905648,
+     "nom": "Bouati Mahmoud",
+     "id": "855",
+     "wilaya_id": "24",
+     "code_postal": "24003"
+    },
+    {
+     "longitude": 7.162864700000001,
+     "latitude": 36.3139054,
+     "nom": "Oued Zenati",
+     "id": "856",
+     "wilaya_id": "24",
+     "code_postal": "24004"
+    },
+    {
+     "longitude": 7.139976,
+     "latitude": 36.1573949,
+     "nom": "Tamlouka",
+     "id": "857",
+     "wilaya_id": "24",
+     "code_postal": "24005"
+    },
+    {
+     "longitude": 7.7118003,
+     "latitude": 36.556799,
+     "nom": "Oued Fragha",
+     "id": "858",
+     "wilaya_id": "24",
+     "code_postal": "24006"
+    },
+    {
+     "longitude": 7.513217999999999,
+     "latitude": 36.2431716,
+     "nom": "Ain Sandel",
+     "id": "859",
+     "wilaya_id": "24",
+     "code_postal": "24007"
+    },
+    {
+     "longitude": 7.222816,
+     "latitude": 36.3729492,
+     "nom": "Ras El Agba",
+     "id": "860",
+     "wilaya_id": "24",
+     "code_postal": "24008"
+    },
+    {
+     "longitude": 7.734880500000001,
+     "latitude": 36.3522993,
+     "nom": "Dahouara",
+     "id": "861",
+     "wilaya_id": "24",
+     "code_postal": "24009"
+    },
+    {
+     "longitude": 7.4787104,
+     "latitude": 36.4587897,
+     "nom": "Belkhir",
+     "id": "862",
+     "wilaya_id": "24",
+     "code_postal": "24010"
+    },
+    {
+     "longitude": 7.369888500000001,
+     "latitude": 36.4312641,
+     "nom": "Ben Djarah",
+     "id": "863",
+     "wilaya_id": "24",
+     "code_postal": "24011"
+    },
+    {
+     "longitude": 7.1144039,
+     "latitude": 36.4622523,
+     "nom": "Bou Hamdane",
+     "id": "864",
+     "wilaya_id": "24",
+     "code_postal": "24012"
+    },
+    {
+     "longitude": 7.2518004,
+     "latitude": 36.246509,
+     "nom": "Ain Makhlouf",
+     "id": "865",
+     "wilaya_id": "24",
+     "code_postal": "24013"
+    },
+    {
+     "longitude": 7.699999999999999,
+     "latitude": 36.616667,
+     "nom": "Ain Ben Beida",
+     "id": "866",
+     "wilaya_id": "24",
+     "code_postal": "24014"
+    },
+    {
+     "longitude": 7.5342015,
+     "latitude": 36.3705271,
+     "nom": "Khezara",
+     "id": "867",
+     "wilaya_id": "24",
+     "code_postal": "24015"
+    },
+    {
+     "longitude": 7.604644599999999,
+     "latitude": 36.4817434,
+     "nom": "Beni Mezline",
+     "id": "868",
+     "wilaya_id": "24",
+     "code_postal": "24016"
+    },
+    {
+     "longitude": 7.507803899999999,
+     "latitude": 36.306868,
+     "nom": "Bou Hachana",
+     "id": "869",
+     "wilaya_id": "24",
+     "code_postal": "24017"
+    },
+    {
+     "longitude": 7.4787104,
+     "latitude": 36.5501826,
+     "nom": "Guelaat Bou Sbaa",
+     "id": "870",
+     "wilaya_id": "24",
+     "code_postal": "24018"
+    },
+    {
+     "longitude": 7.27,
+     "latitude": 36.46,
+     "nom": "Hammam Maskhoutine",
+     "id": "871",
+     "wilaya_id": "24",
+     "code_postal": "24019"
+    },
+    {
+     "longitude": 7.3894772,
+     "latitude": 36.5046911,
+     "nom": "El Fedjoudj",
+     "id": "872",
+     "wilaya_id": "24",
+     "code_postal": "24020"
+    },
+    {
+     "longitude": 7.048499899999999,
+     "latitude": 36.402899,
+     "nom": "Bordj Sabat",
+     "id": "873",
+     "wilaya_id": "24",
+     "code_postal": "24021"
+    },
+    {
+     "longitude": 7.6412489,
+     "latitude": 36.3246695,
+     "nom": "Hamman Nbail",
+     "id": "874",
+     "wilaya_id": "24",
+     "code_postal": "24022"
+    },
+    {
+     "longitude": 7.4325,
+     "latitude": 36.459102,
+     "nom": "Ain Larbi",
+     "id": "875",
+     "wilaya_id": "24",
+     "code_postal": "24023"
+    },
+    {
+     "longitude": 7.309131799999999,
+     "latitude": 36.4457672,
+     "nom": "Medjez Amar",
+     "id": "876",
+     "wilaya_id": "24",
+     "code_postal": "24024"
+    },
+    {
+     "longitude": 7.7362384,
+     "latitude": 36.47192709999999,
+     "nom": "Bouchegouf",
+     "id": "877",
+     "wilaya_id": "24",
+     "code_postal": "24025"
+    },
+    {
+     "longitude": 7.4327273,
+     "latitude": 36.502001,
+     "nom": "Heliopolis",
+     "id": "878",
+     "wilaya_id": "24",
+     "code_postal": "24026"
+    },
+    {
+     "longitude": 7.2841698,
+     "latitude": 36.4170167,
+     "nom": "Ain Hessania",
+     "id": "879",
+     "wilaya_id": "24",
+     "code_postal": "24027"
+    },
+    {
+     "longitude": 7.2342735,
+     "latitude": 36.5451275,
+     "nom": "Roknia",
+     "id": "880",
+     "wilaya_id": "24",
+     "code_postal": "24028"
+    },
+    {
+     "longitude": 7.2518004,
+     "latitude": 36.3866785,
+     "nom": "Salaoua Announa",
+     "id": "881",
+     "wilaya_id": "24",
+     "code_postal": "24029"
+    },
+    {
+     "longitude": 7.7824225,
+     "latitude": 36.4339664,
+     "nom": "Medjez Sfa",
+     "id": "882",
+     "wilaya_id": "24",
+     "code_postal": "24030"
+    },
+    {
+     "longitude": 7.512541199999999,
+     "latitude": 36.45800699999999,
+     "nom": "Boumahra Ahmed",
+     "id": "883",
+     "wilaya_id": "24",
+     "code_postal": "24031"
+    },
+    {
+     "longitude": 7.072702,
+     "latitude": 36.2612886,
+     "nom": "Ain Reggada",
+     "id": "884",
+     "wilaya_id": "24",
+     "code_postal": "24032"
+    },
+    {
+     "longitude": 7.767477299999999,
+     "latitude": 36.38248189999999,
+     "nom": "Oued Cheham",
+     "id": "885",
+     "wilaya_id": "24",
+     "code_postal": "24033"
+    },
+    {
+     "longitude": 7.568736800000001,
+     "latitude": 36.4645365,
+     "nom": "Djeballah Khemissi",
+     "id": "886",
+     "wilaya_id": "24",
+     "code_postal": "24034"
+    },
+    {
+     "longitude": -85.6686026,
+     "latitude": 41.8411603,
+     "nom": "Constantine",
+     "id": "887",
+     "wilaya_id": "25",
+     "code_postal": "25001"
+    },
+    {
+     "longitude": 6.5676625,
+     "latitude": 36.4181986,
+     "nom": "Hamma Bouziane",
+     "id": "888",
+     "wilaya_id": "25",
+     "code_postal": "25002"
+    },
+    {
+     "longitude": -121.0886537,
+     "latitude": 38.6811223,
+     "nom": "El Haria",
+     "id": "889",
+     "wilaya_id": "25",
+     "code_postal": "25003"
+    },
+    {
+     "longitude": 6.702890399999999,
+     "latitude": 36.5309186,
+     "nom": "Zighoud Youcef",
+     "id": "890",
+     "wilaya_id": "25",
+     "code_postal": "25004"
+    },
+    {
+     "longitude": 6.6531216,
+     "latitude": 36.4565656,
+     "nom": "Didouche Mourad",
+     "id": "891",
+     "wilaya_id": "25",
+     "code_postal": "25005"
+    },
+    {
+     "longitude": 6.685198199999999,
+     "latitude": 36.2714408,
+     "nom": "El Khroub",
+     "id": "892",
+     "wilaya_id": "25",
+     "code_postal": "25006"
+    },
+    {
+     "longitude": 6.9423844,
+     "latitude": 36.2135906,
+     "nom": "Ain Abid",
+     "id": "893",
+     "wilaya_id": "25",
+     "code_postal": "25007"
+    },
+    {
+     "longitude": 6.556988199999999,
+     "latitude": 36.5372531,
+     "nom": "Beni Hamiden",
+     "id": "894",
+     "wilaya_id": "25",
+     "code_postal": "25008"
+    },
+    {
+     "longitude": 6.8136642,
+     "latitude": 36.220992,
+     "nom": "Ouled Rahmoune",
+     "id": "895",
+     "wilaya_id": "25",
+     "code_postal": "25009"
+    },
+    {
+     "longitude": 6.471658,
+     "latitude": 36.2831875,
+     "nom": "Ain Smara",
+     "id": "896",
+     "wilaya_id": "25",
+     "code_postal": "25010"
+    },
+    {
+     "longitude": 6.386442799999999,
+     "latitude": 36.4603589,
+     "nom": "Mesaoud Boudjeriou",
+     "id": "897",
+     "wilaya_id": "25",
+     "code_postal": "25011"
+    },
+    {
+     "longitude": 6.429036,
+     "latitude": 36.3718282,
+     "nom": "Ibn Ziad",
+     "id": "898",
+     "wilaya_id": "25",
+     "code_postal": "25012"
+    },
+    {
+     "longitude": 2.7680247,
+     "latitude": 36.2853847,
+     "nom": "Medea",
+     "id": "899",
+     "wilaya_id": "26",
+     "code_postal": "26001"
+    },
+    {
+     "longitude": 2.8463103,
+     "latitude": 36.252581,
+     "nom": "Ouzera",
+     "id": "900",
+     "wilaya_id": "26",
+     "code_postal": "26002"
+    },
+    {
+     "longitude": 3.0776568,
+     "latitude": 35.7669488,
+     "nom": "Ouled Maaref",
+     "id": "901",
+     "wilaya_id": "26",
+     "code_postal": "26003"
+    },
+    {
+     "longitude": 3.1578875,
+     "latitude": 35.8520702,
+     "nom": "Ain Boucif",
+     "id": "902",
+     "wilaya_id": "26",
+     "code_postal": "26004"
+    },
+    {
+     "longitude": 3.2281983,
+     "latitude": 36.403785,
+     "nom": "Aissaouia",
+     "id": "903",
+     "wilaya_id": "26",
+     "code_postal": "26005"
+    },
+    {
+     "longitude": 3.0375914,
+     "latitude": 36.1161743,
+     "nom": "Ouled Deide",
+     "id": "904",
+     "wilaya_id": "26",
+     "code_postal": "26006"
+    },
+    {
+     "longitude": 3.0245978,
+     "latitude": 36.2672156,
+     "nom": "El Omaria",
+     "id": "905",
+     "wilaya_id": "26",
+     "code_postal": "26007"
+    },
+    {
+     "longitude": 2.3881368,
+     "latitude": 35.9080275,
+     "nom": "Derrag",
+     "id": "906",
+     "wilaya_id": "26",
+     "code_postal": "26008"
+    },
+    {
+     "longitude": 3.4094629,
+     "latitude": 36.2472045,
+     "nom": "El Guelbelkebir",
+     "id": "907",
+     "wilaya_id": "26",
+     "code_postal": "26009"
+    },
+    {
+     "longitude": 2.341887,
+     "latitude": 35.5868879,
+     "nom": "Bouaiche",
+     "id": "908",
+     "wilaya_id": "26",
+     "code_postal": "26010"
+    },
+    {
+     "longitude": 2.9675572,
+     "latitude": 36.2155805,
+     "nom": "Ouled Brahim",
+     "id": "910",
+     "wilaya_id": "26",
+     "code_postal": "26012"
+    },
+    {
+     "longitude": 3.2483058,
+     "latitude": 36.034631,
+     "nom": "Sidi Ziane",
+     "id": "912",
+     "wilaya_id": "26",
+     "code_postal": "26014"
+    },
+    {
+     "longitude": 2.6685736,
+     "latitude": 36.3309673,
+     "nom": "Tamesguida",
+     "id": "913",
+     "wilaya_id": "26",
+     "code_postal": "26015"
+    },
+    {
+     "longitude": 2.8776638,
+     "latitude": 36.3369617,
+     "nom": "El Hamdania",
+     "id": "914",
+     "wilaya_id": "26",
+     "code_postal": "26016"
+    },
+    {
+     "longitude": 3.238251,
+     "latitude": 35.9370344,
+     "nom": "Kef Lakhdar",
+     "id": "915",
+     "wilaya_id": "26",
+     "code_postal": "26017"
+    },
+    {
+     "longitude": 3.3993751,
+     "latitude": 35.9325946,
+     "nom": "Chelalet El Adhaoura",
+     "id": "916",
+     "wilaya_id": "26",
+     "code_postal": "26018"
+    },
+    {
+     "longitude": 3.1980527,
+     "latitude": 36.1554282,
+     "nom": "Bouskene",
+     "id": "917",
+     "wilaya_id": "26",
+     "code_postal": "26019"
+    },
+    {
+     "longitude": 3.1177555,
+     "latitude": 36.0272162,
+     "nom": "Rebaia",
+     "id": "918",
+     "wilaya_id": "26",
+     "code_postal": "26020"
+    },
+    {
+     "longitude": 3.1578875,
+     "latitude": 36.2865922,
+     "nom": "Bouchrahil",
+     "id": "919",
+     "wilaya_id": "26",
+     "code_postal": "26021"
+    },
+    {
+     "longitude": 2.4980197,
+     "latitude": 35.9370104,
+     "nom": "Ouled Hellal",
+     "id": "920",
+     "wilaya_id": "26",
+     "code_postal": "26022"
+    },
+    {
+     "longitude": 3.318747,
+     "latitude": 35.978354,
+     "nom": "Tafraout",
+     "id": "921",
+     "wilaya_id": "26",
+     "code_postal": "26023"
+    },
+    {
+     "longitude": 3.1177555,
+     "latitude": 36.3742549,
+     "nom": "Baata",
+     "id": "922",
+     "wilaya_id": "26",
+     "code_postal": "26024"
+    },
+    {
+     "longitude": 2.7182728,
+     "latitude": 35.9498907,
+     "nom": "Boghar",
+     "id": "923",
+     "wilaya_id": "26",
+     "code_postal": "26025"
+    },
+    {
+     "longitude": 3.0876783,
+     "latitude": 36.2559141,
+     "nom": "Sidi Naamane",
+     "id": "924",
+     "wilaya_id": "26",
+     "code_postal": "26026"
+    },
+    {
+     "longitude": 2.7083287,
+     "latitude": 36.0914607,
+     "nom": "Ouled Bouachra",
+     "id": "925",
+     "wilaya_id": "26",
+     "code_postal": "26027"
+    },
+    {
+     "longitude": 3.3317554,
+     "latitude": 36.0683421,
+     "nom": "Sidi Zahar",
+     "id": "926",
+     "wilaya_id": "26",
+     "code_postal": "26028"
+    },
+    {
+     "longitude": 2.6487087,
+     "latitude": 36.2447225,
+     "nom": "Oued Harbil",
+     "id": "927",
+     "wilaya_id": "26",
+     "code_postal": "26029"
+    },
+    {
+     "longitude": 2.847737,
+     "latitude": 36.1967899,
+     "nom": "Benchicao",
+     "id": "928",
+     "wilaya_id": "26",
+     "code_postal": "26030"
+    },
+    {
+     "longitude": 3.318747,
+     "latitude": 35.8041669,
+     "nom": "Sidi Damed",
+     "id": "929",
+     "wilaya_id": "26",
+     "code_postal": "26031"
+    },
+    {
+     "longitude": 2.4999918,
+     "latitude": 35.758478,
+     "nom": "Aziz",
+     "id": "930",
+     "wilaya_id": "26",
+     "code_postal": "26032"
+    },
+    {
+     "longitude": 3.2483058,
+     "latitude": 36.1215213,
+     "nom": "Souagui",
+     "id": "931",
+     "wilaya_id": "26",
+     "code_postal": "26033"
+    },
+    {
+     "longitude": 2.8377656,
+     "latitude": 36.077613,
+     "nom": "Zoubiria",
+     "id": "932",
+     "wilaya_id": "26",
+     "code_postal": "26034"
+    },
+    {
+     "longitude": 2.7481176,
+     "latitude": 35.8729994,
+     "nom": "Ksar El Boukhari",
+     "id": "933",
+     "wilaya_id": "26",
+     "code_postal": "26035"
+    },
+    {
+     "longitude": 3.4902391,
+     "latitude": 36.3098718,
+     "nom": "El Azizia",
+     "id": "934",
+     "wilaya_id": "26",
+     "code_postal": "26036"
+    },
+    {
+     "longitude": 3.4278338,
+     "latitude": 36.1381285,
+     "nom": "Djouab",
+     "id": "935",
+     "wilaya_id": "26",
+     "code_postal": "26037"
+    },
+    {
+     "longitude": 2.5792482,
+     "latitude": 35.582061,
+     "nom": "Chahbounia",
+     "id": "936",
+     "wilaya_id": "26",
+     "code_postal": "26038"
+    },
+    {
+     "longitude": 3.5306765,
+     "latitude": 36.3736214,
+     "nom": "Meghraoua",
+     "id": "937",
+     "wilaya_id": "26",
+     "code_postal": "26039"
+    },
+    {
+     "longitude": 3.5667006,
+     "latitude": 35.9225813,
+     "nom": "Cheniguel",
+     "id": "938",
+     "wilaya_id": "26",
+     "code_postal": "26040"
+    },
+    {
+     "longitude": 3.4701398,
+     "latitude": 35.8528084,
+     "nom": "Ain Ouksir",
+     "id": "939",
+     "wilaya_id": "26",
+     "code_postal": "26041"
+    },
+    {
+     "longitude": 2.6685736,
+     "latitude": 35.8312012,
+     "nom": "Oum El Djalil",
+     "id": "940",
+     "wilaya_id": "26",
+     "code_postal": "26042"
+    },
+    {
+     "longitude": 2.5594214,
+     "latitude": 36.2575001,
+     "nom": "Ouamri",
+     "id": "941",
+     "wilaya_id": "26",
+     "code_postal": "26043"
+    },
+    {
+     "longitude": 2.7481176,
+     "latitude": 36.177412,
+     "nom": "Si Mahdjoub",
+     "id": "942",
+     "wilaya_id": "26",
+     "code_postal": "26044"
+    },
+    {
+     "longitude": 3.3086778,
+     "latitude": 36.2283487,
+     "nom": "Beni Slimane",
+     "id": "944",
+     "wilaya_id": "26",
+     "code_postal": "26046"
+    },
+    {
+     "longitude": 2.9175955,
+     "latitude": 36.1625653,
+     "nom": "Berrouaghia",
+     "id": "945",
+     "wilaya_id": "26",
+     "code_postal": "26047"
+    },
+    {
+     "longitude": 2.9175955,
+     "latitude": 35.9887439,
+     "nom": "Seghouane",
+     "id": "946",
+     "wilaya_id": "26",
+     "code_postal": "26048"
+    },
+    {
+     "longitude": 2.9175955,
+     "latitude": 35.9016881,
+     "nom": "Meftaha",
+     "id": "947",
+     "wilaya_id": "26",
+     "code_postal": "26049"
+    },
+    {
+     "longitude": 3.4397386,
+     "latitude": 36.3654474,
+     "nom": "Mihoub",
+     "id": "948",
+     "wilaya_id": "26",
+     "code_postal": "26050"
+    },
+    {
+     "longitude": 2.7381672,
+     "latitude": 35.7533117,
+     "nom": "Boughezoul",
+     "id": "949",
+     "wilaya_id": "26",
+     "code_postal": "26051"
+    },
+    {
+     "longitude": 3.318747,
+     "latitude": 36.4121257,
+     "nom": "Tablat",
+     "id": "950",
+     "wilaya_id": "26",
+     "code_postal": "26052"
+    },
+    {
+     "longitude": 3.2992135,
+     "latitude": 36.469433,
+     "nom": "Deux Bassins",
+     "id": "951",
+     "wilaya_id": "26",
+     "code_postal": "26053"
+    },
+    {
+     "longitude": 2.7083287,
+     "latitude": 36.2650726,
+     "nom": "Draa Essamar",
+     "id": "952",
+     "wilaya_id": "26",
+     "code_postal": "26054"
+    },
+    {
+     "longitude": 3.3071524,
+     "latitude": 36.2754347,
+     "nom": "Sidi Errabia",
+     "id": "953",
+     "wilaya_id": "26",
+     "code_postal": "26055"
+    },
+    {
+     "longitude": 3.4198797,
+     "latitude": 36.1916138,
+     "nom": "Bir Ben Laabed",
+     "id": "954",
+     "wilaya_id": "26",
+     "code_postal": "26056"
+    },
+    {
+     "longitude": 3.0676373,
+     "latitude": 35.865293,
+     "nom": "El Ouinet",
+     "id": "955",
+     "wilaya_id": "26",
+     "code_postal": "26057"
+    },
+    {
+     "longitude": 2.6387795,
+     "latitude": 35.9951773,
+     "nom": "Ouled Antar",
+     "id": "956",
+     "wilaya_id": "26",
+     "code_postal": "26058"
+    },
+    {
+     "longitude": 2.6487087,
+     "latitude": 36.1362286,
+     "nom": "Bouaichoune",
+     "id": "957",
+     "wilaya_id": "26",
+     "code_postal": "26059"
+    },
+    {
+     "longitude": 2.5891648,
+     "latitude": 36.1809422,
+     "nom": "Hannacha",
+     "id": "958",
+     "wilaya_id": "26",
+     "code_postal": "26060"
+    },
+    {
+     "longitude": 3.5288362,
+     "latitude": 36.2425076,
+     "nom": "Sedraia",
+     "id": "959",
+     "wilaya_id": "26",
+     "code_postal": "26061"
+    },
+    {
+     "longitude": 2.797901,
+     "latitude": 35.9480676,
+     "nom": "Medjebar",
+     "id": "960",
+     "wilaya_id": "26",
+     "code_postal": "26062"
+    },
+    {
+     "longitude": 3.1277854,
+     "latitude": 36.1464261,
+     "nom": "Khams Djouamaa",
+     "id": "961",
+     "wilaya_id": "26",
+     "code_postal": "26063"
+    },
+    {
+     "longitude": 2.8277963,
+     "latitude": 35.8493684,
+     "nom": "Saneg",
+     "id": "962",
+     "wilaya_id": "26",
+     "code_postal": "26064"
+    },
+    {
+     "longitude": 0.1401381,
+     "latitude": 36.01312350000001,
+     "nom": "Mostaganem",
+     "id": "963",
+     "wilaya_id": "27",
+     "code_postal": "27001"
+    },
+    {
+     "longitude": 0.1401381,
+     "latitude": 35.9042298,
+     "nom": "Sayada",
+     "id": "964",
+     "wilaya_id": "27",
+     "code_postal": "27002"
+    },
+    {
+     "longitude": -0.0170737,
+     "latitude": 35.7536603,
+     "nom": "Fornaka",
+     "id": "965",
+     "wilaya_id": "27",
+     "code_postal": "27003"
+    },
+    {
+     "longitude": -0.006994800000000001,
+     "latitude": 35.8307225,
+     "nom": "Stidia",
+     "id": "966",
+     "wilaya_id": "27",
+     "code_postal": "27004"
+    },
+    {
+     "longitude": 0.0489902,
+     "latitude": 35.8034403,
+     "nom": "Ain Nouissy",
+     "id": "967",
+     "wilaya_id": "27",
+     "code_postal": "27005"
+    },
+    {
+     "longitude": 0.102718,
+     "latitude": 35.8606678,
+     "nom": "Hassi Maameche",
+     "id": "968",
+     "wilaya_id": "27",
+     "code_postal": "27006"
+    },
+    {
+     "longitude": 0.2948797,
+     "latitude": 35.9965198,
+     "nom": "Ain Tadles",
+     "id": "969",
+     "wilaya_id": "27",
+     "code_postal": "27007"
+    },
+    {
+     "longitude": 0.3401287,
+     "latitude": 35.9998017,
+     "nom": "Sour",
+     "id": "970",
+     "wilaya_id": "27",
+     "code_postal": "27008"
+    },
+    {
+     "longitude": 0.3818982,
+     "latitude": 35.9500047,
+     "nom": "Oued El Kheir",
+     "id": "971",
+     "wilaya_id": "27",
+     "code_postal": "27009"
+    },
+    {
+     "longitude": 0.2737423,
+     "latitude": 36.0264951,
+     "nom": "Sidi Bellater",
+     "id": "972",
+     "wilaya_id": "27",
+     "code_postal": "27010"
+    },
+    {
+     "longitude": 0.1775946,
+     "latitude": 35.9477561,
+     "nom": "Kheiredine ",
+     "id": "973",
+     "wilaya_id": "27",
+     "code_postal": "27011"
+    },
+    {
+     "longitude": 0.4148744,
+     "latitude": 36.0967786,
+     "nom": "Sidi Ali",
+     "id": "974",
+     "wilaya_id": "27",
+     "code_postal": "27012"
+    },
+    {
+     "longitude": 0.2737423,
+     "latitude": 36.1026171,
+     "nom": "Abdelmalek Ramdane",
+     "id": "975",
+     "wilaya_id": "27",
+     "code_postal": "27013"
+    },
+    {
+     "longitude": 0.3254317,
+     "latitude": 36.0970536,
+     "nom": "Hadjadj",
+     "id": "976",
+     "wilaya_id": "27",
+     "code_postal": "27014"
+    },
+    {
+     "longitude": 0.6227851999999999,
+     "latitude": 36.1882211,
+     "nom": "Nekmaria",
+     "id": "977",
+     "wilaya_id": "27",
+     "code_postal": "27015"
+    },
+    {
+     "longitude": 0.4431618,
+     "latitude": 36.1618701,
+     "nom": "Sidi Lakhdar",
+     "id": "978",
+     "wilaya_id": "27",
+     "code_postal": "27016"
+    },
+    {
+     "longitude": 0.6334462,
+     "latitude": 36.2437869,
+     "nom": "Achaacha",
+     "id": "979",
+     "wilaya_id": "27",
+     "code_postal": "27017"
+    },
+    {
+     "longitude": 0.5754372999999999,
+     "latitude": 36.25357109999999,
+     "nom": "Khadra",
+     "id": "980",
+     "wilaya_id": "27",
+     "code_postal": "27018"
+    },
+    {
+     "longitude": 0.2549631,
+     "latitude": 35.74860839999999,
+     "nom": "Bouguirat",
+     "id": "981",
+     "wilaya_id": "27",
+     "code_postal": "27019"
+    },
+    {
+     "longitude": 0.1881358,
+     "latitude": 35.7801148,
+     "nom": "Sirat",
+     "id": "982",
+     "wilaya_id": "27",
+     "code_postal": "27020"
+    },
+    {
+     "longitude": 0.1284404,
+     "latitude": 35.8361077,
+     "nom": "Ain Sidi Cherif",
+     "id": "983",
+     "wilaya_id": "27",
+     "code_postal": "27021"
+    },
+    {
+     "longitude": 0.1658856,
+     "latitude": 35.841515,
+     "nom": "Mesra",
+     "id": "984",
+     "wilaya_id": "27",
+     "code_postal": "27022"
+    },
+    {
+     "longitude": 0.2315251,
+     "latitude": 35.8434386,
+     "nom": "Mansourah",
+     "id": "985",
+     "wilaya_id": "27",
+     "code_postal": "27023"
+    },
+    {
+     "longitude": 0.3313514,
+     "latitude": 35.8617554,
+     "nom": "Souaflia",
+     "id": "986",
+     "wilaya_id": "27",
+     "code_postal": "27024"
+    },
+    {
+     "longitude": 0.6701891999999999,
+     "latitude": 36.3181385,
+     "nom": "Ouled Boughalem",
+     "id": "987",
+     "wilaya_id": "27",
+     "code_postal": "27025"
+    },
+    {
+     "longitude": 0.5908192,
+     "latitude": 36.0076756,
+     "nom": "Ouled Maallah",
+     "id": "988",
+     "wilaya_id": "27",
+     "code_postal": "27026"
+    },
+    {
+     "longitude": 0.06066369999999999,
+     "latitude": 35.8879489,
+     "nom": "Mezghrane",
+     "id": "989",
+     "wilaya_id": "27",
+     "code_postal": "27027"
+    },
+    {
+     "longitude": 0.1881358,
+     "latitude": 36.0089774,
+     "nom": "Ain Boudinar",
+     "id": "990",
+     "wilaya_id": "27",
+     "code_postal": "27028"
+    },
+    {
+     "longitude": 0.5482376,
+     "latitude": 36.0948862,
+     "nom": "Tazgait",
+     "id": "991",
+     "wilaya_id": "27",
+     "code_postal": "27029"
+    },
+    {
+     "longitude": 0.3771895,
+     "latitude": 35.8464922,
+     "nom": "Safsaf",
+     "id": "992",
+     "wilaya_id": "27",
+     "code_postal": "27030"
+    },
+    {
+     "longitude": 0.2092267,
+     "latitude": 35.810088,
+     "nom": "Touahria",
+     "id": "993",
+     "wilaya_id": "27",
+     "code_postal": "27031"
+    },
+    {
+     "longitude": 0.1202541,
+     "latitude": 35.7529118,
+     "nom": "El Hassiane",
+     "id": "994",
+     "wilaya_id": "27",
+     "code_postal": "27032"
+    },
+    {
+     "longitude": 4.5418141,
+     "latitude": 35.677109,
+     "nom": "M'sila",
+     "id": "995",
+     "wilaya_id": "28",
+     "code_postal": "28001"
+    },
+    {
+     "longitude": 4.7484518,
+     "latitude": 35.7999025,
+     "nom": "Maadid",
+     "id": "996",
+     "wilaya_id": "28",
+     "code_postal": "28002"
+    },
+    {
+     "longitude": 4.3770704,
+     "latitude": 35.94451859999999,
+     "nom": "Hammam Dhalaa",
+     "id": "997",
+     "wilaya_id": "28",
+     "code_postal": "28003"
+    },
+    {
+     "longitude": 4.789873099999999,
+     "latitude": 35.6238892,
+     "nom": "Ouled Derradj",
+     "id": "998",
+     "wilaya_id": "28",
+     "code_postal": "28004"
+    },
+    {
+     "longitude": 4.2538452,
+     "latitude": 35.8183774,
+     "nom": "Tarmount",
+     "id": "999",
+     "wilaya_id": "28",
+     "code_postal": "28005"
+    },
+    {
+     "longitude": 4.624375100000001,
+     "latitude": 35.7175823,
+     "nom": "Mtarfa",
+     "id": "1000",
+     "wilaya_id": "28",
+     "code_postal": "28006"
+    },
+    {
+     "longitude": 4.5005808,
+     "latitude": 35.3289153,
+     "nom": "Khoubana",
+     "id": "1001",
+     "wilaya_id": "28",
+     "code_postal": "28007"
+    },
+    {
+     "longitude": 4.7691586,
+     "latitude": 35.3405434,
+     "nom": "Mcif",
+     "id": "1002",
+     "wilaya_id": "28",
+     "code_postal": "28008"
+    },
+    {
+     "longitude": 4.3770704,
+     "latitude": 35.5085058,
+     "nom": "Chellal",
+     "id": "1003",
+     "wilaya_id": "28",
+     "code_postal": "28009"
+    },
+    {
+     "longitude": 4.5418141,
+     "latitude": 35.5461361,
+     "nom": "Ouled Madhi",
+     "id": "1004",
+     "wilaya_id": "28",
+     "code_postal": "28010"
+    },
+    {
+     "longitude": 5.1223608,
+     "latitude": 35.6102393,
+     "nom": "Magra",
+     "id": "1005",
+     "wilaya_id": "28",
+     "code_postal": "28011"
+    },
+    {
+     "longitude": 5.0078451,
+     "latitude": 35.6477648,
+     "nom": "Berhoum",
+     "id": "1006",
+     "wilaya_id": "28",
+     "code_postal": "28012"
+    },
+    {
+     "longitude": 4.9558696,
+     "latitude": 35.5298671,
+     "nom": "Ain Khadra",
+     "id": "1007",
+     "wilaya_id": "28",
+     "code_postal": "28013"
+    },
+    {
+     "longitude": 4.8728093,
+     "latitude": 35.7078012,
+     "nom": "Ouled Addi Guebala",
+     "id": "1008",
+     "wilaya_id": "28",
+     "code_postal": "28014"
+    },
+    {
+     "longitude": 5.1953554,
+     "latitude": 35.5743889,
+     "nom": "Belaiba",
+     "id": "1009",
+     "wilaya_id": "28",
+     "code_postal": "28015"
+    },
+    {
+     "longitude": 3.7029002,
+     "latitude": 35.8147768,
+     "nom": "Sidi Aissa",
+     "id": "1010",
+     "wilaya_id": "28",
+     "code_postal": "28016"
+    },
+    {
+     "longitude": 3.8451731,
+     "latitude": 35.613995,
+     "nom": "Ain El Hadjel",
+     "id": "1011",
+     "wilaya_id": "28",
+     "code_postal": "28017"
+    },
+    {
+     "longitude": 4.028678,
+     "latitude": 35.7171398,
+     "nom": "Sidi Hadjeres",
+     "id": "1012",
+     "wilaya_id": "28",
+     "code_postal": "28018"
+    },
+    {
+     "longitude": 4.1718542,
+     "latitude": 35.9518081,
+     "nom": "Ouanougha",
+     "id": "1013",
+     "wilaya_id": "28",
+     "code_postal": "28019"
+    },
+    {
+     "longitude": 4.1794668,
+     "latitude": 35.2102695,
+     "nom": "Bou Saada",
+     "id": "1014",
+     "wilaya_id": "28",
+     "code_postal": "28020"
+    },
+    {
+     "longitude": 4.1309067,
+     "latitude": 35.3420781,
+     "nom": "Ouled Sidi Brahim",
+     "id": "1015",
+     "wilaya_id": "28",
+     "code_postal": "28021"
+    },
+    {
+     "longitude": 3.8248241,
+     "latitude": 35.417831,
+     "nom": "Sidi Ameur",
+     "id": "1016",
+     "wilaya_id": "28",
+     "code_postal": "28022"
+    },
+    {
+     "longitude": 3.9266502,
+     "latitude": 35.17339279999999,
+     "nom": "Tamsa",
+     "id": "1017",
+     "wilaya_id": "28",
+     "code_postal": "28023"
+    },
+    {
+     "longitude": 4.6037231,
+     "latitude": 34.9958214,
+     "nom": "Ben Srour",
+     "id": "1018",
+     "wilaya_id": "28",
+     "code_postal": "28024"
+    },
+    {
+     "longitude": 4.8520636,
+     "latitude": 34.8981727,
+     "nom": "Ouled Slimane",
+     "id": "1019",
+     "wilaya_id": "28",
+     "code_postal": "28025"
+    },
+    {
+     "longitude": 4.6037231,
+     "latitude": 35.1715671,
+     "nom": "El Houamed",
+     "id": "1020",
+     "wilaya_id": "28",
+     "code_postal": "28026"
+    },
+    {
+     "longitude": 4.0899911,
+     "latitude": 35.12408,
+     "nom": "El Hamel",
+     "id": "1021",
+     "wilaya_id": "28",
+     "code_postal": "28027"
+    },
+    {
+     "longitude": 4.3770704,
+     "latitude": 35.7268096,
+     "nom": "Ouled Mansour",
+     "id": "1022",
+     "wilaya_id": "28",
+     "code_postal": "28028"
+    },
+    {
+     "longitude": 4.2948884,
+     "latitude": 35.3801821,
+     "nom": "Maarif",
+     "id": "1023",
+     "wilaya_id": "28",
+     "code_postal": "28029"
+    },
+    {
+     "longitude": 5.0286488,
+     "latitude": 35.7340886,
+     "nom": "Dehahna",
+     "id": "1024",
+     "wilaya_id": "28",
+     "code_postal": "28030"
+    },
+    {
+     "longitude": 3.6217802,
+     "latitude": 35.642736,
+     "nom": "Bouti Sayah",
+     "id": "1025",
+     "wilaya_id": "28",
+     "code_postal": "28031"
+    },
+    {
+     "longitude": 4.2538452,
+     "latitude": 35.687602,
+     "nom": "Khettouti Sed Djir",
+     "id": "1026",
+     "wilaya_id": "28",
+     "code_postal": "28032"
+    },
+    {
+     "longitude": 4.8313257,
+     "latitude": 35.0529379,
+     "nom": "Zarzour",
+     "id": "1027",
+     "wilaya_id": "28",
+     "code_postal": "28033"
+    },
+    {
+     "longitude": 4.4593791,
+     "latitude": 34.8911615,
+     "nom": "Oued Chair",
+     "id": "1028",
+     "wilaya_id": "28",
+     "code_postal": "28034"
+    },
+    {
+     "longitude": 4.0899911,
+     "latitude": 35.474817,
+     "nom": "Benzouh",
+     "id": "1029",
+     "wilaya_id": "28",
+     "code_postal": "28035"
+    },
+    {
+     "longitude": 3.9266502,
+     "latitude": 34.82133719999999,
+     "nom": "Bir Foda",
+     "id": "1030",
+     "wilaya_id": "28",
+     "code_postal": "28036"
+    },
+    {
+     "longitude": 4.5005808,
+     "latitude": 34.7132986,
+     "nom": "Ain Fares",
+     "id": "1031",
+     "wilaya_id": "28",
+     "code_postal": "28037"
+    },
+    {
+     "longitude": 4.2948884,
+     "latitude": 34.7648293,
+     "nom": "Sidi Mhamed",
+     "id": "1032",
+     "wilaya_id": "28",
+     "code_postal": "28038"
+    },
+    {
+     "longitude": 3.8044831,
+     "latitude": 35.0454248,
+     "nom": "Ouled Atia",
+     "id": "1033",
+     "wilaya_id": "28",
+     "code_postal": "28039"
+    },
+    {
+     "longitude": 4.7239002,
+     "latitude": 35.5863111,
+     "nom": "Souamaa",
+     "id": "1034",
+     "wilaya_id": "28",
+     "code_postal": "28040"
+    },
+    {
+     "longitude": 4.1718542,
+     "latitude": 34.8132006,
+     "nom": "Ain El Melh",
+     "id": "1035",
+     "wilaya_id": "28",
+     "code_postal": "28041"
+    },
+    {
+     "longitude": 3.642048,
+     "latitude": 35.0503943,
+     "nom": "Medjedel",
+     "id": "1036",
+     "wilaya_id": "28",
+     "code_postal": "28042"
+    },
+    {
+     "longitude": 3.8451731,
+     "latitude": 34.9120859,
+     "nom": "Slim",
+     "id": "1037",
+     "wilaya_id": "28",
+     "code_postal": "28043"
+    },
+    {
+     "longitude": 4.028678,
+     "latitude": 34.5751386,
+     "nom": "Ain Errich",
+     "id": "1038",
+     "wilaya_id": "28",
+     "code_postal": "28044"
+    },
+    {
+     "longitude": 4.0899911,
+     "latitude": 35.9546181,
+     "nom": "Beni Ilmane",
+     "id": "1039",
+     "wilaya_id": "28",
+     "code_postal": "28045"
+    },
+    {
+     "longitude": 4.2948884,
+     "latitude": 35.1170124,
+     "nom": "Oultene",
+     "id": "1040",
+     "wilaya_id": "28",
+     "code_postal": "28046"
+    },
+    {
+     "longitude": 4.19234,
+     "latitude": 35.010688,
+     "nom": "Djebel Messaad",
+     "id": "1041",
+     "wilaya_id": "28",
+     "code_postal": "28047"
+    },
+    {
+     "longitude": 0.1388446,
+     "latitude": 35.3974554,
+     "nom": "Mascara",
+     "id": "1042",
+     "wilaya_id": "29",
+     "code_postal": "29001"
+    },
+    {
+     "longitude": -0.0489902,
+     "latitude": 35.3164348,
+     "nom": "Bou Hanifia",
+     "id": "1043",
+     "wilaya_id": "29",
+     "code_postal": "29002"
+    },
+    {
+     "longitude": 0.0716931,
+     "latitude": 35.3157392,
+     "nom": "Tizi",
+     "id": "1044",
+     "wilaya_id": "29",
+     "code_postal": "29003"
+    },
+    {
+     "longitude": -0.004663,
+     "latitude": 35.46175820000001,
+     "nom": "Hacine",
+     "id": "1045",
+     "wilaya_id": "29",
+     "code_postal": "29004"
+    },
+    {
+     "longitude": 0.2460604,
+     "latitude": 35.3798032,
+     "nom": "Maoussa",
+     "id": "1046",
+     "wilaya_id": "29",
+     "code_postal": "29005"
+    },
+    {
+     "longitude": 0.3296454,
+     "latitude": 35.4154336,
+     "nom": "Teghennif",
+     "id": "1047",
+     "wilaya_id": "29",
+     "code_postal": "29006"
+    },
+    {
+     "longitude": 0.3789103,
+     "latitude": 35.4106358,
+     "nom": "El Hachem",
+     "id": "1048",
+     "wilaya_id": "29",
+     "code_postal": "29007"
+    },
+    {
+     "longitude": 0.3416407,
+     "latitude": 35.3317591,
+     "nom": "Sidi Kada",
+     "id": "1049",
+     "wilaya_id": "29",
+     "code_postal": "29008"
+    },
+    {
+     "longitude": 0.4752897,
+     "latitude": 35.2917125,
+     "nom": "Zelmata",
+     "id": "1050",
+     "wilaya_id": "29",
+     "code_postal": "29009"
+    },
+    {
+     "longitude": 0.687574,
+     "latitude": 35.4551984,
+     "nom": "Oued El Abtal",
+     "id": "1051",
+     "wilaya_id": "29",
+     "code_postal": "29010"
+    },
+    {
+     "longitude": 0.7853762999999999,
+     "latitude": 35.3811088,
+     "nom": "Ain Ferah",
+     "id": "1052",
+     "wilaya_id": "29",
+     "code_postal": "29011"
+    },
+    {
+     "longitude": 0.1682271,
+     "latitude": 35.2367082,
+     "nom": "Ghriss",
+     "id": "1053",
+     "wilaya_id": "29",
+     "code_postal": "29012"
+    },
+    {
+     "longitude": 0.1282536,
+     "latitude": 35.3026637,
+     "nom": "Froha",
+     "id": "1054",
+     "wilaya_id": "29",
+     "code_postal": "29013"
+    },
+    {
+     "longitude": 0.2150873,
+     "latitude": 35.31351,
+     "nom": "Matemore",
+     "id": "1055",
+     "wilaya_id": "29",
+     "code_postal": "29014"
+    },
+    {
+     "longitude": 0.2807868,
+     "latitude": 35.19253940000001,
+     "nom": "Makdha",
+     "id": "1056",
+     "wilaya_id": "29",
+     "code_postal": "29015"
+    },
+    {
+     "longitude": 0.2807868,
+     "latitude": 35.280438,
+     "nom": "Sidi Boussaid",
+     "id": "1057",
+     "wilaya_id": "29",
+     "code_postal": "29016"
+    },
+    {
+     "longitude": 0.3277829,
+     "latitude": 35.510608,
+     "nom": "El Bordj",
+     "id": "1058",
+     "wilaya_id": "29",
+     "code_postal": "29017"
+    },
+    {
+     "longitude": -0.0139908,
+     "latitude": 35.2203411,
+     "nom": "Ain Fekan",
+     "id": "1059",
+     "wilaya_id": "29",
+     "code_postal": "29018"
+    },
+    {
+     "longitude": 0.25,
+     "latitude": 35.1,
+     "nom": "Benian",
+     "id": "1060",
+     "wilaya_id": "29",
+     "code_postal": "29019"
+    },
+    {
+     "longitude": 0.2948797,
+     "latitude": 35.4613997,
+     "nom": "Khalouia",
+     "id": "1061",
+     "wilaya_id": "29",
+     "code_postal": "29020"
+    },
+    {
+     "longitude": 0.4219444,
+     "latitude": 35.5322149,
+     "nom": "El Menaouer",
+     "id": "1062",
+     "wilaya_id": "29",
+     "code_postal": "29021"
+    },
+    {
+     "longitude": 0.09103159999999999,
+     "latitude": 35.1130905,
+     "nom": "Oued Taria",
+     "id": "1063",
+     "wilaya_id": "29",
+     "code_postal": "29022"
+    },
+    {
+     "longitude": 0.3560076,
+     "latitude": 35.104351,
+     "nom": "Aouf",
+     "id": "1064",
+     "wilaya_id": "29",
+     "code_postal": "29023"
+    },
+    {
+     "longitude": 0.2432307,
+     "latitude": 35.4560355,
+     "nom": "Ain Fares",
+     "id": "1065",
+     "wilaya_id": "29",
+     "code_postal": "29024"
+    },
+    {
+     "longitude": -0.1682271,
+     "latitude": 35.5437798,
+     "nom": "Sig",
+     "id": "1067",
+     "wilaya_id": "29",
+     "code_postal": "29026"
+    },
+    {
+     "longitude": -0.2584835,
+     "latitude": 35.5614065,
+     "nom": "Oggaz",
+     "id": "1068",
+     "wilaya_id": "29",
+     "code_postal": "29027"
+    },
+    {
+     "longitude": -0.3144193,
+     "latitude": 35.4274033,
+     "nom": "El Gaada",
+     "id": "1070",
+     "wilaya_id": "29",
+     "code_postal": "29029"
+    },
+    {
+     "longitude": -0.4078058,
+     "latitude": 35.5158402,
+     "nom": "Zahana",
+     "id": "1071",
+     "wilaya_id": "29",
+     "code_postal": "29030"
+    },
+    {
+     "longitude": 0.05599390000000001,
+     "latitude": 35.5876568,
+     "nom": "Mohammadia",
+     "id": "1072",
+     "wilaya_id": "29",
+     "code_postal": "29031"
+    },
+    {
+     "longitude": 0.0128247,
+     "latitude": 35.6546506,
+     "nom": "Sidi Abdelmoumene",
+     "id": "1073",
+     "wilaya_id": "29",
+     "code_postal": "29032"
+    },
+    {
+     "longitude": 0.2068827,
+     "latitude": 35.6872612,
+     "nom": "El Ghomri",
+     "id": "1075",
+     "wilaya_id": "29",
+     "code_postal": "29034"
+    },
+    {
+     "longitude": 0.2120588,
+     "latitude": 35.6293922,
+     "nom": "Sedjerara",
+     "id": "1076",
+     "wilaya_id": "29",
+     "code_postal": "29035"
+    },
+    {
+     "longitude": -0.0489902,
+     "latitude": 35.6068031,
+     "nom": "Moctadouz",
+     "id": "1077",
+     "wilaya_id": "29",
+     "code_postal": "29036"
+    },
+    {
+     "longitude": -0.0863581,
+     "latitude": 35.5575475,
+     "nom": "Bou Henni",
+     "id": "1078",
+     "wilaya_id": "29",
+     "code_postal": "29037"
+    },
+    {
+     "longitude": 0.1404947,
+     "latitude": 35.4256036,
+     "nom": "El Mamounia",
+     "id": "1080",
+     "wilaya_id": "29",
+     "code_postal": "29039"
+    },
+    {
+     "longitude": 0.09243169999999999,
+     "latitude": 35.3800031,
+     "nom": "El Keurt",
+     "id": "1081",
+     "wilaya_id": "29",
+     "code_postal": "29040"
+    },
+    {
+     "longitude": 0.4465984,
+     "latitude": 35.1259091,
+     "nom": "Gharrous",
+     "id": "1082",
+     "wilaya_id": "29",
+     "code_postal": "29041"
+    },
+    {
+     "longitude": -0.259657,
+     "latitude": 35.39296849999999,
+     "nom": "Chorfa",
+     "id": "1084",
+     "wilaya_id": "29",
+     "code_postal": "29043"
+    },
+    {
+     "longitude": 0.5233310999999999,
+     "latitude": 35.4425889,
+     "nom": "Sidi Abdeldjebar",
+     "id": "1087",
+     "wilaya_id": "29",
+     "code_postal": "29046"
+    },
+    {
+     "longitude": 0.403094,
+     "latitude": 35.4446508,
+     "nom": "Sehailia",
+     "id": "1088",
+     "wilaya_id": "29",
+     "code_postal": "29047"
+    },
+    {
+     "longitude": 4.976654,
+     "latitude": 32.1677808,
+     "nom": "Ouargla",
+     "id": "1089",
+     "wilaya_id": "30",
+     "code_postal": "30001"
+    },
+    {
+     "longitude": 5.395264,
+     "latitude": 31.945266,
+     "nom": "Ain Beida",
+     "id": "1090",
+     "wilaya_id": "30",
+     "code_postal": "30002"
+    },
+    {
+     "longitude": 5.3128644,
+     "latitude": 32.1399866,
+     "nom": "Ngoussa",
+     "id": "1091",
+     "wilaya_id": "30",
+     "code_postal": "30003"
+    },
+    {
+     "longitude": 5.393955099999999,
+     "latitude": 30.416772,
+     "nom": "Hassi Messaoud",
+     "id": "1092",
+     "wilaya_id": "30",
+     "code_postal": "30004"
+    },
+    {
+     "longitude": 5.3468563,
+     "latitude": 31.9317115,
+     "nom": "Rouissat",
+     "id": "1093",
+     "wilaya_id": "30",
+     "code_postal": "30005"
+    },
+    {
+     "longitude": 5.9753267,
+     "latitude": 32.9447252,
+     "nom": "Balidat Ameur",
+     "id": "1094",
+     "wilaya_id": "30",
+     "code_postal": "30006"
+    },
+    {
+     "longitude": 6.0838065,
+     "latitude": 33.1161615,
+     "nom": "Tebesbest",
+     "id": "1095",
+     "wilaya_id": "30",
+     "code_postal": "30007"
+    },
+    {
+     "longitude": 6.067641,
+     "latitude": 33.094041,
+     "nom": "Nezla",
+     "id": "1096",
+     "wilaya_id": "30",
+     "code_postal": "30008"
+    },
+    {
+     "longitude": 6.093076,
+     "latitude": 33.2906594,
+     "nom": "Sidi Slimane",
+     "id": "1098",
+     "wilaya_id": "30",
+     "code_postal": "30010"
+    },
+    {
+     "longitude": 5.417519,
+     "latitude": 31.9769255,
+     "nom": "Sidi Khouiled",
+     "id": "1099",
+     "wilaya_id": "30",
+     "code_postal": "30011"
+    },
+    {
+     "longitude": 5.4691361,
+     "latitude": 32.025631,
+     "nom": "Hassi Ben Abdellah",
+     "id": "1100",
+     "wilaya_id": "30",
+     "code_postal": "30012"
+    },
+    {
+     "longitude": 6.0785104,
+     "latitude": 33.0996078,
+     "nom": "Touggourt",
+     "id": "1101",
+     "wilaya_id": "30",
+     "code_postal": "30013"
+    },
+    {
+     "longitude": 5.514493000000001,
+     "latitude": 32.6142956,
+     "nom": "El Hadjira",
+     "id": "1102",
+     "wilaya_id": "30",
+     "code_postal": "30014"
+    },
+    {
+     "longitude": 6.399750099999999,
+     "latitude": 33.0863448,
+     "nom": "Taibet",
+     "id": "1103",
+     "wilaya_id": "30",
+     "code_postal": "30015"
+    },
+    {
+     "longitude": 6.0212106,
+     "latitude": 33.01456710000001,
+     "nom": "Tamacine",
+     "id": "1104",
+     "wilaya_id": "30",
+     "code_postal": "30016"
+    },
+    {
+     "longitude": 6.445015799999999,
+     "latitude": 33.1092231,
+     "nom": "Benaceur",
+     "id": "1105",
+     "wilaya_id": "30",
+     "code_postal": "30017"
+    },
+    {
+     "longitude": 6.094400299999999,
+     "latitude": 33.1940606,
+     "nom": "Megarine",
+     "id": "1107",
+     "wilaya_id": "30",
+     "code_postal": "30019"
+    },
+    {
+     "longitude": 5.4227567,
+     "latitude": 32.6999655,
+     "nom": "El Allia",
+     "id": "1108",
+     "wilaya_id": "30",
+     "code_postal": "30020"
+    },
+    {
+     "longitude": 8.1338558,
+     "latitude": 31.0062563,
+     "nom": "El Borma",
+     "id": "1109",
+     "wilaya_id": "30",
+     "code_postal": "30021"
+    },
+    {
+     "longitude": -0.6337376,
+     "latitude": 35.6976541,
+     "nom": "Oran",
+     "id": "1110",
+     "wilaya_id": "31",
+     "code_postal": "31001"
+    },
+    {
+     "longitude": -0.4691097,
+     "latitude": 35.8052667,
+     "nom": "Gdyel",
+     "id": "1111",
+     "wilaya_id": "31",
+     "code_postal": "31002"
+    },
+    {
+     "longitude": -0.554149,
+     "latitude": 35.7284976,
+     "nom": "Bir El Djir",
+     "id": "1112",
+     "wilaya_id": "31",
+     "code_postal": "31003"
+    },
+    {
+     "longitude": -0.4785495,
+     "latitude": 35.6851254,
+     "nom": "Hassi Bounif",
+     "id": "1113",
+     "wilaya_id": "31",
+     "code_postal": "31004"
+    },
+    {
+     "longitude": -0.6061329999999999,
+     "latitude": 35.6202476,
+     "nom": "Es Senia",
+     "id": "1114",
+     "wilaya_id": "31",
+     "code_postal": "31005"
+    },
+    {
+     "longitude": -0.3465971,
+     "latitude": 35.8602138,
+     "nom": "Arzew",
+     "id": "1115",
+     "wilaya_id": "31",
+     "code_postal": "31006"
+    },
+    {
+     "longitude": -0.2338473,
+     "latitude": 35.7513806,
+     "nom": "Bethioua",
+     "id": "1116",
+     "wilaya_id": "31",
+     "code_postal": "31007"
+    },
+    {
+     "longitude": -0.1682271,
+     "latitude": 35.762407,
+     "nom": "Marsat El Hadjadj",
+     "id": "1117",
+     "wilaya_id": "31",
+     "code_postal": "31008"
+    },
+    {
+     "longitude": -0.8008388,
+     "latitude": 35.74895300000001,
+     "nom": "Ain Turk",
+     "id": "1118",
+     "wilaya_id": "31",
+     "code_postal": "31009"
+    },
+    {
+     "longitude": -0.4596721,
+     "latitude": 35.5539698,
+     "nom": "Oued Tlelat",
+     "id": "1120",
+     "wilaya_id": "31",
+     "code_postal": "31011"
+    },
+    {
+     "longitude": -0.5446911999999999,
+     "latitude": 35.4550561,
+     "nom": "Tafraoui",
+     "id": "1121",
+     "wilaya_id": "31",
+     "code_postal": "31012"
+    },
+    {
+     "longitude": -0.5446911999999999,
+     "latitude": 35.673918,
+     "nom": "Sidi Chami",
+     "id": "1122",
+     "wilaya_id": "31",
+     "code_postal": "31013"
+    },
+    {
+     "longitude": -0.3936722,
+     "latitude": 35.6307787,
+     "nom": "Boufatis",
+     "id": "1123",
+     "wilaya_id": "31",
+     "code_postal": "31014"
+    },
+    {
+     "longitude": -0.7105267,
+     "latitude": 35.722219,
+     "nom": "Mers El Kebir",
+     "id": "1124",
+     "wilaya_id": "31",
+     "code_postal": "31015"
+    },
+    {
+     "longitude": -0.7813933,
+     "latitude": 35.7184264,
+     "nom": "Bousfer",
+     "id": "1125",
+     "wilaya_id": "31",
+     "code_postal": "31016"
+    },
+    {
+     "longitude": -1.0011902,
+     "latitude": 35.627277,
+     "nom": "El Karma",
+     "id": "1126",
+     "wilaya_id": "31",
+     "code_postal": "31017"
+    },
+    {
+     "longitude": -0.4974359,
+     "latitude": 35.6194616,
+     "nom": "El Braya",
+     "id": "1127",
+     "wilaya_id": "31",
+     "code_postal": "31018"
+    },
+    {
+     "longitude": -0.4676447,
+     "latitude": 35.7289564,
+     "nom": "Hassi Ben Okba",
+     "id": "1128",
+     "wilaya_id": "31",
+     "code_postal": "31019"
+    },
+    {
+     "longitude": -0.3654204,
+     "latitude": 35.7292156,
+     "nom": "Ben Freha",
+     "id": "1129",
+     "wilaya_id": "31",
+     "code_postal": "31020"
+    },
+    {
+     "longitude": -0.374617,
+     "latitude": 35.8010772,
+     "nom": "Hassi Mefsoukh",
+     "id": "1130",
+     "wilaya_id": "31",
+     "code_postal": "31021"
+    },
+    {
+     "longitude": -0.6526335999999999,
+     "latitude": 35.6993064,
+     "nom": "Sidi Ben Yabka",
+     "id": "1131",
+     "wilaya_id": "31",
+     "code_postal": "31022"
+    },
+    {
+     "longitude": -0.7722973999999999,
+     "latitude": 35.5852064,
+     "nom": "Messerghin",
+     "id": "1132",
+     "wilaya_id": "31",
+     "code_postal": "31023"
+    },
+    {
+     "longitude": -0.8865833999999999,
+     "latitude": 35.5844234,
+     "nom": "Boutlelis",
+     "id": "1133",
+     "wilaya_id": "31",
+     "code_postal": "31024"
+    },
+    {
+     "longitude": -1.0011902,
+     "latitude": 35.627277,
+     "nom": "Ain Kerma",
+     "id": "1134",
+     "wilaya_id": "31",
+     "code_postal": "31025"
+    },
+    {
+     "longitude": -0.2816754,
+     "latitude": 35.8081628,
+     "nom": "Ain Biya",
+     "id": "1135",
+     "wilaya_id": "31",
+     "code_postal": "31026"
+    },
+    {
+     "longitude": 1.0203224,
+     "latitude": 33.65813869999999,
+     "nom": "El Bayadh",
+     "id": "1136",
+     "wilaya_id": "32",
+     "code_postal": "32001"
+    },
+    {
+     "longitude": 0.9271366999999999,
+     "latitude": 34.0188896,
+     "nom": "Rogassa",
+     "id": "1137",
+     "wilaya_id": "32",
+     "code_postal": "32002"
+    },
+    {
+     "longitude": 1.2506002,
+     "latitude": 33.8348155,
+     "nom": "Stitten",
+     "id": "1138",
+     "wilaya_id": "32",
+     "code_postal": "32003"
+    },
+    {
+     "longitude": 1.2586654,
+     "latitude": 33.0978041,
+     "nom": "Brezina",
+     "id": "1139",
+     "wilaya_id": "32",
+     "code_postal": "32004"
+    },
+    {
+     "longitude": 1.2001181,
+     "latitude": 33.3793059,
+     "nom": "Ghassoul",
+     "id": "1140",
+     "wilaya_id": "32",
+     "code_postal": "32005"
+    },
+    {
+     "longitude": 1.5329678,
+     "latitude": 33.7283305,
+     "nom": "Boualem",
+     "id": "1141",
+     "wilaya_id": "32",
+     "code_postal": "32006"
+    },
+    {
+     "longitude": 0.5399631,
+     "latitude": 32.9031575,
+     "nom": "El Abiodh Sidi Cheikh",
+     "id": "1142",
+     "wilaya_id": "32",
+     "code_postal": "32007"
+    },
+    {
+     "longitude": 0.7390245,
+     "latitude": 33.4081281,
+     "nom": "Ain El Orak",
+     "id": "1143",
+     "wilaya_id": "32",
+     "code_postal": "32008"
+    },
+    {
+     "longitude": 0.5849023999999999,
+     "latitude": 33.0916013,
+     "nom": "Arbaouat",
+     "id": "1144",
+     "wilaya_id": "32",
+     "code_postal": "32009"
+    },
+    {
+     "longitude": 0.09103159999999999,
+     "latitude": 34.0390465,
+     "nom": "Bougtoub",
+     "id": "1145",
+     "wilaya_id": "32",
+     "code_postal": "32010"
+    },
+    {
+     "longitude": 0.0700051,
+     "latitude": 34.1364841,
+     "nom": "El Kheither",
+     "id": "1146",
+     "wilaya_id": "32",
+     "code_postal": "32011"
+    },
+    {
+     "longitude": 0.0233208,
+     "latitude": 32.8704903,
+     "nom": "Boussemghoun",
+     "id": "1148",
+     "wilaya_id": "32",
+     "code_postal": "32013"
+    },
+    {
+     "longitude": 0.06066369999999999,
+     "latitude": 33.0394912,
+     "nom": "Chellala",
+     "id": "1149",
+     "wilaya_id": "32",
+     "code_postal": "32014"
+    },
+    {
+     "longitude": 1.4362206,
+     "latitude": 33.7685936,
+     "nom": "Sidi Ameur",
+     "id": "1153",
+     "wilaya_id": "32",
+     "code_postal": "32018"
+    },
+    {
+     "longitude": 0.3642437,
+     "latitude": 33.3130066,
+     "nom": "El Mehara",
+     "id": "1154",
+     "wilaya_id": "32",
+     "code_postal": "32019"
+    },
+    {
+     "longitude": 0.3113278,
+     "latitude": 33.6479569,
+     "nom": "Tousmouline",
+     "id": "1155",
+     "wilaya_id": "32",
+     "code_postal": "32020"
+    },
+    {
+     "longitude": 1.7271179,
+     "latitude": 33.83187789999999,
+     "nom": "Sidi Slimane",
+     "id": "1156",
+     "wilaya_id": "32",
+     "code_postal": "32021"
+    },
+    {
+     "longitude": 1.683333,
+     "latitude": 33.716667,
+     "nom": "Sidi Tifour",
+     "id": "1157",
+     "wilaya_id": "32",
+     "code_postal": "32022"
+    },
+    {
+     "longitude": 8.4732718,
+     "latitude": 26.5094346,
+     "nom": "Illizi",
+     "id": "1158",
+     "wilaya_id": "33",
+     "code_postal": "33001"
+    },
+    {
+     "longitude": 9.4811604,
+     "latitude": 24.5545691,
+     "nom": "Djanet",
+     "id": "1159",
+     "wilaya_id": "33",
+     "code_postal": "33002"
+    },
+    {
+     "longitude": 9.422346,
+     "latitude": 29.9672147,
+     "nom": "Debdeb",
+     "id": "1160",
+     "wilaya_id": "33",
+     "code_postal": "33003"
+    },
+    {
+     "longitude": 6.7547522,
+     "latitude": 28.115695,
+     "nom": "Bordj Omar Driss",
+     "id": "1161",
+     "wilaya_id": "33",
+     "code_postal": "33004"
+    },
+    {
+     "longitude": 8.434873,
+     "latitude": 24.8849934,
+     "nom": "Bordj El Haouasse",
+     "id": "1162",
+     "wilaya_id": "33",
+     "code_postal": "33005"
+    },
+    {
+     "longitude": 9.5784754,
+     "latitude": 28.0461513,
+     "nom": "In Amenas",
+     "id": "1163",
+     "wilaya_id": "33",
+     "code_postal": "33006"
+    },
+    {
+     "longitude": 4.7564046,
+     "latitude": 36.0704188,
+     "nom": "Bordj Bou Arreridj",
+     "id": "1164",
+     "wilaya_id": "34",
+     "code_postal": "34001"
+    },
+    {
+     "longitude": 5.0356951,
+     "latitude": 35.947031,
+     "nom": "Ras El Oued",
+     "id": "1165",
+     "wilaya_id": "34",
+     "code_postal": "34002"
+    },
+    {
+     "longitude": 4.883185,
+     "latitude": 36.2612267,
+     "nom": "Bordj Zemoura",
+     "id": "1166",
+     "wilaya_id": "34",
+     "code_postal": "34003"
+    },
+    {
+     "longitude": 4.43879,
+     "latitude": 36.1376769,
+     "nom": "Mansoura",
+     "id": "1167",
+     "wilaya_id": "34",
+     "code_postal": "34004"
+    },
+    {
+     "longitude": 4.3895593,
+     "latitude": 36.1184335,
+     "nom": "El Mhir",
+     "id": "1168",
+     "wilaya_id": "34",
+     "code_postal": "34005"
+    },
+    {
+     "longitude": 4.1419948,
+     "latitude": 36.0673882,
+     "nom": "Ben Daoud",
+     "id": "1169",
+     "wilaya_id": "34",
+     "code_postal": "34006"
+    },
+    {
+     "longitude": 4.624375100000001,
+     "latitude": 36.0655916,
+     "nom": "El Achir",
+     "id": "1170",
+     "wilaya_id": "34",
+     "code_postal": "34007"
+    },
+    {
+     "longitude": 5.1223608,
+     "latitude": 36.1321301,
+     "nom": "Ain Taghrout",
+     "id": "1171",
+     "wilaya_id": "34",
+     "code_postal": "34008"
+    },
+    {
+     "longitude": 4.9247074,
+     "latitude": 35.9124803,
+     "nom": "Bordj Ghdir",
+     "id": "1172",
+     "wilaya_id": "34",
+     "code_postal": "34009"
+    },
+    {
+     "longitude": 4.914323899999999,
+     "latitude": 36.0974673,
+     "nom": "Sidi Embarek",
+     "id": "1173",
+     "wilaya_id": "34",
+     "code_postal": "34010"
+    },
+    {
+     "longitude": 4.7795149,
+     "latitude": 35.983529,
+     "nom": "El Hamadia",
+     "id": "1174",
+     "wilaya_id": "34",
+     "code_postal": "34011"
+    },
+    {
+     "longitude": 4.914323899999999,
+     "latitude": 35.9672331,
+     "nom": "Belimour",
+     "id": "1175",
+     "wilaya_id": "34",
+     "code_postal": "34012"
+    },
+    {
+     "longitude": 4.6714821,
+     "latitude": 36.1340533,
+     "nom": "Medjana",
+     "id": "1176",
+     "wilaya_id": "34",
+     "code_postal": "34013"
+    },
+    {
+     "longitude": 4.6001675,
+     "latitude": 36.2312193,
+     "nom": "Teniet En Nasr",
+     "id": "1177",
+     "wilaya_id": "34",
+     "code_postal": "34014"
+    },
+    {
+     "longitude": 4.6628371,
+     "latitude": 36.2922699,
+     "nom": "Djaafra",
+     "id": "1178",
+     "wilaya_id": "34",
+     "code_postal": "34015"
+    },
+    {
+     "longitude": 4.738017,
+     "latitude": 36.3719865,
+     "nom": "El Main",
+     "id": "1179",
+     "wilaya_id": "34",
+     "code_postal": "34016"
+    },
+    {
+     "longitude": 5.080691799999999,
+     "latitude": 35.8733817,
+     "nom": "Ouled Brahem",
+     "id": "1180",
+     "wilaya_id": "34",
+     "code_postal": "34017"
+    },
+    {
+     "longitude": 4.7701642,
+     "latitude": 36.2214873,
+     "nom": "Ouled Dahmane",
+     "id": "1181",
+     "wilaya_id": "34",
+     "code_postal": "34018"
+    },
+    {
+     "longitude": 4.7955348,
+     "latitude": 36.1520672,
+     "nom": "Hasnaoua",
+     "id": "1182",
+     "wilaya_id": "34",
+     "code_postal": "34019"
+    },
+    {
+     "longitude": 4.997446099999999,
+     "latitude": 36.2240477,
+     "nom": "Khelil",
+     "id": "1183",
+     "wilaya_id": "34",
+     "code_postal": "34020"
+    },
+    {
+     "longitude": 4.9870491,
+     "latitude": 35.8011473,
+     "nom": "Taglait",
+     "id": "1184",
+     "wilaya_id": "34",
+     "code_postal": "34021"
+    },
+    {
+     "longitude": 4.5956667,
+     "latitude": 35.9921303,
+     "nom": "Ksour",
+     "id": "1185",
+     "wilaya_id": "34",
+     "code_postal": "34022"
+    },
+    {
+     "longitude": 4.3340554,
+     "latitude": 36.2289906,
+     "nom": "Ouled Sidi Brahim",
+     "id": "1186",
+     "wilaya_id": "34",
+     "code_postal": "34023"
+    },
+    {
+     "longitude": 4.6657027,
+     "latitude": 36.2374167,
+     "nom": "Colla",
+     "id": "1188",
+     "wilaya_id": "34",
+     "code_postal": "34025"
+    },
+    {
+     "longitude": 5.1223608,
+     "latitude": 36.0453882,
+     "nom": "Tixter",
+     "id": "1189",
+     "wilaya_id": "34",
+     "code_postal": "34026"
+    },
+    {
+     "longitude": 4.624375100000001,
+     "latitude": 35.8917787,
+     "nom": "El Ach",
+     "id": "1190",
+     "wilaya_id": "34",
+     "code_postal": "34027"
+    },
+    {
+     "longitude": 4.8013775,
+     "latitude": 36.0470339,
+     "nom": "El Anseur",
+     "id": "1191",
+     "wilaya_id": "34",
+     "code_postal": "34028"
+    },
+    {
+     "longitude": 4.800233299999999,
+     "latitude": 36.2645778,
+     "nom": "Tesmart",
+     "id": "1192",
+     "wilaya_id": "34",
+     "code_postal": "34029"
+    },
+    {
+     "longitude": 5.002327,
+     "latitude": 36.0367494,
+     "nom": "Ain Tesra",
+     "id": "1193",
+     "wilaya_id": "34",
+     "code_postal": "34030"
+    },
+    {
+     "longitude": 5.027662299999999,
+     "latitude": 36.1463398,
+     "nom": "Bir Kasdali",
+     "id": "1194",
+     "wilaya_id": "34",
+     "code_postal": "34031"
+    },
+    {
+     "longitude": 4.9039424,
+     "latitude": 35.8480848,
+     "nom": "Ghilassa",
+     "id": "1195",
+     "wilaya_id": "34",
+     "code_postal": "34032"
+    },
+    {
+     "longitude": 4.7795149,
+     "latitude": 35.8965925,
+     "nom": "Rabta",
+     "id": "1196",
+     "wilaya_id": "34",
+     "code_postal": "34033"
+    },
+    {
+     "longitude": 4.2538452,
+     "latitude": 36.1660564,
+     "nom": "Haraza",
+     "id": "1197",
+     "wilaya_id": "34",
+     "code_postal": "34034"
+    },
+    {
+     "longitude": 3.4851867,
+     "latitude": 36.7580109,
+     "nom": "Boumerdes",
+     "id": "1198",
+     "wilaya_id": "35",
+     "code_postal": "35001"
+    },
+    {
+     "longitude": 3.4296446,
+     "latitude": 36.7003998,
+     "nom": "Boudouaou",
+     "id": "1199",
+     "wilaya_id": "35",
+     "code_postal": "35002"
+    },
+    {
+     "longitude": 3.9897847,
+     "latitude": 36.8433446,
+     "nom": "Afir",
+     "id": "1200",
+     "wilaya_id": "35",
+     "code_postal": "35004"
+    },
+    {
+     "longitude": 3.753666299999999,
+     "latitude": 36.7552496,
+     "nom": "Bordj Menaiel",
+     "id": "1201",
+     "wilaya_id": "35",
+     "code_postal": "35005"
+    },
+    {
+     "longitude": 3.8757119,
+     "latitude": 36.7943784,
+     "nom": "Baghlia",
+     "id": "1202",
+     "wilaya_id": "35",
+     "code_postal": "35006"
+    },
+    {
+     "longitude": 3.8583028,
+     "latitude": 36.85560630000001,
+     "nom": "Sidi Daoud",
+     "id": "1203",
+     "wilaya_id": "35",
+     "code_postal": "35007"
+    },
+    {
+     "longitude": 3.8146526,
+     "latitude": 36.7317908,
+     "nom": "Naciria",
+     "id": "1204",
+     "wilaya_id": "35",
+     "code_postal": "35008"
+    },
+    {
+     "longitude": 3.7333537,
+     "latitude": 36.8419263,
+     "nom": "Djinet",
+     "id": "1205",
+     "wilaya_id": "35",
+     "code_postal": "35009"
+    },
+    {
+     "longitude": 3.6724649,
+     "latitude": 36.6931797,
+     "nom": "Isser",
+     "id": "1206",
+     "wilaya_id": "35",
+     "code_postal": "35010"
+    },
+    {
+     "longitude": 3.6010514,
+     "latitude": 36.7859638,
+     "nom": "Zemmouri",
+     "id": "1207",
+     "wilaya_id": "35",
+     "code_postal": "35011"
+    },
+    {
+     "longitude": 3.6116494,
+     "latitude": 36.7381058,
+     "nom": "Si Mustapha",
+     "id": "1208",
+     "wilaya_id": "35",
+     "code_postal": "35012"
+    },
+    {
+     "longitude": 3.4902391,
+     "latitude": 36.720184,
+     "nom": "Tidjelabine",
+     "id": "1209",
+     "wilaya_id": "35",
+     "code_postal": "35013"
+    },
+    {
+     "longitude": 3.682608,
+     "latitude": 36.6174343,
+     "nom": "Chabet El Ameur",
+     "id": "1210",
+     "wilaya_id": "35",
+     "code_postal": "35014"
+    },
+    {
+     "longitude": 3.5509074,
+     "latitude": 36.7399281,
+     "nom": "Thenia",
+     "id": "1211",
+     "wilaya_id": "35",
+     "code_postal": "35015"
+    },
+    {
+     "longitude": 3.7993992,
+     "latitude": 36.662278,
+     "nom": "Timezrit",
+     "id": "1212",
+     "wilaya_id": "35",
+     "code_postal": "35018"
+    },
+    {
+     "longitude": 3.4447863,
+     "latitude": 36.73765480000001,
+     "nom": "Corso",
+     "id": "1213",
+     "wilaya_id": "35",
+     "code_postal": "35019"
+    },
+    {
+     "longitude": 3.3892894,
+     "latitude": 36.6800054,
+     "nom": "Ouled Moussa",
+     "id": "1214",
+     "wilaya_id": "35",
+     "code_postal": "35020"
+    },
+    {
+     "longitude": 3.371541,
+     "latitude": 36.636145,
+     "nom": "Larbatache",
+     "id": "1215",
+     "wilaya_id": "35",
+     "code_postal": "35021"
+    },
+    {
+     "longitude": 3.4789503,
+     "latitude": 36.6261517,
+     "nom": "Bouzegza Keddara",
+     "id": "1216",
+     "wilaya_id": "35",
+     "code_postal": "35022"
+    },
+    {
+     "longitude": 3.9368439,
+     "latitude": 36.7923763,
+     "nom": "Taourga",
+     "id": "1217",
+     "wilaya_id": "35",
+     "code_postal": "35025"
+    },
+    {
+     "longitude": 3.8146526,
+     "latitude": 36.79634679999999,
+     "nom": "Ouled Aissa",
+     "id": "1218",
+     "wilaya_id": "35",
+     "code_postal": "35026"
+    },
+    {
+     "longitude": 3.9011747,
+     "latitude": 36.8526735,
+     "nom": "Ben Choud",
+     "id": "1219",
+     "wilaya_id": "35",
+     "code_postal": "35027"
+    },
+    {
+     "longitude": 3.9368439,
+     "latitude": 36.8783599,
+     "nom": "Dellys",
+     "id": "1220",
+     "wilaya_id": "35",
+     "code_postal": "35028"
+    },
+    {
+     "longitude": 3.5913939,
+     "latitude": 36.6309911,
+     "nom": "Ammal",
+     "id": "1221",
+     "wilaya_id": "35",
+     "code_postal": "35029"
+    },
+    {
+     "longitude": 3.5762077,
+     "latitude": 36.65839270000001,
+     "nom": "Beni Amrane",
+     "id": "1222",
+     "wilaya_id": "35",
+     "code_postal": "35030"
+    },
+    {
+     "longitude": 3.5863313,
+     "latitude": 36.69041170000001,
+     "nom": "Souk El Had",
+     "id": "1223",
+     "wilaya_id": "35",
+     "code_postal": "35031"
+    },
+    {
+     "longitude": 3.394332,
+     "latitude": 36.7606292,
+     "nom": "Boudouaou El Bahri",
+     "id": "1224",
+     "wilaya_id": "35",
+     "code_postal": "35032"
+    },
+    {
+     "longitude": 3.3439291,
+     "latitude": 36.7082162,
+     "nom": "Ouled Hedadj",
+     "id": "1225",
+     "wilaya_id": "35",
+     "code_postal": "35033"
+    },
+    {
+     "longitude": 3.2633918,
+     "latitude": 36.6781231,
+     "nom": "Hammedi",
+     "id": "1227",
+     "wilaya_id": "35",
+     "code_postal": "35036"
+    },
+    {
+     "longitude": 3.3288183,
+     "latitude": 36.6385933,
+     "nom": "Khemis El Khechna",
+     "id": "1228",
+     "wilaya_id": "35",
+     "code_postal": "35037"
+    },
+    {
+     "longitude": 3.4296446,
+     "latitude": 36.6141776,
+     "nom": "El Kharrouba",
+     "id": "1229",
+     "wilaya_id": "35",
+     "code_postal": "35038"
+    },
+    {
+     "longitude": 8.2869478,
+     "latitude": 36.7298829,
+     "nom": "El Tarf",
+     "id": "1230",
+     "wilaya_id": "36",
+     "code_postal": "36001"
+    },
+    {
+     "longitude": 8.112011599999999,
+     "latitude": 36.5275079,
+     "nom": "Bouhadjar",
+     "id": "1231",
+     "wilaya_id": "36",
+     "code_postal": "36002"
+    },
+    {
+     "longitude": 7.981084500000001,
+     "latitude": 36.7508388,
+     "nom": "Ben Mhidi",
+     "id": "1232",
+     "wilaya_id": "36",
+     "code_postal": "36003"
+    },
+    {
+     "longitude": 8.374571699999999,
+     "latitude": 36.68089880000001,
+     "nom": "Bougous",
+     "id": "1233",
+     "wilaya_id": "36",
+     "code_postal": "36004"
+    },
+    {
+     "longitude": 8.4450763,
+     "latitude": 36.8904568,
+     "nom": "El Kala",
+     "id": "1234",
+     "wilaya_id": "36",
+     "code_postal": "36005"
+    },
+    {
+     "longitude": 8.4293891,
+     "latitude": 36.7947505,
+     "nom": "Ain El Assel",
+     "id": "1235",
+     "wilaya_id": "36",
+     "code_postal": "36006"
+    },
+    {
+     "longitude": 8.6270628,
+     "latitude": 36.8232929,
+     "nom": "El Aioun",
+     "id": "1236",
+     "wilaya_id": "36",
+     "code_postal": "36007"
+    },
+    {
+     "longitude": 8.1994276,
+     "latitude": 36.7787756,
+     "nom": "Bouteldja",
+     "id": "1237",
+     "wilaya_id": "36",
+     "code_postal": "36008"
+    },
+    {
+     "longitude": 8.5940814,
+     "latitude": 36.8791039,
+     "nom": "Souarekh",
+     "id": "1238",
+     "wilaya_id": "36",
+     "code_postal": "36009"
+    },
+    {
+     "longitude": 8.068343,
+     "latitude": 36.8305549,
+     "nom": "Berrihane",
+     "id": "1239",
+     "wilaya_id": "36",
+     "code_postal": "36010"
+    },
+    {
+     "longitude": 8.101092000000001,
+     "latitude": 36.7748272,
+     "nom": "Lac Des Oiseaux",
+     "id": "1240",
+     "wilaya_id": "36",
+     "code_postal": "36011"
+    },
+    {
+     "longitude": 8.112011599999999,
+     "latitude": 36.6562562,
+     "nom": "Chefia",
+     "id": "1241",
+     "wilaya_id": "36",
+     "code_postal": "36012"
+    },
+    {
+     "longitude": 7.730807,
+     "latitude": 36.6923855,
+     "nom": "Drean",
+     "id": "1242",
+     "wilaya_id": "36",
+     "code_postal": "36013"
+    },
+    {
+     "longitude": 7.850395099999999,
+     "latitude": 36.6309261,
+     "nom": "Chihani",
+     "id": "1243",
+     "wilaya_id": "36",
+     "code_postal": "36014"
+    },
+    {
+     "longitude": 7.7090854,
+     "latitude": 36.7366692,
+     "nom": "Chebaita Mokhtar",
+     "id": "1244",
+     "wilaya_id": "36",
+     "code_postal": "36015"
+    },
+    {
+     "longitude": 7.806885100000001,
+     "latitude": 36.7195675,
+     "nom": "Besbes",
+     "id": "1245",
+     "wilaya_id": "36",
+     "code_postal": "36016"
+    },
+    {
+     "longitude": 7.981084500000001,
+     "latitude": 36.6651214,
+     "nom": "Asfour",
+     "id": "1246",
+     "wilaya_id": "36",
+     "code_postal": "36017"
+    },
+    {
+     "longitude": 7.861276699999999,
+     "latitude": 36.8123586,
+     "nom": "Echatt",
+     "id": "1247",
+     "wilaya_id": "36",
+     "code_postal": "36018"
+    },
+    {
+     "longitude": 7.904820000000001,
+     "latitude": 36.7238061,
+     "nom": "Zerizer",
+     "id": "1248",
+     "wilaya_id": "36",
+     "code_postal": "36019"
+    },
+    {
+     "longitude": 8.243174699999999,
+     "latitude": 36.6472292,
+     "nom": "Zitouna",
+     "id": "1249",
+     "wilaya_id": "36",
+     "code_postal": "36020"
+    },
+    {
+     "longitude": 8.1994276,
+     "latitude": 36.5644539,
+     "nom": "Ain Kerma",
+     "id": "1250",
+     "wilaya_id": "36",
+     "code_postal": "36021"
+    },
+    {
+     "longitude": 8.0356087,
+     "latitude": 36.4359809,
+     "nom": "Oued Zitoun",
+     "id": "1251",
+     "wilaya_id": "36",
+     "code_postal": "36022"
+    },
+    {
+     "longitude": 7.981084500000001,
+     "latitude": 36.536361,
+     "nom": "Hammam Beni Salah",
+     "id": "1252",
+     "wilaya_id": "36",
+     "code_postal": "36023"
+    },
+    {
+     "longitude": 8.5355489,
+     "latitude": 36.7865239,
+     "nom": "Raml Souk",
+     "id": "1253",
+     "wilaya_id": "36",
+     "code_postal": "36024"
+    },
+    {
+     "longitude": -8.1276526,
+     "latitude": 27.6761012,
+     "nom": "Tindouf",
+     "id": "1254",
+     "wilaya_id": "37",
+     "code_postal": "37001"
+    },
+    {
+     "longitude": -5.393955099999999,
+     "latitude": 28.1934255,
+     "nom": "Oum El Assel",
+     "id": "1255",
+     "wilaya_id": "37",
+     "code_postal": "37002"
+    },
+    {
+     "longitude": 1.8074586,
+     "latitude": 35.6015182,
+     "nom": "Tissemsilt",
+     "id": "1256",
+     "wilaya_id": "38",
+     "code_postal": "38001"
+    },
+    {
+     "longitude": 1.615375,
+     "latitude": 35.8526248,
+     "nom": "Bordj Bou Naama",
+     "id": "1257",
+     "wilaya_id": "38",
+     "code_postal": "38002"
+    },
+    {
+     "longitude": 2.0077316,
+     "latitude": 35.8767044,
+     "nom": "Theniet El Had",
+     "id": "1258",
+     "wilaya_id": "38",
+     "code_postal": "38003"
+    },
+    {
+     "longitude": 1.5620347,
+     "latitude": 35.9350445,
+     "nom": "Lazharia",
+     "id": "1259",
+     "wilaya_id": "38",
+     "code_postal": "38004"
+    },
+    {
+     "longitude": 1.5450766,
+     "latitude": 35.7471861,
+     "nom": "Lardjem",
+     "id": "1261",
+     "wilaya_id": "38",
+     "code_postal": "38006"
+    },
+    {
+     "longitude": 1.3360772,
+     "latitude": 35.7128273,
+     "nom": "Melaab",
+     "id": "1262",
+     "wilaya_id": "38",
+     "code_postal": "38007"
+    },
+    {
+     "longitude": 1.5064654,
+     "latitude": 35.6961771,
+     "nom": "Sidi Lantri",
+     "id": "1263",
+     "wilaya_id": "38",
+     "code_postal": "38008"
+    },
+    {
+     "longitude": 2.2605775,
+     "latitude": 35.864058,
+     "nom": "Bordj El Emir Abdelkader",
+     "id": "1264",
+     "wilaya_id": "38",
+     "code_postal": "38009"
+    },
+    {
+     "longitude": 1.9954938,
+     "latitude": 35.6887221,
+     "nom": "Layoune",
+     "id": "1265",
+     "wilaya_id": "38",
+     "code_postal": "38010"
+    },
+    {
+     "longitude": 1.961246,
+     "latitude": 35.6674352,
+     "nom": "Khemisti",
+     "id": "1266",
+     "wilaya_id": "38",
+     "code_postal": "38011"
+    },
+    {
+     "longitude": 1.866667,
+     "latitude": 35.683333,
+     "nom": "Ouled Bessem",
+     "id": "1267",
+     "wilaya_id": "38",
+     "code_postal": "38012"
+    },
+    {
+     "longitude": 1.7510636,
+     "latitude": 35.6725615,
+     "nom": "Ammari",
+     "id": "1268",
+     "wilaya_id": "38",
+     "code_postal": "38013"
+    },
+    {
+     "longitude": 2.1125019,
+     "latitude": 35.947749,
+     "nom": "Youssoufia",
+     "id": "1269",
+     "wilaya_id": "38",
+     "code_postal": "38014"
+    },
+    {
+     "longitude": 1.9484098,
+     "latitude": 35.8252207,
+     "nom": "Sidi Boutouchent",
+     "id": "1270",
+     "wilaya_id": "38",
+     "code_postal": "38015"
+    },
+    {
+     "longitude": 1.7076637,
+     "latitude": 35.7422684,
+     "nom": "Sidi Abed",
+     "id": "1273",
+     "wilaya_id": "38",
+     "code_postal": "38018"
+    },
+    {
+     "longitude": 1.6842771,
+     "latitude": 35.8651956,
+     "nom": "Sidi Slimane",
+     "id": "1275",
+     "wilaya_id": "38",
+     "code_postal": "38020"
+    },
+    {
+     "longitude": 1.615375,
+     "latitude": 35.8907698,
+     "nom": "Boucaid",
+     "id": "1276",
+     "wilaya_id": "38",
+     "code_postal": "38021"
+    },
+    {
+     "longitude": 1.6894332,
+     "latitude": 35.8148108,
+     "nom": "Beni Lahcene",
+     "id": "1277",
+     "wilaya_id": "38",
+     "code_postal": "38022"
+    },
+    {
+     "longitude": 6.8479682,
+     "latitude": 33.3713397,
+     "nom": "El Oued",
+     "id": "1278",
+     "wilaya_id": "39",
+     "code_postal": "39001"
+    },
+    {
+     "longitude": 6.9048148,
+     "latitude": 33.2859695,
+     "nom": "Robbah",
+     "id": "1279",
+     "wilaya_id": "39",
+     "code_postal": "39002"
+    },
+    {
+     "longitude": 6.7547522,
+     "latitude": 33.2383162,
+     "nom": "Oued El Alenda",
+     "id": "1280",
+     "wilaya_id": "39",
+     "code_postal": "39003"
+    },
+    {
+     "longitude": 6.8930418,
+     "latitude": 33.3209357,
+     "nom": "Bayadha",
+     "id": "1281",
+     "wilaya_id": "39",
+     "code_postal": "39004"
+    },
+    {
+     "longitude": 6.9504378,
+     "latitude": 33.2806326,
+     "nom": "Nakhla",
+     "id": "1282",
+     "wilaya_id": "39",
+     "code_postal": "39005"
+    },
+    {
+     "longitude": 6.8029489,
+     "latitude": 33.5092788,
+     "nom": "Guemar",
+     "id": "1283",
+     "wilaya_id": "39",
+     "code_postal": "39006"
+    },
+    {
+     "longitude": 6.829740300000001,
+     "latitude": 33.4018134,
+     "nom": "Kouinine",
+     "id": "1284",
+     "wilaya_id": "39",
+     "code_postal": "39007"
+    },
+    {
+     "longitude": 6.722640999999999,
+     "latitude": 33.5638323,
+     "nom": "Reguiba",
+     "id": "1285",
+     "wilaya_id": "39",
+     "code_postal": "39008"
+    },
+    {
+     "longitude": 6.2303867,
+     "latitude": 34.1108764,
+     "nom": "Hamraia",
+     "id": "1286",
+     "wilaya_id": "39",
+     "code_postal": "39009"
+    },
+    {
+     "longitude": 6.797592,
+     "latitude": 33.470536,
+     "nom": "Taghzout",
+     "id": "1287",
+     "wilaya_id": "39",
+     "code_postal": "39010"
+    },
+    {
+     "longitude": 6.952532799999999,
+     "latitude": 33.5148096,
+     "nom": "Debila",
+     "id": "1288",
+     "wilaya_id": "39",
+     "code_postal": "39011"
+    },
+    {
+     "longitude": 6.894084599999999,
+     "latitude": 33.4763609,
+     "nom": "Hassani Abdelkrim",
+     "id": "1289",
+     "wilaya_id": "39",
+     "code_postal": "39012"
+    },
+    {
+     "longitude": 6.9907197,
+     "latitude": 33.5601263,
+     "nom": "Hassi Khelifa",
+     "id": "1290",
+     "wilaya_id": "39",
+     "code_postal": "39013"
+    },
+    {
+     "longitude": 7.394882000000001,
+     "latitude": 33.7091203,
+     "nom": "Taleb Larbi",
+     "id": "1291",
+     "wilaya_id": "39",
+     "code_postal": "39014"
+    },
+    {
+     "longitude": 7.6114217,
+     "latitude": 32.6678571,
+     "nom": "Douar El Ma",
+     "id": "1292",
+     "wilaya_id": "39",
+     "code_postal": "39015"
+    },
+    {
+     "longitude": 6.9067231,
+     "latitude": 33.5451746,
+     "nom": "Sidi Aoun",
+     "id": "1293",
+     "wilaya_id": "39",
+     "code_postal": "39016"
+    },
+    {
+     "longitude": 6.935674,
+     "latitude": 33.4196537,
+     "nom": "Trifaoui",
+     "id": "1294",
+     "wilaya_id": "39",
+     "code_postal": "39017"
+    },
+    {
+     "longitude": 6.9308492,
+     "latitude": 33.56150909999999,
+     "nom": "Magrane",
+     "id": "1295",
+     "wilaya_id": "39",
+     "code_postal": "39018"
+    },
+    {
+     "longitude": 7.179025999999999,
+     "latitude": 34.0327057,
+     "nom": "Beni Guecha",
+     "id": "1296",
+     "wilaya_id": "39",
+     "code_postal": "39019"
+    },
+    {
+     "longitude": 6.7828626,
+     "latitude": 33.4141525,
+     "nom": "Ourmas",
+     "id": "1297",
+     "wilaya_id": "39",
+     "code_postal": "39020"
+    },
+    {
+     "longitude": 5.772120399999999,
+     "latitude": 34.3284258,
+     "nom": "Still",
+     "id": "1298",
+     "wilaya_id": "39",
+     "code_postal": "39021"
+    },
+    {
+     "longitude": 5.6628859,
+     "latitude": 33.4703125,
+     "nom": "Mrara",
+     "id": "1299",
+     "wilaya_id": "39",
+     "code_postal": "39022"
+    },
+    {
+     "longitude": 5.9607892,
+     "latitude": 33.8381481,
+     "nom": "Sidi Khellil",
+     "id": "1300",
+     "wilaya_id": "39",
+     "code_postal": "39023"
+    },
+    {
+     "longitude": 6.033511400000001,
+     "latitude": 33.6745734,
+     "nom": "Tendla",
+     "id": "1301",
+     "wilaya_id": "39",
+     "code_postal": "39024"
+    },
+    {
+     "longitude": 6.943726600000001,
+     "latitude": 33.2460788,
+     "nom": "El Ogla",
+     "id": "1302",
+     "wilaya_id": "39",
+     "code_postal": "39025"
+    },
+    {
+     "longitude": 6.707928700000001,
+     "latitude": 33.197504,
+     "nom": "Mih Ouansa",
+     "id": "1303",
+     "wilaya_id": "39",
+     "code_postal": "39026"
+    },
+    {
+     "longitude": 5.9304039,
+     "latitude": 33.9327331,
+     "nom": "El Mghair",
+     "id": "1304",
+     "wilaya_id": "39",
+     "code_postal": "39027"
+    },
+    {
+     "longitude": 5.986358600000001,
+     "latitude": 33.5383569,
+     "nom": "Djamaa",
+     "id": "1305",
+     "wilaya_id": "39",
+     "code_postal": "39028"
+    },
+    {
+     "longitude": 6.012463899999999,
+     "latitude": 33.499649,
+     "nom": "Sidi Amrane",
+     "id": "1307",
+     "wilaya_id": "39",
+     "code_postal": "39030"
+    },
+    {
+     "longitude": 7.1467072,
+     "latitude": 35.4309947,
+     "nom": "Khenchela",
+     "id": "1308",
+     "wilaya_id": "40",
+     "code_postal": "40001"
+    },
+    {
+     "longitude": 7.2450588,
+     "latitude": 35.6007746,
+     "nom": "Mtoussa",
+     "id": "1309",
+     "wilaya_id": "40",
+     "code_postal": "40002"
+    },
+    {
+     "longitude": 6.9262805,
+     "latitude": 35.4929142,
+     "nom": "Kais",
+     "id": "1310",
+     "wilaya_id": "40",
+     "code_postal": "40003"
+    },
+    {
+     "longitude": 7.113058199999999,
+     "latitude": 35.5215422,
+     "nom": "Baghai",
+     "id": "1311",
+     "wilaya_id": "40",
+     "code_postal": "40004"
+    },
+    {
+     "longitude": 7.0848063,
+     "latitude": 35.4646303,
+     "nom": "El Hamma",
+     "id": "1312",
+     "wilaya_id": "40",
+     "code_postal": "40005"
+    },
+    {
+     "longitude": 7.464693700000001,
+     "latitude": 35.44189190000001,
+     "nom": "Ain Touila",
+     "id": "1313",
+     "wilaya_id": "40",
+     "code_postal": "40006"
+    },
+    {
+     "longitude": 6.7467229,
+     "latitude": 35.3202828,
+     "nom": "Bouhmama",
+     "id": "1315",
+     "wilaya_id": "40",
+     "code_postal": "40008"
+    },
+    {
+     "longitude": 6.6831929,
+     "latitude": 34.9151135,
+     "nom": "El Oueldja",
+     "id": "1316",
+     "wilaya_id": "40",
+     "code_postal": "40009"
+    },
+    {
+     "longitude": 6.8981083,
+     "latitude": 35.5721583,
+     "nom": "Remila",
+     "id": "1317",
+     "wilaya_id": "40",
+     "code_postal": "40010"
+    },
+    {
+     "longitude": 7.0095263,
+     "latitude": 35.0372584,
+     "nom": "Cherchar",
+     "id": "1318",
+     "wilaya_id": "40",
+     "code_postal": "40011"
+    },
+    {
+     "longitude": 6.8927435,
+     "latitude": 34.9191877,
+     "nom": "Djellal",
+     "id": "1319",
+     "wilaya_id": "40",
+     "code_postal": "40012"
+    },
+    {
+     "longitude": 7.100948799999999,
+     "latitude": 35.1688096,
+     "nom": "Babar",
+     "id": "1320",
+     "wilaya_id": "40",
+     "code_postal": "40013"
+    },
+    {
+     "longitude": 6.833333,
+     "latitude": 35.316667,
+     "nom": "Tamza",
+     "id": "1321",
+     "wilaya_id": "40",
+     "code_postal": "40014"
+    },
+    {
+     "longitude": 7.1419953,
+     "latitude": 35.395142,
+     "nom": "Ensigha",
+     "id": "1322",
+     "wilaya_id": "40",
+     "code_postal": "40015"
+    },
+    {
+     "longitude": 7.352415399999999,
+     "latitude": 35.2956216,
+     "nom": "Ouled Rechache",
+     "id": "1323",
+     "wilaya_id": "40",
+     "code_postal": "40016"
+    },
+    {
+     "longitude": 6.574334899999999,
+     "latitude": 35.2382122,
+     "nom": "Msara",
+     "id": "1325",
+     "wilaya_id": "40",
+     "code_postal": "40018"
+    },
+    {
+     "longitude": 6.643769,
+     "latitude": 35.41198809999999,
+     "nom": "Yabous",
+     "id": "1326",
+     "wilaya_id": "40",
+     "code_postal": "40019"
+    },
+    {
+     "longitude": 6.760774899999999,
+     "latitude": 34.9986118,
+     "nom": "Khirane",
+     "id": "1327",
+     "wilaya_id": "40",
+     "code_postal": "40020"
+    },
+    {
+     "longitude": 6.7801849,
+     "latitude": 35.3634675,
+     "nom": "Chelia",
+     "id": "1328",
+     "wilaya_id": "40",
+     "code_postal": "40021"
+    },
+    {
+     "longitude": 7.948389799999999,
+     "latitude": 36.2695872,
+     "nom": "Souk Ahras",
+     "id": "1329",
+     "wilaya_id": "41",
+     "code_postal": "41001"
+    },
+    {
+     "longitude": 7.532566000000001,
+     "latitude": 36.13085600000001,
+     "nom": "Sedrata",
+     "id": "1330",
+     "wilaya_id": "41",
+     "code_postal": "41002"
+    },
+    {
+     "longitude": 7.7878579,
+     "latitude": 36.261304,
+     "nom": "Hanancha",
+     "id": "1331",
+     "wilaya_id": "41",
+     "code_postal": "41003"
+    },
+    {
+     "longitude": 7.835435500000001,
+     "latitude": 36.3565044,
+     "nom": "Mechroha",
+     "id": "1332",
+     "wilaya_id": "41",
+     "code_postal": "41004"
+    },
+    {
+     "longitude": 7.7878579,
+     "latitude": 36.1911936,
+     "nom": "Tiffech",
+     "id": "1334",
+     "wilaya_id": "41",
+     "code_postal": "41006"
+    },
+    {
+     "longitude": 7.956561999999999,
+     "latitude": 36.228617,
+     "nom": "Zaarouria",
+     "id": "1335",
+     "wilaya_id": "41",
+     "code_postal": "41007"
+    },
+    {
+     "longitude": 8.0437909,
+     "latitude": 36.163447,
+     "nom": "Taoura",
+     "id": "1336",
+     "wilaya_id": "41",
+     "code_postal": "41008"
+    },
+    {
+     "longitude": 7.8816843,
+     "latitude": 36.1216219,
+     "nom": "Drea",
+     "id": "1337",
+     "wilaya_id": "41",
+     "code_postal": "41009"
+    },
+    {
+     "longitude": 8.333485099999999,
+     "latitude": 36.229847,
+     "nom": "Haddada",
+     "id": "1338",
+     "wilaya_id": "41",
+     "code_postal": "41010"
+    },
+    {
+     "longitude": 8.3225325,
+     "latitude": 36.284474,
+     "nom": "Khedara",
+     "id": "1339",
+     "wilaya_id": "41",
+     "code_postal": "41011"
+    },
+    {
+     "longitude": 8.150243300000001,
+     "latitude": 36.1966832,
+     "nom": "Merahna",
+     "id": "1340",
+     "wilaya_id": "41",
+     "code_postal": "41012"
+    },
+    {
+     "longitude": 8.3307468,
+     "latitude": 36.3834462,
+     "nom": "Ouled Moumen",
+     "id": "1341",
+     "wilaya_id": "41",
+     "code_postal": "41013"
+    },
+    {
+     "longitude": 7.4300234,
+     "latitude": 36.0140333,
+     "nom": "Bir Bouhouche",
+     "id": "1342",
+     "wilaya_id": "41",
+     "code_postal": "41014"
+    },
+    {
+     "longitude": 7.8204791,
+     "latitude": 36.0756762,
+     "nom": "Mdaourouche",
+     "id": "1343",
+     "wilaya_id": "41",
+     "code_postal": "41015"
+    },
+    {
+     "longitude": 7.6032892,
+     "latitude": 36.0302067,
+     "nom": "Oum El Adhaim",
+     "id": "1344",
+     "wilaya_id": "41",
+     "code_postal": "41016"
+    },
+    {
+     "longitude": 8.1912279,
+     "latitude": 36.4011867,
+     "nom": "Ain Zana",
+     "id": "1345",
+     "wilaya_id": "41",
+     "code_postal": "41017"
+    },
+    {
+     "longitude": 7.4915642,
+     "latitude": 35.9296769,
+     "nom": "Safel El Ouiden",
+     "id": "1349",
+     "wilaya_id": "41",
+     "code_postal": "41021"
+    },
+    {
+     "longitude": 7.6520984,
+     "latitude": 36.194568,
+     "nom": "Khemissa",
+     "id": "1351",
+     "wilaya_id": "41",
+     "code_postal": "41023"
+    },
+    {
+     "longitude": 7.917071299999999,
+     "latitude": 35.9246613,
+     "nom": "Oued Keberit",
+     "id": "1352",
+     "wilaya_id": "41",
+     "code_postal": "41024"
+    },
+    {
+     "longitude": 7.597868099999999,
+     "latitude": 35.884391,
+     "nom": "Terraguelt",
+     "id": "1353",
+     "wilaya_id": "41",
+     "code_postal": "41025"
+    },
+    {
+     "longitude": 8.1378124,
+     "latitude": 35.9596833,
+     "nom": "Zouabi",
+     "id": "1354",
+     "wilaya_id": "41",
+     "code_postal": "41026"
+    },
+    {
+     "longitude": 2.3912362,
+     "latitude": 36.6178786,
+     "nom": "Tipaza",
+     "id": "1355",
+     "wilaya_id": "42",
+     "code_postal": "42001"
+    },
+    {
+     "longitude": 2.2433487,
+     "latitude": 36.4803387,
+     "nom": "Menaceur",
+     "id": "1356",
+     "wilaya_id": "42",
+     "code_postal": "42002"
+    },
+    {
+     "longitude": 1.8023093,
+     "latitude": 36.5570162,
+     "nom": "Larhat",
+     "id": "1357",
+     "wilaya_id": "42",
+     "code_postal": "42003"
+    },
+    {
+     "longitude": 2.7972634,
+     "latitude": 36.6785804,
+     "nom": "Douaouda",
+     "id": "1358",
+     "wilaya_id": "42",
+     "code_postal": "42004"
+    },
+    {
+     "longitude": 2.5098914,
+     "latitude": 36.4858595,
+     "nom": "Bourkika",
+     "id": "1359",
+     "wilaya_id": "42",
+     "code_postal": "42005"
+    },
+    {
+     "longitude": 2.6834778,
+     "latitude": 36.6170732,
+     "nom": "Khemisti",
+     "id": "1360",
+     "wilaya_id": "42",
+     "code_postal": "42006"
+    },
+    {
+     "longitude": 2.4141276,
+     "latitude": 36.5124409,
+     "nom": "Hadjout",
+     "id": "1362",
+     "wilaya_id": "42",
+     "code_postal": "42012"
+    },
+    {
+     "longitude": 2.3123031,
+     "latitude": 36.5330597,
+     "nom": "Sidi Amar",
+     "id": "1363",
+     "wilaya_id": "42",
+     "code_postal": "42013"
+    },
+    {
+     "longitude": 1.9294681,
+     "latitude": 36.5290373,
+     "nom": "Gouraya",
+     "id": "1364",
+     "wilaya_id": "42",
+     "code_postal": "42014"
+    },
+    {
+     "longitude": 2.3665549,
+     "latitude": 36.5805948,
+     "nom": "Nodor",
+     "id": "1365",
+     "wilaya_id": "42",
+     "code_postal": "42015"
+    },
+    {
+     "longitude": 2.728219,
+     "latitude": 36.6106665,
+     "nom": "Chaiba",
+     "id": "1366",
+     "wilaya_id": "42",
+     "code_postal": "42016"
+    },
+    {
+     "longitude": 2.5842062,
+     "latitude": 36.5868863,
+     "nom": "Ain Tagourait",
+     "id": "1367",
+     "wilaya_id": "42",
+     "code_postal": "42017"
+    },
+    {
+     "longitude": 2.2039933,
+     "latitude": 36.567504,
+     "nom": "Cherchel",
+     "id": "1368",
+     "wilaya_id": "42",
+     "code_postal": "42022"
+    },
+    {
+     "longitude": 1.7052325,
+     "latitude": 36.5000176,
+     "nom": "Damous",
+     "id": "1369",
+     "wilaya_id": "42",
+     "code_postal": "42023"
+    },
+    {
+     "longitude": 2.3714901,
+     "latitude": 36.4670595,
+     "nom": "Meurad",
+     "id": "1370",
+     "wilaya_id": "42",
+     "code_postal": "42024"
+    },
+    {
+     "longitude": 2.7530936,
+     "latitude": 36.65863160000001,
+     "nom": "Fouka",
+     "id": "1371",
+     "wilaya_id": "42",
+     "code_postal": "42025"
+    },
+    {
+     "longitude": 2.7033575,
+     "latitude": 36.6381992,
+     "nom": "Bou Ismail",
+     "id": "1372",
+     "wilaya_id": "42",
+     "code_postal": "42026"
+    },
+    {
+     "longitude": 2.5693337,
+     "latitude": 36.5062122,
+     "nom": "Ahmer El Ain",
+     "id": "1373",
+     "wilaya_id": "42",
+     "code_postal": "42027"
+    },
+    {
+     "longitude": 2.6536742,
+     "latitude": 36.6177382,
+     "nom": "Bou Haroun",
+     "id": "1374",
+     "wilaya_id": "42",
+     "code_postal": "42030"
+    },
+    {
+     "longitude": 2.1155691,
+     "latitude": 36.5583006,
+     "nom": "Sidi Ghiles",
+     "id": "1375",
+     "wilaya_id": "42",
+     "code_postal": "42032"
+    },
+    {
+     "longitude": 2.0077316,
+     "latitude": 36.4845193,
+     "nom": "Messelmoun",
+     "id": "1376",
+     "wilaya_id": "42",
+     "code_postal": "42033"
+    },
+    {
+     "longitude": 2.5296971,
+     "latitude": 36.5502644,
+     "nom": "Sidi Rached",
+     "id": "1377",
+     "wilaya_id": "42",
+     "code_postal": "42034"
+    },
+    {
+     "longitude": 2.7708021,
+     "latitude": 36.6432441,
+     "nom": "Kolea",
+     "id": "1378",
+     "wilaya_id": "42",
+     "code_postal": "42035"
+    },
+    {
+     "longitude": 2.6387795,
+     "latitude": 36.558707,
+     "nom": "Attatba",
+     "id": "1379",
+     "wilaya_id": "42",
+     "code_postal": "42036"
+    },
+    {
+     "longitude": 2.086133,
+     "latitude": 36.4831797,
+     "nom": "Sidi Semiane",
+     "id": "1380",
+     "wilaya_id": "42",
+     "code_postal": "42040"
+    },
+    {
+     "longitude": 1.7344155,
+     "latitude": 36.4455299,
+     "nom": "Beni Milleuk",
+     "id": "1381",
+     "wilaya_id": "42",
+     "code_postal": "42041"
+    },
+    {
+     "longitude": 2.0567163,
+     "latitude": 36.5593263,
+     "nom": "Hadjerat Ennous",
+     "id": "1382",
+     "wilaya_id": "42",
+     "code_postal": "42042"
+    },
+    {
+     "longitude": 6.2535257,
+     "latitude": 36.4512301,
+     "nom": "Mila",
+     "id": "1383",
+     "wilaya_id": "43",
+     "code_postal": "43001"
+    },
+    {
+     "longitude": 5.9304039,
+     "latitude": 36.4084009,
+     "nom": "Ferdjioua",
+     "id": "1384",
+     "wilaya_id": "43",
+     "code_postal": "43002"
+    },
+    {
+     "longitude": 6.195132,
+     "latitude": 36.1464769,
+     "nom": "Chelghoum Laid",
+     "id": "1385",
+     "wilaya_id": "43",
+     "code_postal": "43003"
+    },
+    {
+     "longitude": 6.3438785,
+     "latitude": 36.2900333,
+     "nom": "Oued Athmenia",
+     "id": "1386",
+     "wilaya_id": "43",
+     "code_postal": "43004"
+    },
+    {
+     "longitude": 6.173911599999999,
+     "latitude": 36.2557129,
+     "nom": "Ain Mellouk",
+     "id": "1387",
+     "wilaya_id": "43",
+     "code_postal": "43005"
+    },
+    {
+     "longitude": 6.3438785,
+     "latitude": 36.0737429,
+     "nom": "Telerghma",
+     "id": "1388",
+     "wilaya_id": "43",
+     "code_postal": "43006"
+    },
+    {
+     "longitude": 6.429036,
+     "latitude": 36.199047,
+     "nom": "Oued Seguen",
+     "id": "1389",
+     "wilaya_id": "43",
+     "code_postal": "43007"
+    },
+    {
+     "longitude": 6.0044121,
+     "latitude": 36.1345369,
+     "nom": "Tadjenanet",
+     "id": "1390",
+     "wilaya_id": "43",
+     "code_postal": "43008"
+    },
+    {
+     "longitude": 6.0044121,
+     "latitude": 36.22109409999999,
+     "nom": "Benyahia Abderrahmane",
+     "id": "1391",
+     "wilaya_id": "43",
+     "code_postal": "43009"
+    },
+    {
+     "longitude": 6.2092318,
+     "latitude": 36.521883,
+     "nom": "Oued Endja",
+     "id": "1392",
+     "wilaya_id": "43",
+     "code_postal": "43010"
+    },
+    {
+     "longitude": 6.131492799999999,
+     "latitude": 36.3442991,
+     "nom": "Ahmed Rachedi",
+     "id": "1393",
+     "wilaya_id": "43",
+     "code_postal": "43011"
+    },
+    {
+     "longitude": 6.089103199999999,
+     "latitude": 36.00025370000001,
+     "nom": "Ouled Khalouf",
+     "id": "1394",
+     "wilaya_id": "43",
+     "code_postal": "43012"
+    },
+    {
+     "longitude": 6.0573302,
+     "latitude": 36.4020351,
+     "nom": "Tiberguent",
+     "id": "1395",
+     "wilaya_id": "43",
+     "code_postal": "43013"
+    },
+    {
+     "longitude": 6.0467429,
+     "latitude": 36.3054223,
+     "nom": "Bouhatem",
+     "id": "1396",
+     "wilaya_id": "43",
+     "code_postal": "43014"
+    },
+    {
+     "longitude": 5.993833899999999,
+     "latitude": 36.4699357,
+     "nom": "Rouached",
+     "id": "1397",
+     "wilaya_id": "43",
+     "code_postal": "43015"
+    },
+    {
+     "longitude": 6.317290600000001,
+     "latitude": 36.5232782,
+     "nom": "Grarem Gouga",
+     "id": "1399",
+     "wilaya_id": "43",
+     "code_postal": "43017"
+    },
+    {
+     "longitude": 6.2482149,
+     "latitude": 36.4999929,
+     "nom": "Sidi Merouane",
+     "id": "1400",
+     "wilaya_id": "43",
+     "code_postal": "43018"
+    },
+    {
+     "longitude": 5.7932008,
+     "latitude": 36.5337153,
+     "nom": "Tassadane Haddada",
+     "id": "1401",
+     "wilaya_id": "43",
+     "code_postal": "43019"
+    },
+    {
+     "longitude": 5.9198387,
+     "latitude": 36.3117689,
+     "nom": "Derradji Bousselah",
+     "id": "1402",
+     "wilaya_id": "43",
+     "code_postal": "43020"
+    },
+    {
+     "longitude": 5.9304039,
+     "latitude": 36.5377483,
+     "nom": "Minar Zarza",
+     "id": "1403",
+     "wilaya_id": "43",
+     "code_postal": "43021"
+    },
+    {
+     "longitude": 6.142094699999999,
+     "latitude": 36.5485751,
+     "nom": "Terrai Bainen",
+     "id": "1405",
+     "wilaya_id": "43",
+     "code_postal": "43023"
+    },
+    {
+     "longitude": 6.341219199999999,
+     "latitude": 36.5731327,
+     "nom": "Hamala",
+     "id": "1406",
+     "wilaya_id": "43",
+     "code_postal": "43024"
+    },
+    {
+     "longitude": 6.325265799999999,
+     "latitude": 36.3962417,
+     "nom": "Ain Tine",
+     "id": "1407",
+     "wilaya_id": "43",
+     "code_postal": "43025"
+    },
+    {
+     "longitude": 6.2163597,
+     "latitude": 36.0370883,
+     "nom": "El Mechira",
+     "id": "1408",
+     "wilaya_id": "43",
+     "code_postal": "43026"
+    },
+    {
+     "longitude": 6.2535257,
+     "latitude": 36.3649586,
+     "nom": "Sidi Khelifa",
+     "id": "1409",
+     "wilaya_id": "43",
+     "code_postal": "43027"
+    },
+    {
+     "longitude": 6.173911599999999,
+     "latitude": 36.4715385,
+     "nom": "Zeghaia",
+     "id": "1410",
+     "wilaya_id": "43",
+     "code_postal": "43028"
+    },
+    {
+     "longitude": 5.824835200000001,
+     "latitude": 36.4351668,
+     "nom": "Elayadi Barbes",
+     "id": "1411",
+     "wilaya_id": "43",
+     "code_postal": "43029"
+    },
+    {
+     "longitude": 5.8670405,
+     "latitude": 36.389948,
+     "nom": "Ain Beida Harriche",
+     "id": "1412",
+     "wilaya_id": "43",
+     "code_postal": "43030"
+    },
+    {
+     "longitude": 5.993833899999999,
+     "latitude": 36.383658,
+     "nom": "Yahia Beniguecha",
+     "id": "1413",
+     "wilaya_id": "43",
+     "code_postal": "43031"
+    },
+    {
+     "longitude": 6.2216678,
+     "latitude": 36.5605977,
+     "nom": "Chigara",
+     "id": "1414",
+     "wilaya_id": "43",
+     "code_postal": "43032"
+    },
+    {
+     "longitude": 1.9641065,
+     "latitude": 36.263186,
+     "nom": "Ain Defla",
+     "id": "1415",
+     "wilaya_id": "44",
+     "code_postal": "44001"
+    },
+    {
+     "longitude": 2.2335066,
+     "latitude": 36.3181921,
+     "nom": "Miliana",
+     "id": "1416",
+     "wilaya_id": "44",
+     "code_postal": "44002"
+    },
+    {
+     "longitude": 2.5197932,
+     "latitude": 36.3450137,
+     "nom": "Boumedfaa",
+     "id": "1417",
+     "wilaya_id": "44",
+     "code_postal": "44003"
+    },
+    {
+     "longitude": 2.2138289,
+     "latitude": 36.2535274,
+     "nom": "Khemis Miliana",
+     "id": "1418",
+     "wilaya_id": "44",
+     "code_postal": "44004"
+    },
+    {
+     "longitude": 2.3616203,
+     "latitude": 36.3915345,
+     "nom": "Hammam Righa",
+     "id": "1419",
+     "wilaya_id": "44",
+     "code_postal": "44005"
+    },
+    {
+     "longitude": 2.0469151,
+     "latitude": 36.3540148,
+     "nom": "Arib",
+     "id": "1420",
+     "wilaya_id": "44",
+     "code_postal": "44006"
+    },
+    {
+     "longitude": 2.086133,
+     "latitude": 36.1798746,
+     "nom": "Djelida",
+     "id": "1421",
+     "wilaya_id": "44",
+     "code_postal": "44007"
+    },
+    {
+     "longitude": 1.851343,
+     "latitude": 36.3571923,
+     "nom": "El Amra",
+     "id": "1422",
+     "wilaya_id": "44",
+     "code_postal": "44008"
+    },
+    {
+     "longitude": 1.9294681,
+     "latitude": 36.1824916,
+     "nom": "Bourached",
+     "id": "1423",
+     "wilaya_id": "44",
+     "code_postal": "44009"
+    },
+    {
+     "longitude": 1.7052325,
+     "latitude": 36.2184385,
+     "nom": "El Attaf",
+     "id": "1424",
+     "wilaya_id": "44",
+     "code_postal": "44010"
+    },
+    {
+     "longitude": 1.6566377,
+     "latitude": 36.2733492,
+     "nom": "El Abadia",
+     "id": "1425",
+     "wilaya_id": "44",
+     "code_postal": "44011"
+    },
+    {
+     "longitude": 2.4136924,
+     "latitude": 36.2181875,
+     "nom": "Djendel",
+     "id": "1426",
+     "wilaya_id": "44",
+     "code_postal": "44012"
+    },
+    {
+     "longitude": 2.5495112,
+     "latitude": 36.1383732,
+     "nom": "Oued Chorfa",
+     "id": "1427",
+     "wilaya_id": "44",
+     "code_postal": "44013"
+    },
+    {
+     "longitude": 2.4011124,
+     "latitude": 36.1305702,
+     "nom": "Ain Lechiakh",
+     "id": "1428",
+     "wilaya_id": "44",
+     "code_postal": "44014"
+    },
+    {
+     "longitude": 2.3616203,
+     "latitude": 36.04442969999999,
+     "nom": "Oued Djemaa",
+     "id": "1429",
+     "wilaya_id": "44",
+     "code_postal": "44015"
+    },
+    {
+     "longitude": 1.8220818,
+     "latitude": 36.2384198,
+     "nom": "Rouina",
+     "id": "1430",
+     "wilaya_id": "44",
+     "code_postal": "44016"
+    },
+    {
+     "longitude": 1.8220818,
+     "latitude": 36.1515977,
+     "nom": "Zeddine",
+     "id": "1431",
+     "wilaya_id": "44",
+     "code_postal": "44017"
+    },
+    {
+     "longitude": 1.9294681,
+     "latitude": 36.0086314,
+     "nom": "El Hassania",
+     "id": "1432",
+     "wilaya_id": "44",
+     "code_postal": "44018"
+    },
+    {
+     "longitude": 2.2138289,
+     "latitude": 36.1884431,
+     "nom": "Bir Ouled Khelifa",
+     "id": "1433",
+     "wilaya_id": "44",
+     "code_postal": "44019"
+    },
+    {
+     "longitude": 2.325157700000001,
+     "latitude": 36.23139030000001,
+     "nom": "Ain Soltane",
+     "id": "1434",
+     "wilaya_id": "44",
+     "code_postal": "44020"
+    },
+    {
+     "longitude": 2.1646722,
+     "latitude": 35.9611096,
+     "nom": "Tarik Ibn Ziad",
+     "id": "1435",
+     "wilaya_id": "44",
+     "code_postal": "44021"
+    },
+    {
+     "longitude": 2.1646722,
+     "latitude": 36.09160809999999,
+     "nom": "Bordj Emir Khaled",
+     "id": "1436",
+     "wilaya_id": "44",
+     "code_postal": "44022"
+    },
+    {
+     "longitude": 2.2827384,
+     "latitude": 36.3497591,
+     "nom": "Ain Torki",
+     "id": "1437",
+     "wilaya_id": "44",
+     "code_postal": "44023"
+    },
+    {
+     "longitude": 0.4431618,
+     "latitude": 36.1618701,
+     "nom": "Sidi Lakhdar",
+     "id": "1438",
+     "wilaya_id": "44",
+     "code_postal": "44024"
+    },
+    {
+     "longitude": 2.1646722,
+     "latitude": 36.3519477,
+     "nom": "Ben Allal",
+     "id": "1439",
+     "wilaya_id": "44",
+     "code_postal": "44025"
+    },
+    {
+     "longitude": 2.3764258,
+     "latitude": 36.3533538,
+     "nom": "Ain Benian",
+     "id": "1440",
+     "wilaya_id": "44",
+     "code_postal": "44026"
+    },
+    {
+     "longitude": 2.4011124,
+     "latitude": 36.3041215,
+     "nom": "Hoceinia",
+     "id": "1441",
+     "wilaya_id": "44",
+     "code_postal": "44027"
+    },
+    {
+     "longitude": 2.4900943,
+     "latitude": 36.0961767,
+     "nom": "Barbouche",
+     "id": "1442",
+     "wilaya_id": "44",
+     "code_postal": "44028"
+    },
+    {
+     "longitude": 2.0077316,
+     "latitude": 36.0943295,
+     "nom": "Djemaa Ouled Chikh",
+     "id": "1443",
+     "wilaya_id": "44",
+     "code_postal": "44029"
+    },
+    {
+     "longitude": 1.9588007,
+     "latitude": 36.3446556,
+     "nom": "Mekhatria",
+     "id": "1444",
+     "wilaya_id": "44",
+     "code_postal": "44030"
+    },
+    {
+     "longitude": 1.7830973,
+     "latitude": 35.9346997,
+     "nom": "Bathia",
+     "id": "1445",
+     "wilaya_id": "44",
+     "code_postal": "44031"
+    },
+    {
+     "longitude": 1.7733566,
+     "latitude": 36.3150386,
+     "nom": "Ain Bouyahia",
+     "id": "1447",
+     "wilaya_id": "44",
+     "code_postal": "44033"
+    },
+    {
+     "longitude": 1.7344155,
+     "latitude": 36.09858,
+     "nom": "El Maine",
+     "id": "1448",
+     "wilaya_id": "44",
+     "code_postal": "44034"
+    },
+    {
+     "longitude": 1.6469253,
+     "latitude": 36.1541243,
+     "nom": "Tiberkanine",
+     "id": "1449",
+     "wilaya_id": "44",
+     "code_postal": "44035"
+    },
+    {
+     "longitude": 1.8512951,
+     "latitude": 35.9824454,
+     "nom": "Belaas",
+     "id": "1450",
+     "wilaya_id": "44",
+     "code_postal": "44036"
+    },
+    {
+     "longitude": -0.3748354,
+     "latitude": 33.1683267,
+     "nom": "Naama",
+     "id": "1451",
+     "wilaya_id": "45",
+     "code_postal": "45001"
+    },
+    {
+     "longitude": -0.2762707,
+     "latitude": 33.5442772,
+     "nom": "Mechria",
+     "id": "1452",
+     "wilaya_id": "45",
+     "code_postal": "45002"
+    },
+    {
+     "longitude": -0.5778033,
+     "latitude": 32.75633320000001,
+     "nom": "Ain Sefra",
+     "id": "1453",
+     "wilaya_id": "45",
+     "code_postal": "45003"
+    },
+    {
+     "longitude": -0.4266584,
+     "latitude": 32.7682249,
+     "nom": "Tiout",
+     "id": "1454",
+     "wilaya_id": "45",
+     "code_postal": "45004"
+    },
+    {
+     "longitude": -0.9820667999999999,
+     "latitude": 32.8046166,
+     "nom": "Sfissifa",
+     "id": "1455",
+     "wilaya_id": "45",
+     "code_postal": "45005"
+    },
+    {
+     "longitude": -0.5754372999999999,
+     "latitude": 32.5161631,
+     "nom": "Moghrar",
+     "id": "1456",
+     "wilaya_id": "45",
+     "code_postal": "45006"
+    },
+    {
+     "longitude": -0.0793488,
+     "latitude": 33.005701,
+     "nom": "Assela",
+     "id": "1457",
+     "wilaya_id": "45",
+     "code_postal": "45007"
+    },
+    {
+     "longitude": -0.9438468,
+     "latitude": 32.397902,
+     "nom": "Djeniane Bourzeg",
+     "id": "1458",
+     "wilaya_id": "45",
+     "code_postal": "45008"
+    },
+    {
+     "longitude": -0.763049,
+     "latitude": 33.288551,
+     "nom": "Ain Ben Khelil",
+     "id": "1459",
+     "wilaya_id": "45",
+     "code_postal": "45009"
+    },
+    {
+     "longitude": -0.7271479000000001,
+     "latitude": 33.7189056,
+     "nom": "Makman Ben Amer",
+     "id": "1460",
+     "wilaya_id": "45",
+     "code_postal": "45010"
+    },
+    {
+     "longitude": -1.375755,
+     "latitude": 33.713589,
+     "nom": "Kasdir",
+     "id": "1461",
+     "wilaya_id": "45",
+     "code_postal": "45011"
+    },
+    {
+     "longitude": -0.1284404,
+     "latitude": 33.7600866,
+     "nom": "El Biod",
+     "id": "1462",
+     "wilaya_id": "45",
+     "code_postal": "45012"
+    },
+    {
+     "longitude": -1.1424514,
+     "latitude": 35.3072501,
+     "nom": "Ain Temouchent",
+     "id": "1463",
+     "wilaya_id": "46",
+     "code_postal": "46001"
+    },
+    {
+     "longitude": -1.1017334,
+     "latitude": 35.3361405,
+     "nom": "Chaabet El Ham",
+     "id": "1464",
+     "wilaya_id": "46",
+     "code_postal": "46002"
+    },
+    {
+     "longitude": -1.2001181,
+     "latitude": 35.2006828,
+     "nom": "Ain Kihal",
+     "id": "1465",
+     "wilaya_id": "46",
+     "code_postal": "46003"
+    },
+    {
+     "longitude": -0.9677300999999999,
+     "latitude": 35.3701948,
+     "nom": "Hammam Bouhadjar",
+     "id": "1466",
+     "wilaya_id": "46",
+     "code_postal": "46004"
+    },
+    {
+     "longitude": -1.1424989,
+     "latitude": 35.5795438,
+     "nom": "Bou Zedjar",
+     "id": "1467",
+     "wilaya_id": "46",
+     "code_postal": "46005"
+    },
+    {
+     "longitude": -0.9856518000000001,
+     "latitude": 35.2204682,
+     "nom": "Oued Berkeche",
+     "id": "1468",
+     "wilaya_id": "46",
+     "code_postal": "46006"
+    },
+    {
+     "longitude": -1.065797,
+     "latitude": 35.2019341,
+     "nom": "Aghlal",
+     "id": "1469",
+     "wilaya_id": "46",
+     "code_postal": "46007"
+    },
+    {
+     "longitude": -1.1797022,
+     "latitude": 35.4190324,
+     "nom": "Terga",
+     "id": "1470",
+     "wilaya_id": "46",
+     "code_postal": "46008"
+    },
+    {
+     "longitude": -0.8818151,
+     "latitude": 35.4037488,
+     "nom": "Ain El Arbaa",
+     "id": "1471",
+     "wilaya_id": "46",
+     "code_postal": "46009"
+    },
+    {
+     "longitude": -0.6607039,
+     "latitude": 35.4133773,
+     "nom": "Tamzoura",
+     "id": "1472",
+     "wilaya_id": "46",
+     "code_postal": "46010"
+    },
+    {
+     "longitude": -1.0119509,
+     "latitude": 35.29988,
+     "nom": "Chentouf",
+     "id": "1473",
+     "wilaya_id": "46",
+     "code_postal": "46011"
+    },
+    {
+     "longitude": -1.1809029,
+     "latitude": 35.3052158,
+     "nom": "Sidi Ben Adda",
+     "id": "1474",
+     "wilaya_id": "46",
+     "code_postal": "46012"
+    },
+    {
+     "longitude": -0.9928226000000001,
+     "latitude": 35.1379554,
+     "nom": "Aoubellil",
+     "id": "1475",
+     "wilaya_id": "46",
+     "code_postal": "46013"
+    },
+    {
+     "longitude": -1.0945436,
+     "latitude": 35.3883099,
+     "nom": "El Malah",
+     "id": "1476",
+     "wilaya_id": "46",
+     "code_postal": "46014"
+    },
+    {
+     "longitude": -0.8949292999999999,
+     "latitude": 35.35292740000001,
+     "nom": "Sidi Boumediene",
+     "id": "1477",
+     "wilaya_id": "46",
+     "code_postal": "46015"
+    },
+    {
+     "longitude": -0.8127369000000001,
+     "latitude": 35.3740738,
+     "nom": "Oued Sabah",
+     "id": "1478",
+     "wilaya_id": "46",
+     "code_postal": "46016"
+    },
+    {
+     "longitude": -1.1917104,
+     "latitude": 35.4709656,
+     "nom": "Ouled Boudjemaa",
+     "id": "1479",
+     "wilaya_id": "46",
+     "code_postal": "46017"
+    },
+    {
+     "longitude": -1.2530057,
+     "latitude": 35.2550837,
+     "nom": "Ain Tolba",
+     "id": "1480",
+     "wilaya_id": "46",
+     "code_postal": "46018"
+    },
+    {
+     "longitude": -1.0179304,
+     "latitude": 35.5259362,
+     "nom": "El Amria",
+     "id": "1481",
+     "wilaya_id": "46",
+     "code_postal": "46019"
+    },
+    {
+     "longitude": -1.0514312,
+     "latitude": 35.4544602,
+     "nom": "Hassi El Ghella",
+     "id": "1482",
+     "wilaya_id": "46",
+     "code_postal": "46020"
+    },
+    {
+     "longitude": -0.9880123,
+     "latitude": 35.273753,
+     "nom": "Hassasna",
+     "id": "1483",
+     "wilaya_id": "46",
+     "code_postal": "46021"
+    },
+    {
+     "longitude": -1.2217459,
+     "latitude": 35.3733876,
+     "nom": "Ouled Kihal",
+     "id": "1484",
+     "wilaya_id": "46",
+     "code_postal": "46022"
+    },
+    {
+     "longitude": -1.3710402,
+     "latitude": 35.3004743,
+     "nom": "Beni Saf",
+     "id": "1485",
+     "wilaya_id": "46",
+     "code_postal": "46023"
+    },
+    {
+     "longitude": -1.3107772,
+     "latitude": 35.2819277,
+     "nom": "Sidi Safi",
+     "id": "1486",
+     "wilaya_id": "46",
+     "code_postal": "46024"
+    },
+    {
+     "longitude": -1.1424514,
+     "latitude": 35.3072501,
+     "nom": "Oulhaca El Gheraba",
+     "id": "1487",
+     "wilaya_id": "46",
+     "code_postal": "46025"
+    },
+    {
+     "longitude": -1.4476979,
+     "latitude": 35.24262340000001,
+     "nom": "Tadmaya",
+     "id": "1488",
+     "wilaya_id": "46",
+     "code_postal": "46026"
+    },
+    {
+     "longitude": -1.4072392,
+     "latitude": 35.2204402,
+     "nom": "El Emir Abdelkader",
+     "id": "1489",
+     "wilaya_id": "46",
+     "code_postal": "46027"
+    },
+    {
+     "longitude": 3.6738412,
+     "latitude": 32.4902246,
+     "nom": "Ghardaia",
+     "id": "1491",
+     "wilaya_id": "47",
+     "code_postal": "47001"
+    },
+    {
+     "longitude": 2.8876436,
+     "latitude": 30.59958869999999,
+     "nom": "El Meniaa",
+     "id": "1492",
+     "wilaya_id": "47",
+     "code_postal": "47002"
+    },
+    {
+     "longitude": 3.6116494,
+     "latitude": 32.5421541,
+     "nom": "Dhayet Bendhahoua",
+     "id": "1493",
+     "wilaya_id": "47",
+     "code_postal": "47003"
+    },
+    {
+     "longitude": 3.7718098,
+     "latitude": 32.8337669,
+     "nom": "Berriane",
+     "id": "1494",
+     "wilaya_id": "47",
+     "code_postal": "47004"
+    },
+    {
+     "longitude": 3.5989888,
+     "latitude": 32.2908262,
+     "nom": "Metlili",
+     "id": "1495",
+     "wilaya_id": "47",
+     "code_postal": "47005"
+    },
+    {
+     "longitude": 4.492221499999999,
+     "latitude": 32.7900544,
+     "nom": "El Guerrara",
+     "id": "1496",
+     "wilaya_id": "47",
+     "code_postal": "47006"
+    },
+    {
+     "longitude": 3.7471211,
+     "latitude": 32.4766504,
+     "nom": "El Atteuf",
+     "id": "1497",
+     "wilaya_id": "47",
+     "code_postal": "47007"
+    },
+    {
+     "longitude": 4.2230836,
+     "latitude": 32.4101618,
+     "nom": "Zelfana",
+     "id": "1498",
+     "wilaya_id": "47",
+     "code_postal": "47008"
+    },
+    {
+     "longitude": 3.5838002,
+     "latitude": 32.1666038,
+     "nom": "Sebseb",
+     "id": "1499",
+     "wilaya_id": "47",
+     "code_postal": "47009"
+    },
+    {
+     "longitude": 3.6015207,
+     "latitude": 32.4633255,
+     "nom": "Bounoura",
+     "id": "1500",
+     "wilaya_id": "47",
+     "code_postal": "47010"
+    },
+    {
+     "longitude": 3.6762683,
+     "latitude": 31.6027043,
+     "nom": "Hassi Fehal",
+     "id": "1501",
+     "wilaya_id": "47",
+     "code_postal": "47011"
+    },
+    {
+     "longitude": 2.9126022,
+     "latitude": 30.5472849,
+     "nom": "Hassi Gara",
+     "id": "1502",
+     "wilaya_id": "47",
+     "code_postal": "47012"
+    },
+    {
+     "longitude": 3.751126799999999,
+     "latitude": 31.9802146,
+     "nom": "Mansoura",
+     "id": "1503",
+     "wilaya_id": "47",
+     "code_postal": "47013"
+    },
+    {
+     "longitude": 0.5588787,
+     "latitude": 35.7339361,
+     "nom": "Relizane",
+     "id": "1504",
+     "wilaya_id": "48",
+     "code_postal": "48001"
+    },
+    {
+     "longitude": 0.9199773,
+     "latitude": 35.9607107,
+     "nom": "Oued Rhiou",
+     "id": "1505",
+     "wilaya_id": "48",
+     "code_postal": "48002"
+    },
+    {
+     "longitude": 0.5057015,
+     "latitude": 35.8528374,
+     "nom": "Belaassel Bouzegza",
+     "id": "1506",
+     "wilaya_id": "48",
+     "code_postal": "48003"
+    },
+    {
+     "longitude": 0.3407167,
+     "latitude": 35.6760307,
+     "nom": "Sidi Saada",
+     "id": "1507",
+     "wilaya_id": "48",
+     "code_postal": "48004"
+    },
+    {
+     "longitude": 0.9641466999999999,
+     "latitude": 35.8255092,
+     "nom": "Ouled Aiche",
+     "id": "1508",
+     "wilaya_id": "48",
+     "code_postal": "48005"
+    },
+    {
+     "longitude": 0.7782418,
+     "latitude": 35.6466822,
+     "nom": "Sidi Lazreg",
+     "id": "1509",
+     "wilaya_id": "48",
+     "code_postal": "48006"
+    },
+    {
+     "longitude": 0.774675,
+     "latitude": 35.90454769999999,
+     "nom": "El Hamadna",
+     "id": "1510",
+     "wilaya_id": "48",
+     "code_postal": "48007"
+    },
+    {
+     "longitude": 0.8413067999999999,
+     "latitude": 36.1434513,
+     "nom": "Sidi Mhamed Ben Ali",
+     "id": "1511",
+     "wilaya_id": "48",
+     "code_postal": "48008"
+    },
+    {
+     "longitude": 0.7544692000000001,
+     "latitude": 36.1263731,
+     "nom": "Mediouna",
+     "id": "1512",
+     "wilaya_id": "48",
+     "code_postal": "48009"
+    },
+    {
+     "longitude": 0.5139688,
+     "latitude": 35.9113884,
+     "nom": "Sidi Khettab",
+     "id": "1513",
+     "wilaya_id": "48",
+     "code_postal": "48010"
+    },
+    {
+     "longitude": 1.1089244,
+     "latitude": 35.8692431,
+     "nom": "Ammi Moussa",
+     "id": "1514",
+     "wilaya_id": "48",
+     "code_postal": "48011"
+    },
+    {
+     "longitude": 0.7509045,
+     "latitude": 35.7247051,
+     "nom": "Zemmoura",
+     "id": "1515",
+     "wilaya_id": "48",
+     "code_postal": "48012"
+    },
+    {
+     "longitude": 0.8317813000000001,
+     "latitude": 35.9259567,
+     "nom": "Djidiouia",
+     "id": "1517",
+     "wilaya_id": "48",
+     "code_postal": "48014"
+    },
+    {
+     "longitude": 0.8246386,
+     "latitude": 36.091951,
+     "nom": "El Guettar",
+     "id": "1518",
+     "wilaya_id": "48",
+     "code_postal": "48015"
+    },
+    {
+     "longitude": 0.701233,
+     "latitude": 36.019135,
+     "nom": "Hamri",
+     "id": "1519",
+     "wilaya_id": "48",
+     "code_postal": "48016"
+    },
+    {
+     "longitude": 0.4620313,
+     "latitude": 35.731615,
+     "nom": "El Matmar",
+     "id": "1520",
+     "wilaya_id": "48",
+     "code_postal": "48017"
+    },
+    {
+     "longitude": 0.5872689999999999,
+     "latitude": 35.6026539,
+     "nom": "Sidi Mhamed Ben Aouda",
+     "id": "1521",
+     "wilaya_id": "48",
+     "code_postal": "48018"
+    },
+    {
+     "longitude": 1.1377008,
+     "latitude": 35.7762676,
+     "nom": "Ain Tarek",
+     "id": "1522",
+     "wilaya_id": "48",
+     "code_postal": "48019"
+    },
+    {
+     "longitude": 0.9259434000000001,
+     "latitude": 35.5800262,
+     "nom": "Oued Essalem",
+     "id": "1523",
+     "wilaya_id": "48",
+     "code_postal": "48020"
+    },
+    {
+     "longitude": 0.8996991999999999,
+     "latitude": 36.0465615,
+     "nom": "Ouarizane",
+     "id": "1524",
+     "wilaya_id": "48",
+     "code_postal": "48021"
+    },
+    {
+     "longitude": 0.8770473,
+     "latitude": 36.1187509,
+     "nom": "Mazouna",
+     "id": "1525",
+     "wilaya_id": "48",
+     "code_postal": "48022"
+    },
+    {
+     "longitude": 0.3289585,
+     "latitude": 35.5803849,
+     "nom": "Kalaa",
+     "id": "1526",
+     "wilaya_id": "48",
+     "code_postal": "48023"
+    },
+    {
+     "longitude": 0.3919059,
+     "latitude": 35.6246337,
+     "nom": "Ain Rahma",
+     "id": "1527",
+     "wilaya_id": "48",
+     "code_postal": "48024"
+    },
+    {
+     "longitude": 0.3536548,
+     "latitude": 35.7210595,
+     "nom": "Yellel",
+     "id": "1528",
+     "wilaya_id": "48",
+     "code_postal": "48025"
+    },
+    {
+     "longitude": 0.6796767000000001,
+     "latitude": 35.7960821,
+     "nom": "Oued El Djemaa",
+     "id": "1529",
+     "wilaya_id": "48",
+     "code_postal": "48026"
+    },
+    {
+     "longitude": 1.2818815,
+     "latitude": 35.8675295,
+     "nom": "Ramka",
+     "id": "1530",
+     "wilaya_id": "48",
+     "code_postal": "48027"
+    },
+    {
+     "longitude": 0.8651302999999999,
+     "latitude": 35.6474585,
+     "nom": "Mendes",
+     "id": "1531",
+     "wilaya_id": "48",
+     "code_postal": "48028"
+    },
+    {
+     "longitude": 0.9796769999999999,
+     "latitude": 35.8921599,
+     "nom": "Lahlef",
+     "id": "1532",
+     "wilaya_id": "48",
+     "code_postal": "48029"
+    },
+    {
+     "longitude": 0.6642606999999999,
+     "latitude": 36.1106051,
+     "nom": "Beni Zentis",
+     "id": "1533",
+     "wilaya_id": "48",
+     "code_postal": "48030"
+    },
+    {
+     "longitude": 1.248195,
+     "latitude": 35.9550366,
+     "nom": "Souk El Haad",
+     "id": "1534",
+     "wilaya_id": "48",
+     "code_postal": "48031"
+    },
+    {
+     "longitude": 0.6832351,
+     "latitude": 35.6991649,
+     "nom": "Dar Ben Abdellah",
+     "id": "1535",
+     "wilaya_id": "48",
+     "code_postal": "48032"
+    },
+    {
+     "longitude": -0.6618221999999999,
+     "latitude": 35.6895866,
+     "nom": "El Hassi",
+     "id": "1536",
+     "wilaya_id": "48",
+     "code_postal": "48033"
+    },
+    {
+     "longitude": 1.1484972,
+     "latitude": 35.6792524,
+     "nom": "Had Echkalla",
+     "id": "1537",
+     "wilaya_id": "48",
+     "code_postal": "48034"
+    },
+    {
+     "longitude": 0.5186938,
+     "latitude": 35.7150028,
+     "nom": "Bendaoud",
+     "id": "1538",
+     "wilaya_id": "48",
+     "code_postal": "48035"
+    },
+    {
+     "longitude": 1.1185143,
+     "latitude": 35.9072969,
+     "nom": "El Ouldja",
+     "id": "1539",
+     "wilaya_id": "48",
+     "code_postal": "48036"
+    }
+   ]

--- a/json/wilayas.json
+++ b/json/wilayas.json
@@ -1,9 +1,242 @@
-/**
- Export to JSON plugin for PHPMyAdmin
- @version 0.1
- @author othmanus
- */
-
-// wilayas
-
-[{"id":"1","code":"1","nom":"Adrar"}, {"id":"2","code":"2","nom":"Chlef"}, {"id":"3","code":"3","nom":"Laghouat"}, {"id":"4","code":"4","nom":"Oum El Bouaghi"}, {"id":"5","code":"5","nom":"Batna"}, {"id":"6","code":"6","nom":"B\u00e9ja\u00efa"}, {"id":"7","code":"7","nom":"Biskra"}, {"id":"8","code":"8","nom":"B\u00e9char"}, {"id":"9","code":"9","nom":"Blida"}, {"id":"10","code":"10","nom":"Bouira"}, {"id":"11","code":"11","nom":"Tamanrasset"}, {"id":"12","code":"12","nom":"T\u00e9bessa"}, {"id":"13","code":"13","nom":"Tlemcen"}, {"id":"14","code":"14","nom":"Tiaret"}, {"id":"15","code":"15","nom":"Tizi Ouzou"}, {"id":"16","code":"16","nom":"Alger"}, {"id":"17","code":"17","nom":"Djelfa"}, {"id":"18","code":"18","nom":"Jijel"}, {"id":"19","code":"19","nom":"S\u00e9tif"}, {"id":"20","code":"20","nom":"Sa\u00efda"}, {"id":"21","code":"21","nom":"Skikda"}, {"id":"22","code":"22","nom":"Sidi Bel Abb\u00e8s"}, {"id":"23","code":"23","nom":"Annaba"}, {"id":"24","code":"24","nom":"Guelma"}, {"id":"25","code":"25","nom":"Constantine"}, {"id":"26","code":"26","nom":"M\u00e9d\u00e9a"}, {"id":"27","code":"27","nom":"Mostaganem"}, {"id":"28","code":"28","nom":"M'Sila"}, {"id":"29","code":"29","nom":"Mascara"}, {"id":"30","code":"30","nom":"Ouargla"}, {"id":"31","code":"31","nom":"Oran"}, {"id":"32","code":"32","nom":"El Bayadh"}, {"id":"33","code":"33","nom":"Illizi"}, {"id":"34","code":"34","nom":"Bordj Bou Arreridj"}, {"id":"35","code":"35","nom":"Boumerd\u00e8s"}, {"id":"36","code":"36","nom":"El Tarf"}, {"id":"37","code":"37","nom":"Tindouf"}, {"id":"38","code":"38","nom":"Tissemsilt"}, {"id":"39","code":"39","nom":"El Oued"}, {"id":"40","code":"40","nom":"Khenchela"}, {"id":"41","code":"41","nom":"Souk Ahras"}, {"id":"42","code":"42","nom":"Tipaza"}, {"id":"43","code":"43","nom":"Mila"}, {"id":"44","code":"44","nom":"A\u00efn Defla"}, {"id":"45","code":"45","nom":"Na\u00e2ma"}, {"id":"46","code":"46","nom":"A\u00efn T\u00e9mouchent"}, {"id":"47","code":"47","nom":"Gharda\u00efa"}, {"id":"48","code":"48","nom":"Relizane"}]
+[
+    {
+     "id": "1",
+     "code": "1",
+     "nom": "Adrar"
+    },
+    {
+     "id": "2",
+     "code": "2",
+     "nom": "Chlef"
+    },
+    {
+     "id": "3",
+     "code": "3",
+     "nom": "Laghouat"
+    },
+    {
+     "id": "4",
+     "code": "4",
+     "nom": "Oum El Bouaghi"
+    },
+    {
+     "id": "5",
+     "code": "5",
+     "nom": "Batna"
+    },
+    {
+     "id": "6",
+     "code": "6",
+     "nom": "Béjaïa"
+    },
+    {
+     "id": "7",
+     "code": "7",
+     "nom": "Biskra"
+    },
+    {
+     "id": "8",
+     "code": "8",
+     "nom": "Béchar"
+    },
+    {
+     "id": "9",
+     "code": "9",
+     "nom": "Blida"
+    },
+    {
+     "id": "10",
+     "code": "10",
+     "nom": "Bouira"
+    },
+    {
+     "id": "11",
+     "code": "11",
+     "nom": "Tamanrasset"
+    },
+    {
+     "id": "12",
+     "code": "12",
+     "nom": "Tébessa"
+    },
+    {
+     "id": "13",
+     "code": "13",
+     "nom": "Tlemcen"
+    },
+    {
+     "id": "14",
+     "code": "14",
+     "nom": "Tiaret"
+    },
+    {
+     "id": "15",
+     "code": "15",
+     "nom": "Tizi Ouzou"
+    },
+    {
+     "id": "16",
+     "code": "16",
+     "nom": "Alger"
+    },
+    {
+     "id": "17",
+     "code": "17",
+     "nom": "Djelfa"
+    },
+    {
+     "id": "18",
+     "code": "18",
+     "nom": "Jijel"
+    },
+    {
+     "id": "19",
+     "code": "19",
+     "nom": "Sétif"
+    },
+    {
+     "id": "20",
+     "code": "20",
+     "nom": "Saïda"
+    },
+    {
+     "id": "21",
+     "code": "21",
+     "nom": "Skikda"
+    },
+    {
+     "id": "22",
+     "code": "22",
+     "nom": "Sidi Bel Abbès"
+    },
+    {
+     "id": "23",
+     "code": "23",
+     "nom": "Annaba"
+    },
+    {
+     "id": "24",
+     "code": "24",
+     "nom": "Guelma"
+    },
+    {
+     "id": "25",
+     "code": "25",
+     "nom": "Constantine"
+    },
+    {
+     "id": "26",
+     "code": "26",
+     "nom": "Médéa"
+    },
+    {
+     "id": "27",
+     "code": "27",
+     "nom": "Mostaganem"
+    },
+    {
+     "id": "28",
+     "code": "28",
+     "nom": "M'Sila"
+    },
+    {
+     "id": "29",
+     "code": "29",
+     "nom": "Mascara"
+    },
+    {
+     "id": "30",
+     "code": "30",
+     "nom": "Ouargla"
+    },
+    {
+     "id": "31",
+     "code": "31",
+     "nom": "Oran"
+    },
+    {
+     "id": "32",
+     "code": "32",
+     "nom": "El Bayadh"
+    },
+    {
+     "id": "33",
+     "code": "33",
+     "nom": "Illizi"
+    },
+    {
+     "id": "34",
+     "code": "34",
+     "nom": "Bordj Bou Arreridj"
+    },
+    {
+     "id": "35",
+     "code": "35",
+     "nom": "Boumerdès"
+    },
+    {
+     "id": "36",
+     "code": "36",
+     "nom": "El Tarf"
+    },
+    {
+     "id": "37",
+     "code": "37",
+     "nom": "Tindouf"
+    },
+    {
+     "id": "38",
+     "code": "38",
+     "nom": "Tissemsilt"
+    },
+    {
+     "id": "39",
+     "code": "39",
+     "nom": "El Oued"
+    },
+    {
+     "id": "40",
+     "code": "40",
+     "nom": "Khenchela"
+    },
+    {
+     "id": "41",
+     "code": "41",
+     "nom": "Souk Ahras"
+    },
+    {
+     "id": "42",
+     "code": "42",
+     "nom": "Tipaza"
+    },
+    {
+     "id": "43",
+     "code": "43",
+     "nom": "Mila"
+    },
+    {
+     "id": "44",
+     "code": "44",
+     "nom": "Aïn Defla"
+    },
+    {
+     "id": "45",
+     "code": "45",
+     "nom": "Naâma"
+    },
+    {
+     "id": "46",
+     "code": "46",
+     "nom": "Aïn Témouchent"
+    },
+    {
+     "id": "47",
+     "code": "47",
+     "nom": "Ghardaïa"
+    },
+    {
+     "id": "48",
+     "code": "48",
+     "nom": "Relizane"
+    }
+   ]

--- a/php/communes.php
+++ b/php/communes.php
@@ -9,8 +9,7 @@
 // Database `algeria-cities`
 //
 
-// `algeria-cities`.`communes`
-$communes = array(
+return [
   array('id' => '1','code_postal' => '01001','nom' => 'Adrar','wilaya_id' => '1'),
   array('id' => '2','code_postal' => '01002','nom' => 'Tamest','wilaya_id' => '1'),
   array('id' => '3','code_postal' => '01003','nom' => 'Charouine','wilaya_id' => '1'),
@@ -1552,4 +1551,4 @@ $communes = array(
   array('id' => '1539','code_postal' => '48036','nom' => 'El Ouldja','wilaya_id' => '48'),
   array('id' => '1540','code_postal' => '48037','nom' => 'Merdja Sidi Abed','wilaya_id' => '48'),
   array('id' => '1541','code_postal' => '48038','nom' => 'Ouled Sidi Mihoub','wilaya_id' => '48')
-);
+];

--- a/php/wilayas.php
+++ b/php/wilayas.php
@@ -10,7 +10,7 @@
 //
 
 // `algeria-cities`.`wilayas`
-$wilayas = array(
+return [
   array('id' => '1','code' => '1','nom' => 'Adrar'),
   array('id' => '2','code' => '2','nom' => 'Chlef'),
   array('id' => '3','code' => '3','nom' => 'Laghouat'),
@@ -59,4 +59,4 @@ $wilayas = array(
   array('id' => '46','code' => '46','nom' => 'Aïn Témouchent'),
   array('id' => '47','code' => '47','nom' => 'Ghardaïa'),
   array('id' => '48','code' => '48','nom' => 'Relizane')
-);
+];


### PR DESCRIPTION
changed the array holding the data.
instead of storing it into a variable, now it is returned.
i also corrected a mistake in JSON files.
you can't use PHP-like comments inside a JSON file. besides, the JSON files needed a beautify to be usable a bit more.

#### How to use ? 
include the file like this: 
```php
$communes = include('communes.php');
```
#### Why assigning data when including and not in the original file ? 
simply because it enhances code readability.

#### List of changed files: 
**5** files see : [Files changed](https://github.com/othmanus/algeria-cities/pull/9/files)